### PR TITLE
XS⚠️ ◾ UI - Sizing Changes req by Adam

### DIFF
--- a/src/ui/src/components/auth/IdentityServerAuthManager.tsx
+++ b/src/ui/src/components/auth/IdentityServerAuthManager.tsx
@@ -73,7 +73,9 @@ export function IdentityServerAuthManager() {
   if (!status?.isAuthenticated) {
     return (
       <div className="flex items-center">
-        <Button className="w-full" onClick={login}>Sign In</Button>
+        <Button className="w-full" onClick={login}>
+          Sign In
+        </Button>
         {error && <span className="text-ssw-red text-xs ml-2">{error}</span>}
       </div>
     );

--- a/src/ui/src/components/auth/IdentityServerAuthManager.tsx
+++ b/src/ui/src/components/auth/IdentityServerAuthManager.tsx
@@ -73,7 +73,7 @@ export function IdentityServerAuthManager() {
   if (!status?.isAuthenticated) {
     return (
       <div className="flex items-center">
-        <Button onClick={login}>Sign In</Button>
+        <Button className="w-full" onClick={login}>Sign In</Button>
         {error && <span className="text-ssw-red text-xs ml-2">{error}</span>}
       </div>
     );

--- a/src/ui/src/components/layout/sidebar.tsx
+++ b/src/ui/src/components/layout/sidebar.tsx
@@ -14,7 +14,7 @@ export default function Sidebar() {
       <ScreenRecorder showButtonOnly={true} className="w-full justify-start" />
       <nav className="flex flex-col gap-6">
         <SidebarLink to="/">
-          <img src={YakOutline} alt="YakShaver" className="h-4 w-4" />
+          <img src={YakOutline} alt="YakShaver" className="h-5 w-5" />
           Shaves
         </SidebarLink>
         {/* TODO: Add in for https://github.com/SSWConsulting/SSW.YakShaver.Desktop/issues/816  */}

--- a/src/ui/src/components/recording/ScreenRecorder.tsx
+++ b/src/ui/src/components/recording/ScreenRecorder.tsx
@@ -81,7 +81,7 @@ function RecordButton({
   return (
     <div className={cn("flex w-full rounded-md overflow-hidden", className)}>
       <Button
-        className="flex-1 text bg-ssw-red text-ssw-red-foreground hover:bg-ssw-red/90 items-center justify-start rounded-none rounded-l-md"
+        className="flex-1 bg-ssw-red text-ssw-red-foreground hover:bg-ssw-red/90 items-center justify-start rounded-none rounded-l-md"
         onClick={onToggleRecording}
         size="chunky"
         disabled={isDisabled}

--- a/src/ui/src/components/recording/ScreenRecorder.tsx
+++ b/src/ui/src/components/recording/ScreenRecorder.tsx
@@ -65,14 +65,14 @@ function RecordButton({
     return (
       <Button
         className={cn(
-          "bg-ssw-red text-ssw-red-foreground hover:bg-ssw-red/90 items-center",
+          "bg-ssw-red text-xl text-ssw-red-foreground hover:bg-ssw-red/90 items-center",
           className,
         )}
         onClick={onToggleRecording}
         size="chunky"
         disabled={isDisabled}
       >
-        <CircleStopIcon />
+        <CircleStopIcon className="w-5 h-5" />
         {label}
       </Button>
     );
@@ -81,7 +81,7 @@ function RecordButton({
   return (
     <div className={cn("flex w-full rounded-md overflow-hidden", className)}>
       <Button
-        className="flex-1 bg-ssw-red text-ssw-red-foreground hover:bg-ssw-red/90 items-center justify-start rounded-none rounded-l-md"
+        className="flex-1 text bg-ssw-red text-ssw-red-foreground hover:bg-ssw-red/90 items-center justify-start rounded-none rounded-l-md"
         onClick={onToggleRecording}
         size="chunky"
         disabled={isDisabled}

--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -168,7 +168,7 @@ export function SettingsDialog() {
           aria-label="Open settings"
         >
           <Settings className="h-5 w-5" />
-          <span className='text-xl'>Settings</span>
+          <span className="text-xl">Settings</span>
         </Button>
       </DialogTrigger>
 

--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -167,8 +167,8 @@ export function SettingsDialog() {
           className="flex items-center justify-start gap-2 text-white/60 bg-transparent hover:text-white hover:bg-white/10 transition-colors duration-300"
           aria-label="Open settings"
         >
-          <Settings className="h-4 w-4" />
-          <span>Settings</span>
+          <Settings className="h-5 w-5" />
+          <span className='text-xl'>Settings</span>
         </Button>
       </DialogTrigger>
 

--- a/src/ui/src/components/shaves/NoShaves.tsx
+++ b/src/ui/src/components/shaves/NoShaves.tsx
@@ -9,7 +9,7 @@ const NO_SHAVES_STEPS: string[] = [
 export function NoShaves() {
   return (
     <Empty>
-      <EmptyHeader className='gap-6'>
+      <EmptyHeader className='gap-6 items-start!'>
         <EmptyTitle>⛔️ - You don't have any YakShaves yet!</EmptyTitle>
         <EmptyDescription className="">Get started in 3 easy steps:</EmptyDescription>
       </EmptyHeader>

--- a/src/ui/src/components/shaves/NoShaves.tsx
+++ b/src/ui/src/components/shaves/NoShaves.tsx
@@ -10,7 +10,7 @@ export function NoShaves() {
   return (
     <Empty>
       <EmptyHeader>
-        <EmptyTitle>You don't have any YakShaves yet!</EmptyTitle>
+        <EmptyTitle>⛔️ - You don't have any YakShaves yet!</EmptyTitle>
         <EmptyDescription>Get started in 3 easy steps:</EmptyDescription>
       </EmptyHeader>
       <div className="flex flex-col gap-6">

--- a/src/ui/src/components/shaves/NoShaves.tsx
+++ b/src/ui/src/components/shaves/NoShaves.tsx
@@ -11,7 +11,7 @@ export function NoShaves() {
     <Empty>
       <EmptyHeader className='gap-6 items-start!'>
         <EmptyTitle>⛔️ - You don't have any YakShaves yet!</EmptyTitle>
-        <EmptyDescription className="">Get started in 3 easy steps:</EmptyDescription>
+        <EmptyDescription>Get started in 3 easy steps:</EmptyDescription>
       </EmptyHeader>
       <div className="flex flex-col gap-6">
         {NO_SHAVES_STEPS.map((step, index) => (

--- a/src/ui/src/components/shaves/NoShaves.tsx
+++ b/src/ui/src/components/shaves/NoShaves.tsx
@@ -9,7 +9,7 @@ const NO_SHAVES_STEPS: string[] = [
 export function NoShaves() {
   return (
     <Empty>
-      <EmptyHeader className='gap-6 items-start!'>
+      <EmptyHeader className="gap-6 items-start!">
         <EmptyTitle>⛔️ - You don't have any YakShaves yet!</EmptyTitle>
         <EmptyDescription>Get started in 3 easy steps:</EmptyDescription>
       </EmptyHeader>

--- a/src/ui/src/components/shaves/NoShaves.tsx
+++ b/src/ui/src/components/shaves/NoShaves.tsx
@@ -9,14 +9,14 @@ const NO_SHAVES_STEPS: string[] = [
 export function NoShaves() {
   return (
     <Empty>
-      <EmptyHeader>
+      <EmptyHeader className='gap-6'>
         <EmptyTitle>⛔️ - You don't have any YakShaves yet!</EmptyTitle>
-        <EmptyDescription>Get started in 3 easy steps:</EmptyDescription>
+        <EmptyDescription className="">Get started in 3 easy steps:</EmptyDescription>
       </EmptyHeader>
       <div className="flex flex-col gap-6">
         {NO_SHAVES_STEPS.map((step, index) => (
           <div key={step} className="flex items-center gap-3">
-            <span className="rounded-full border border-white/25 h-8 w-8 flex items-center justify-center text-sm font-medium">
+            <span className="rounded-full border border-white/25 h-8 w-8 flex items-center justify-center text-lg font-medium">
               {index + 1}
             </span>
             <span className="font-light text-muted-foreground">{step}</span>

--- a/src/ui/src/components/ui/button.tsx
+++ b/src/ui/src/components/ui/button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
-        chunky: "px-6 py-4"
+        chunky: "h-14 px-6 py-4"
       },
     },
     defaultVariants: {

--- a/src/ui/src/components/ui/empty.tsx
+++ b/src/ui/src/components/ui/empty.tsx
@@ -62,7 +62,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-title"
-      className={cn("text-lg font-medium tracking-tight", className)}
+      className={cn("text-xl font-medium tracking-tight", className)}
       {...props}
     />
   )
@@ -73,7 +73,7 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
     <div
       data-slot="empty-description"
       className={cn(
-        "text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+        "text-muted-foreground [&>a:hover]:text-primary text-lg/relaxed [&>a]:underline [&>a]:underline-offset-4",
         className
       )}
       {...props}

--- a/src/ui/src/components/ui/sidebar-link.tsx
+++ b/src/ui/src/components/ui/sidebar-link.tsx
@@ -12,7 +12,7 @@ export function SidebarLink({ to, children }: SidebarLinkProps) {
         to={to}
         end
         className={({ isActive }) =>
-          `flex items-center gap-2 px-6 py-4 rounded-md text-sm transition-colors duration-300 ${
+          `flex items-center gap-2 px-6 py-4 rounded-md text-xl transition-colors duration-300 ${
             isActive
               ? "bg-white/8 text-white hover:bg-white/15"
               : "text-white/60 bg-transparent hover:text-white hover:bg-white/10"


### PR DESCRIPTION
cc: @adamcogan 

**Context**
```
6. Left nav - Increase font size to be same size as on the YakShaver portal (left nav)

   What was the before and after
 
7. Add emoij when 0 -  ⛔️
 
8. Fix the spacing + the center text should be left aligned (the line after the 0 yakshaves)
 
9. Main panel - increase the font size

    What was the before and after
 ```

- [ ] Increased Sidebar buttons from 14px to 20px text (matches Portal) 
- [ ] Bumped up middle of page text size, heading is now 20px and the body is 18px (was 18px and 14px respectively before)
- [ ] For when advanced record button is active we've kept 14px so we can see all the text 
- [ ] Left aligned the No Shaves text
- [ ] Added emoji 
- [ ] Made sign in button full width 

<img width="1702" height="1037" alt="Screenshot 2026-04-17 at 3 33 39 pm" src="https://github.com/user-attachments/assets/ccdb766c-f54f-44ab-a1ee-306562fc701c" />

**Figure: Before ❌ Text too small**

<img width="1461" height="1042" alt="Screenshot 2026-04-17 at 3 32 41 pm" src="https://github.com/user-attachments/assets/7ead45ff-ee70-44e9-b94a-a6a07ceaf2df" />

**Figure: ✅ After - bumped up text size **
