### PR TITLE
XS⚠️ ◾ (MacOS) Fix: Allow app to quit properly when updating to new version

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -460,3 +460,7 @@ app.on("activate", () => {
 export function getMainWindow(): BrowserWindow | null {
   return mainWindow;
 }
+
+export function setIsQuitting(value: boolean): void {
+  isQuitting = value;
+}

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, ipcMain } from "electron";
 import { autoUpdater } from "electron-updater";
 import { config } from "../config/env";
+import { setIsQuitting } from "../index";
 import { GitHubTokenStorage } from "../services/storage/github-token-storage";
 import type { ReleaseChannel } from "../services/storage/release-channel-storage";
 import { ReleaseChannelStorage } from "../services/storage/release-channel-storage";
@@ -91,6 +92,8 @@ export class ReleaseChannelIPCHandlers {
         })
         .then((result) => {
           if (result.response === 0) {
+            // Set isQuitting to true so that the before-quit handler allows the app to quit
+            setIsQuitting(true);
             // Force immediate quit and install
             setImmediate(() => {
               // isSilent: false, isForceRunAfter: true, check docs: https://www.jsdocs.io/package/electron-updater#AppUpdater.quitAndInstall


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️  OpenCode + Kimi K2.5

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️  https://github.com/SSWConsulting/SSW.YakShaver/issues/3486
The auto update wasn't working randomly on MacOs.

When the user clicked "Restart Now" to install the update on macOS, `autoUpdater.quitAndInstall()` was called. However, the app has a before-quit handler that prevents the app from quitting if `isQuitting` is false. The handler would call `event.preventDefault()` and run cleanup, which prevented the auto-updater from properly quitting and installing the update.

**Note:**
This doesn't affect Windows, as this is improvement for both systems to properly quit the app after clicking "Restart Now" button.

> 2. What was changed?

✏️  The Fix:
1. Exported a `setIsQuitting()` function from `index.ts`
2. In `release-channel-handlers.ts`, now set `isQuitting = true` via `setIsQuitting(true)` before calling `autoUpdater.quitAndInstall()`. This ensures the before-quit handler allows the app to quit normally, letting the auto-updater complete the installation process.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️  No
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
