### PR TITLE
  XS⚠️ ◾fix no visible picture-in-picture on windows

### DIFF
--- a/src/backend/services/recording/camera-window.ts
+++ b/src/backend/services/recording/camera-window.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { BrowserWindow, screen } from "electron";
+import { BrowserWindow, ipcMain, screen } from "electron";
 
 const WINDOW_SIZE = { width: 400, height: 225 }; // 16:9 aspect ratio
 const MARGIN = 20;
@@ -55,7 +55,10 @@ export class CameraWindow {
       this.snapToScreenEdge();
     });
 
-    this.window.setAlwaysOnTop(true, "floating");
+    // "screen-saver" matches the screen-frame overlay and the control bar.
+    // On Windows the lower "floating" level renders this PiP behind the
+    // full-screen frame overlay, hiding the camera entirely.
+    this.window.setAlwaysOnTop(true, "screen-saver");
 
     await (this.isDev ? this.window.loadURL(url) : this.window.loadFile(url));
 
@@ -64,7 +67,6 @@ export class CameraWindow {
     }
 
     await new Promise<void>((resolve) => {
-      const { ipcMain } = require("electron");
       let resolved = false;
       let timeout: NodeJS.Timeout;
 


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

Claude opus 4.7

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

https://github.com/SSWConsulting/SSW.YakShaver.Desktop/issues/795

> 2. What was changed?

raises the camera window to `"screen-saver"`

## Test plan
  - [x] Windows: start a screen recording with a camera selected → PiP camera window appears at bottom-right of recording display
  - [x] Windows: PiP renders camera feed (not just a transparent rectangle) and accepts dragging
  - [x] Windows: stop recording → PiP closes cleanly
  - [x] Windows: camera-only recording mode still works (no regression)
  - [x] macOS: regression check — PiP still appears, still positions/snaps correctly, control bar still on top
  

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->