### PR TITLE
XS✔ ◾ Workflow - download youtube-dl-exec manually

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -238,12 +238,30 @@ jobs:
         run: |
           mkdir -p node_modules/youtube-dl-exec/bin
 
-          # Download the binary using the GitHub CLI (Authenticated)
-          # We rename it to 'yt-dlp' so the package finds it
-          gh release download --repo yt-dlp/yt-dlp --pattern 'yt-dlp_macos' --output node_modules/youtube-dl-exec/bin/yt-dlp
+          PATTERN="yt-dlp_macos"
+          OUTPUT_FILE="node_modules/youtube-dl-exec/bin/yt-dlp"
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+
+          until gh release download \
+            --repo yt-dlp/yt-dlp \
+            --pattern "$PATTERN" \
+            --clobber \
+            --output "$OUTPUT_FILE"; do
+
+            echo "Attempt $ATTEMPT to download yt-dlp binary failed." >&2
+
+            if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+              echo "Failed to download yt-dlp binary after $MAX_ATTEMPTS attempts." >&2
+              exit 1
+            fi
+
+            ATTEMPT=$((ATTEMPT+1))
+            sleep 5
+          done
           
           # Make the binary executable
-          chmod +x node_modules/youtube-dl-exec/bin/yt-dlp
+          chmod +x "$OUTPUT_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-electron-app.yml
+++ b/.github/workflows/release-electron-app.yml
@@ -174,12 +174,30 @@ jobs:
         run: |
           mkdir -p node_modules/youtube-dl-exec/bin
 
-          # Download the binary using the GitHub CLI (Authenticated)
-          # We rename it to 'yt-dlp' so the package finds it
-          gh release download --repo yt-dlp/yt-dlp --pattern 'yt-dlp_macos' --output node_modules/youtube-dl-exec/bin/yt-dlp
+          PATTERN="yt-dlp_macos"
+          OUTPUT_FILE="node_modules/youtube-dl-exec/bin/yt-dlp"
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+
+          until gh release download \
+            --repo yt-dlp/yt-dlp \
+            --pattern "$PATTERN" \
+            --clobber \
+            --output "$OUTPUT_FILE"; do
+
+            echo "Attempt $ATTEMPT to download yt-dlp binary failed." >&2
+
+            if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+              echo "Failed to download yt-dlp binary after $MAX_ATTEMPTS attempts." >&2
+              exit 1
+            fi
+
+            ATTEMPT=$((ATTEMPT+1))
+            sleep 5
+          done
           
           # Make the binary executable
-          chmod +x node_modules/youtube-dl-exec/bin/yt-dlp
+          chmod +x "$OUTPUT_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ with github token, we still got the rate limit error
<img width="1420" height="410" alt="image" src="https://github.com/user-attachments/assets/12c35048-fa9f-4e72-b853-91806806e60a" />


> 2. What was changed?

✏️ Downlowd ytb manually.
It runs "sh -c node scripts/postinstall.js" to download the youtube-dl-exec during dependency installation, and this script does not use the github token by default. This causes that we still have an unauthenticated API rate limit error. 
Manually install it using github token to bypass this issue.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
