### PR TITLE
XS⚠️ ◾ Fix Custom Prompt Text Field Width

### DIFF
--- a/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
+++ b/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
@@ -140,7 +140,7 @@ export const PromptForm = forwardRef<PromptFormRef, PromptFormProps>(
                     {...field}
                     placeholder="Enter your custom instructions here..."
                     disabled={isDefault}
-                    className="resize-none flex-1 max-h-50 overflow-y-auto font-mono text-sm bg-black/40 border-white/20 max-w-full wrap-break-word break-normal whitespace-pre-wrap"
+                    className="resize-none flex-1 max-h-50 overflow-y-auto font-mono text-sm bg-black/40 border-white/20 max-w-full wrap-break-word break-normal whitespace-pre-wrap overflow-x-hidden [word-break:break-word]"
                   />
                 </FormControl>
                 <FormDescription>


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

N/A

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

#185 

> 2. What was changed?
- set the max width for Custom Prompt form
- break long texts
<img width="2370" height="1574" alt="image" src="https://github.com/user-attachments/assets/d7f03973-54a7-4648-bd7c-fdb2a02a43a0" />  

**Figure: The text field value now fit the text field**  


Before

https://github.com/user-attachments/assets/d4d7655e-ceed-485c-97a1-b18a0eea62b6



After

https://github.com/user-attachments/assets/35642e85-6517-4425-82c9-82739fc3609a





> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->
N/A

<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->



