### PR TITLE
Fixed health check for LLM

### DIFF
--- a/src/ui/src/components/health-status/health-status.tsx
+++ b/src/ui/src/components/health-status/health-status.tsx
@@ -31,7 +31,7 @@ export const HealthStatus = React.forwardRef<HTMLDivElement, HealthStatusProps>(
     },
     ref,
   ) => {
-    if (isDisabled) {
+    if (isDisabled && !isChecking) {
       return (
         <div
           ref={ref}


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️  N/A

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️  Disabled status was displayed when it was health checking the LLM API Key

> 2. What was changed?

✏️  Fixed condition to display checking status instead of disabled

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️  N/A

<img width="794" height="498" alt="image" src="https://github.com/user-attachments/assets/45adb1f3-709d-4ef5-855b-7b85ad66515e" />

**Figure: ❌ Before**

<img width="766" height="493" alt="image" src="https://github.com/user-attachments/assets/153f6c30-ff7f-4ab0-8f58-721a8ebe7294" />

**Figure: ✅ After**

<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
