### PR TITLE
XS⚠️ ◾ Improve Login Flow for YakShaver Desktop App

### DIFF
--- a/src/backend/services/auth/microsoft-auth.ts
+++ b/src/backend/services/auth/microsoft-auth.ts
@@ -197,7 +197,6 @@ export class MicrosoftAuthService {
 
       const successHtml = fs.readFileSync(successPath, "utf8");
       const errorHtml = fs.readFileSync(errorPath, "utf8");
-
       const openBrowser = async (url: string) => await shell.openExternal(url);
       const interactiveRequest: InteractiveRequest = {
         ...tokenRequest,


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

https://github.com/SSWConsulting/SSW.YakShaver.Desktop/issues/422 

> 2. What was changed?

Add singleinstance lock to make sure only one app is opening
The prod and dev app have the same name, so there would be only one dev or prod app opening at the same time too.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
