### PR TITLE
XS✔ ◾ Update workflow run name

### DIFF
--- a/.github/workflows/automated-release-electron-app.yml
+++ b/.github/workflows/automated-release-electron-app.yml
@@ -1,4 +1,5 @@
 name: Automated Electron App Release
+run-name: "YakShaver App Release - Build #${{ github.run_number }}"
 
 on:
   push:


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The workflow run name is not obvious.

> 2. What was changed?

✏️ Modify the workflow run name in the format of: YakShaver App Release - Build number

Reason I didn't use the release version or tag:
We can’t use it because GitHub Actions evaluates the run name before jobs run, and expressions don’t support dates or formatting. Attempts updating run name later in the workflow, github.event.head_commit.timestamp, or format() don’t work.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
