### PR TITLE
XS⚠️ ◾ Added tracking for update ready notification

### DIFF
--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -45,6 +45,7 @@ export class ReleaseChannelIPCHandlers {
   } | null = null;
   private updateCheckInterval: NodeJS.Timeout | null = null;
   private readonly UPDATE_CHECK_INTERVAL = 10 * 60 * 1000; // Check every 10 minutes
+  private updateDialogDismissedInSession = false; // Track if user dismissed update dialog this session
 
   constructor() {
     ipcMain.handle(IPC_CHANNELS.RELEASE_CHANNEL_GET, () => this.getChannel());
@@ -81,6 +82,11 @@ export class ReleaseChannelIPCHandlers {
     });
 
     autoUpdater.on("update-downloaded", () => {
+      // Skip showing dialog if user already dismissed it this session
+      if (this.updateDialogDismissedInSession) {
+        return;
+      }
+
       dialog
         .showMessageBox({
           type: "info",
@@ -99,6 +105,9 @@ export class ReleaseChannelIPCHandlers {
               // isSilent: false, isForceRunAfter: true, check docs: https://www.jsdocs.io/package/electron-updater#AppUpdater.quitAndInstall
               autoUpdater.quitAndInstall(false, true);
             });
+          } else {
+            // User chose "Later" - remember this for the current session
+            this.updateDialogDismissedInSession = true;
           }
         })
         .catch((err) => {


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ opencode + Kimi K2.5

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #646 

> 2. What was changed?

✏️ Added session-level tracking flag

How it works:
- When an update is downloaded, the dialog only shows if the user hasn't dismissed it this session
- When user clicks "Later", we set updateDialogDismissedInSession = true
- Subsequent update-downloaded events will be ignored for the current session
- The flag resets on app restart (new session)

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ No
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
