### PR TITLE
XS⚠️ ◾ fix: move version text into sidebar to prevent overflow

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -15,25 +15,10 @@ import { WorkflowPage } from "./pages/WorkflowPage";
 import { ipcClient } from "./services/ipc-client";
 
 export default function App() {
-  const [appVersion, setAppVersion] = useState<string>("");
-  const [commitHash, setCommitHash] = useState<string>("");
   const [isOnboardingVisible, setIsOnboardingVisible] = useState(false);
 
   // Auto-save shaves when workflow completes
   useShaveManager();
-
-  useEffect(() => {
-    const fetchVersion = async () => {
-      try {
-        const info = await window.electronAPI.releaseChannel.getCurrentVersion();
-        setAppVersion(info.version);
-        setCommitHash(info.commitHash);
-      } catch (error) {
-        console.error("Failed to fetch app version information:", error);
-      }
-    };
-    fetchVersion();
-  }, []);
 
   useEffect(() => {
     const unsubscribe = ipcClient.app.onProtocolError((message) => {
@@ -63,11 +48,6 @@ export default function App() {
                   </Routes>
                 </HashRouter>
               )}
-
-              <div className="fixed bottom-2 left-2 text-[10px] text-white/30 z-50 pointer-events-none font-mono">
-                {appVersion && `v${appVersion} `}
-                {commitHash && `(${commitHash})`}
-              </div>
             </div>
           </InteractionProvider>
         </TelemetryConsentInitializer>

--- a/src/ui/src/components/layout/sidebar.tsx
+++ b/src/ui/src/components/layout/sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import YakOutline from "/logos/SQ-YakShaver-LogoIcon-Outline.svg?url";
 import logoImage from "/logos/YakShaver-Horizontal-Color-Darkmode.svg?url";
 import { IdentityServerAuthManager } from "../auth/IdentityServerAuthManager";
@@ -6,6 +7,22 @@ import { SettingsDialog } from "../settings/SettingsDialog";
 import { SidebarLink } from "../ui/sidebar-link";
 
 export default function Sidebar() {
+  const [appVersion, setAppVersion] = useState<string>("");
+  const [commitHash, setCommitHash] = useState<string>("");
+
+  useEffect(() => {
+    const fetchVersion = async () => {
+      try {
+        const info = await window.electronAPI.releaseChannel.getCurrentVersion();
+        setAppVersion(info.version);
+        setCommitHash(info.commitHash);
+      } catch (error) {
+        console.error("Failed to fetch app version information:", error);
+      }
+    };
+    fetchVersion();
+  }, []);
+
   return (
     <div className=" fixed top-0 left-0 w-[18rem] h-full bg-black/60 border-r border-white/25 flex flex-col gap-6 p-8 z-40">
       <h1>
@@ -26,6 +43,13 @@ export default function Sidebar() {
       <div className="relative bottom-0 mt-auto flex flex-col gap-3 left-0">
         <SettingsDialog />
         <IdentityServerAuthManager />
+        {(appVersion || commitHash) && (
+          <div className="text-[10px] text-white/30 font-mono break-all leading-tight">
+            {/* {appVersion && `v${appVersion} `}
+            {commitHash && `(${commitHash})`} */}
+            v2026.4.16-BUILD.186.ecfca55 (ecfa55adfb2dc871622ac3f03d78dd18bf0040)
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/src/components/layout/sidebar.tsx
+++ b/src/ui/src/components/layout/sidebar.tsx
@@ -45,9 +45,9 @@ export default function Sidebar() {
         <IdentityServerAuthManager />
         {(appVersion || commitHash) && (
           <div className="text-[10px] text-white/30 font-mono break-all leading-tight">
-            {/* {appVersion && `v${appVersion} `}
-            {commitHash && `(${commitHash})`} */}
-            v2026.4.16-BUILD.186.ecfca55 (ecfa55adfb2dc871622ac3f03d78dd18bf0040)
+            {appVersion && `v${appVersion} `}
+            {commitHash && `(${commitHash})`}
+            
           </div>
         )}
       </div>

--- a/src/ui/src/components/layout/sidebar.tsx
+++ b/src/ui/src/components/layout/sidebar.tsx
@@ -47,7 +47,6 @@ export default function Sidebar() {
           <div className="text-[10px] text-white/30 font-mono break-all leading-tight">
             {appVersion && `v${appVersion} `}
             {commitHash && `(${commitHash})`}
-            
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Closes #835
- Moved the app version/commit watermark from a screen-fixed div in `App.tsx` into the sidebar footer so it's bounded by the sidebar width
- Added `break-all` so long version strings wrap cleanly instead of overflowing past the sidebar edge

<img width="1002" height="1026" alt="Screenshot 2026-04-17 at 10 42 28 am" src="https://github.com/user-attachments/assets/1e2fe5c9-3d65-4850-91e2-bc9dc853213d" />

**Figure: Wrapping correctly afterwards**