### PR TITLE
XS✔ ◾ Add concurrency control to PR release workflow

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -12,6 +12,10 @@ env:
   APP_NAME: SSW.YakShaver
   NODE_VERSION: 20
 
+concurrency:
+  group: pr-pre-release-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cleanup-release:
     if: |


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

can you change the PR deploy script a bit so that if there are many commits in a short period of time it will cancel the previous build rather than taking it to completion

AKA DEBOUNCE

GPT-5.1 Codex

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

<img width="1049" height="829" alt="image" src="https://github.com/user-attachments/assets/6ae64006-dc68-435d-aa7d-7726cc128f62" />

> 2. What was changed?

Add concurrency control to PR release workflow

