### PR TITLE
XS⚠️ ◾ Refactor ReasoningStep to use collapsible details

### DIFF
--- a/src/ui/src/components/workflow/ReasoningStep.tsx
+++ b/src/ui/src/components/workflow/ReasoningStep.tsx
@@ -1,4 +1,4 @@
-import { Brain } from "lucide-react";
+import { Brain, ChevronRight } from "lucide-react";
 import { type ParsedResult, RawTextDisplay } from "./FinalResultPanel";
 
 interface ReasoningStepProps {
@@ -15,17 +15,15 @@ export function ReasoningStep({ reasoning }: ReasoningStepProps) {
   }
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-2">
+    <details className="group space-y-1" open>
+      <summary className="flex items-center gap-2 cursor-pointer hover:text-primary/90">
         <Brain className="w-4 h-4" />
-        AI Reasoning & Plan
-      </div>
-      <details className="ml-4 text-xs" open>
-        <summary className="text-zinc-400 cursor-pointer hover:text-zinc-400/80">
-          View details
-        </summary>
+        <span>AI Reasoning &amp; Plan</span>
+        <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+      </summary>
+      <div className="ml-4 text-xs">
         <RawTextDisplay content={(parsed.text ?? "") as string} />
-      </details>
-    </div>
+      </div>
+    </details>
   );
 }


### PR DESCRIPTION
Replaces the previous layout with a `<details>` element for improved UI. Adds a ChevronRight icon to indicate collapsibility and streamlines the display of AI reasoning details.

> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ GPT 5.2

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #524 

> 2. What was changed?

<img width="378" height="351" alt="image" src="https://github.com/user-attachments/assets/0ca16124-31ba-4cd1-92cb-116c46c2f6b6" />

**Figure: Now using Chevron from shadcn**

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
