### PR TITLE
XS⚠️ ◾ feat: enhance CI workflows with Windows and macOS update manifest val…

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -197,27 +197,6 @@ jobs:
             Write-Host "Fixed $($_.Name)"
           }
 
-      - name: Verify Windows update manifest
-        shell: pwsh
-        run: |
-          $channel = "${{ needs.cleanup-release.outputs.channel }}"
-          $manifest = "build/$channel.yml"
-
-          if (-not (Test-Path $manifest)) {
-            Write-Host "Available YAML files:"
-            Get-ChildItem "build/*.yml" | ForEach-Object { Write-Host "  $($_.Name)" }
-            throw "Missing Windows update manifest: $manifest"
-          }
-
-          if (Get-ChildItem "build/*-mac.yml" -ErrorAction SilentlyContinue) {
-            throw "Windows build must not produce macOS update manifests"
-          }
-
-          $content = Get-Content $manifest -Raw
-          if ($content -notmatch "\.exe") {
-            throw "Windows update manifest must reference the Windows installer"
-          }
-
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -197,6 +197,27 @@ jobs:
             Write-Host "Fixed $($_.Name)"
           }
 
+      - name: Verify Windows update manifest
+        shell: pwsh
+        run: |
+          $channel = "${{ needs.cleanup-release.outputs.channel }}"
+          $manifest = "build/$channel.yml"
+
+          if (-not (Test-Path $manifest)) {
+            Write-Host "Available YAML files:"
+            Get-ChildItem "build/*.yml" | ForEach-Object { Write-Host "  $($_.Name)" }
+            throw "Missing Windows update manifest: $manifest"
+          }
+
+          if (Get-ChildItem "build/*-mac.yml" -ErrorAction SilentlyContinue) {
+            throw "Windows build must not produce macOS update manifests"
+          }
+
+          $content = Get-Content $manifest -Raw
+          if ($content -notmatch "\.exe") {
+            throw "Windows update manifest must reference the Windows installer"
+          }
+
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -521,23 +542,96 @@ jobs:
       github.event.action != 'closed' &&
       needs.cleanup-release.outputs.pr_number != ''
     steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install manifest merge dependencies
+        run: npm ci --ignore-scripts --prefer-offline
+        env:
+          YOUTUBE_DL_SKIP_DOWNLOAD: true
+
       - name: Download Windows artifacts
         uses: actions/download-artifact@v8
         with:
           name: windows-build
-          path: artifacts/
+          path: artifacts/windows/
 
       - name: Download macOS (arm64) artifacts
         uses: actions/download-artifact@v8
         with:
           name: macos-arm64-build
-          path: artifacts/
+          path: artifacts/macos-arm64/
 
       - name: Download macOS (x64) artifacts
         uses: actions/download-artifact@v8
         with:
           name: macos-x64-build
-          path: artifacts/
+          path: artifacts/macos-x64/
+
+      - name: Prepare release artifacts
+        run: |
+          set -euo pipefail
+
+          CHANNEL="${{ needs.cleanup-release.outputs.channel }}"
+          mkdir -p release-artifacts
+
+          find artifacts/windows -maxdepth 1 -type f -exec cp {} release-artifacts/ \;
+
+          WINDOWS_MANIFEST="release-artifacts/${CHANNEL}.yml"
+          if [[ ! -f "$WINDOWS_MANIFEST" ]]; then
+            echo "Missing Windows update manifest: $WINDOWS_MANIFEST" >&2
+            find release-artifacts -maxdepth 1 -type f -name "*.yml" -print >&2
+            exit 1
+          fi
+
+          if ! grep -q "\.exe" "$WINDOWS_MANIFEST"; then
+            echo "Windows update manifest must reference the Windows installer" >&2
+            exit 1
+          fi
+
+          ARM64_MANIFEST=$(find artifacts/macos-arm64 -name "*-mac.yml" -type f | head -n 1)
+          X64_MANIFEST=$(find artifacts/macos-x64 -name "*-mac.yml" -type f | head -n 1)
+
+          if [[ -z "$ARM64_MANIFEST" || -z "$X64_MANIFEST" ]]; then
+            echo "Missing macOS update manifest artifacts" >&2
+            find artifacts -type f -name "*.yml" -print >&2
+            exit 1
+          fi
+
+          node scripts/merge-mac-update-manifests.js \
+            --arm64 "$ARM64_MANIFEST" \
+            --x64 "$X64_MANIFEST" \
+            --output "release-artifacts/${CHANNEL}-mac.yml"
+
+          find artifacts/macos-arm64 artifacts/macos-x64 \
+            \( -name "YakShaver-*-mac.zip" -o -name "YakShaver-*-mac.zip.blockmap" \) \
+            -exec cp {} release-artifacts/ \;
+
+          MAC_ZIP_COUNT=$(find release-artifacts -maxdepth 1 -name "YakShaver-*-mac.zip" | wc -l | tr -d ' ')
+          if [[ "$MAC_ZIP_COUNT" -ne 2 ]]; then
+            echo "Expected exactly two macOS ZIP artifacts; found $MAC_ZIP_COUNT" >&2
+            find release-artifacts -maxdepth 1 -name "YakShaver-*-mac.zip" -print >&2
+            exit 1
+          fi
+
+          MAC_BLOCKMAP_COUNT=$(find release-artifacts -maxdepth 1 -name "YakShaver-*-mac.zip.blockmap" | wc -l | tr -d ' ')
+          if [[ "$MAC_BLOCKMAP_COUNT" -ne 2 ]]; then
+            echo "Expected exactly two macOS ZIP blockmaps; found $MAC_BLOCKMAP_COUNT" >&2
+            find release-artifacts -maxdepth 1 -name "YakShaver-*-mac.zip.blockmap" -print >&2
+            exit 1
+          fi
+
+          MAC_MANIFEST_COUNT=$(find release-artifacts -maxdepth 1 -name "*-mac.yml" | wc -l | tr -d ' ')
+          if [[ "$MAC_MANIFEST_COUNT" -ne 1 ]]; then
+            echo "Expected exactly one macOS update manifest; found $MAC_MANIFEST_COUNT" >&2
+            find release-artifacts -maxdepth 1 -name "*-mac.yml" -print >&2
+            exit 1
+          fi
 
       - name: Create single GitHub release with all artifacts
         uses: softprops/action-gh-release@v2
@@ -552,7 +646,7 @@ jobs:
 
             This is an automated pre-release. It will be updated automatically when new commits are pushed to the PR.
           prerelease: true
-          files: artifacts/**/*
+          files: release-artifacts/**/*
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-electron-app.yml
+++ b/.github/workflows/release-electron-app.yml
@@ -141,26 +141,6 @@ jobs:
           CI: true
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify Windows update manifest
-        shell: pwsh
-        run: |
-          $manifest = "build/latest.yml"
-
-          if (-not (Test-Path $manifest)) {
-            Write-Host "Available YAML files:"
-            Get-ChildItem "build/*.yml" | ForEach-Object { Write-Host "  $($_.Name)" }
-            throw "Missing Windows update manifest: $manifest"
-          }
-
-          if (Get-ChildItem "build/*-mac.yml" -ErrorAction SilentlyContinue) {
-            throw "Windows build must not produce macOS update manifests"
-          }
-
-          $content = Get-Content $manifest -Raw
-          if ($content -notmatch "\.exe") {
-            throw "Windows update manifest must reference the Windows installer"
-          }
-
       - name: Create fixed-name artifacts for stable download links
         shell: pwsh
         run: |

--- a/.github/workflows/release-electron-app.yml
+++ b/.github/workflows/release-electron-app.yml
@@ -141,6 +141,26 @@ jobs:
           CI: true
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify Windows update manifest
+        shell: pwsh
+        run: |
+          $manifest = "build/latest.yml"
+
+          if (-not (Test-Path $manifest)) {
+            Write-Host "Available YAML files:"
+            Get-ChildItem "build/*.yml" | ForEach-Object { Write-Host "  $($_.Name)" }
+            throw "Missing Windows update manifest: $manifest"
+          }
+
+          if (Get-ChildItem "build/*-mac.yml" -ErrorAction SilentlyContinue) {
+            throw "Windows build must not produce macOS update manifests"
+          }
+
+          $content = Get-Content $manifest -Raw
+          if ($content -notmatch "\.exe") {
+            throw "Windows update manifest must reference the Windows installer"
+          }
+
       - name: Create fixed-name artifacts for stable download links
         shell: pwsh
         run: |
@@ -279,7 +299,7 @@ jobs:
           echo "Updated package.json version to $VERSION"
 
       - name: Publish macOS arm64 app
-        run: npm run publish -- --mac --arm64 -c.mac.target.arch=arm64 -c.mac.artifactName='${productName}-${version}-${arch}-mac.${ext}'
+        run: npm run publish -- --mac --arm64 -c.mac.target.arch=arm64 -c.mac.artifactName='${productName}-${version}-${arch}-mac.${ext}' --publish never
         env:
           NODE_ENV: production
           CI: true
@@ -311,10 +331,23 @@ jobs:
           fi
           echo "Found arm64 DMG: $DMG_ARM64"
           cp "$DMG_ARM64" "YakShaver-latest-arm64.dmg"
+          gh release upload "$VERSION" \
+            YakShaver-*-arm64-mac.dmg \
+            YakShaver-*-arm64-mac.zip \
+            YakShaver-*-arm64-mac.zip.blockmap \
+            --clobber \
+            --repo SSWConsulting/SSW.YakShaver.Desktop
           gh release upload "$VERSION" "YakShaver-latest-arm64.dmg" --clobber --repo SSWConsulting/SSW.YakShaver.Desktop
           echo "Successfully uploaded YakShaver-latest-arm64.dmg for stable download link"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload macOS (arm64) update manifest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-arm64-update-manifest
+          path: build/*-mac.yml
+          retention-days: 1
 
   build-macos-x64:
     needs: check-release
@@ -425,7 +458,7 @@ jobs:
           echo "Updated package.json version to $VERSION"
 
       - name: Publish macOS x64 app
-        run: npm run publish -- --mac --x64 -c.mac.target.arch=x64 -c.mac.artifactName='${productName}-${version}-${arch}-mac.${ext}'
+        run: npm run publish -- --mac --x64 -c.mac.target.arch=x64 -c.mac.artifactName='${productName}-${version}-${arch}-mac.${ext}' --publish never
         env:
           NODE_ENV: production
           CI: true
@@ -497,7 +530,79 @@ jobs:
           fi
           echo "Found x64 DMG: $DMG_X64"
           cp "$DMG_X64" "YakShaver-latest-x64.dmg"
+          gh release upload "$VERSION" \
+            YakShaver-*-x64-mac.dmg \
+            YakShaver-*-x64-mac.zip \
+            YakShaver-*-x64-mac.zip.blockmap \
+            --clobber \
+            --repo SSWConsulting/SSW.YakShaver.Desktop
           gh release upload "$VERSION" "YakShaver-latest-x64.dmg" --clobber --repo SSWConsulting/SSW.YakShaver.Desktop
           echo "Successfully uploaded YakShaver-latest-x64.dmg for stable download link"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload macOS (x64) update manifest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-x64-update-manifest
+          path: build/*-mac.yml
+          retention-days: 1
+
+  publish-macos-update-manifest:
+    needs:
+      - check-release
+      - build-macos-arm64
+      - build-macos-x64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install manifest merge dependencies
+        run: npm ci --ignore-scripts --prefer-offline
+        env:
+          YOUTUBE_DL_SKIP_DOWNLOAD: true
+
+      - name: Download macOS (arm64) update manifest
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-arm64-update-manifest
+          path: artifacts/macos-arm64/
+
+      - name: Download macOS (x64) update manifest
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-x64-update-manifest
+          path: artifacts/macos-x64/
+
+      - name: Merge and publish macOS update manifest
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.check-release.outputs.version }}"
+          ARM64_MANIFEST=$(find artifacts/macos-arm64 -name "*-mac.yml" -type f | head -n 1)
+          X64_MANIFEST=$(find artifacts/macos-x64 -name "*-mac.yml" -type f | head -n 1)
+
+          if [[ -z "$ARM64_MANIFEST" || -z "$X64_MANIFEST" ]]; then
+            echo "Missing macOS update manifest artifacts" >&2
+            find artifacts -type f -name "*.yml" -print >&2
+            exit 1
+          fi
+
+          mkdir -p release-artifacts
+          node scripts/merge-mac-update-manifests.js \
+            --arm64 "$ARM64_MANIFEST" \
+            --x64 "$X64_MANIFEST" \
+            --output "release-artifacts/latest-mac.yml"
+
+          gh release upload "$VERSION" \
+            release-artifacts/latest-mac.yml \
+            --clobber \
+            --repo SSWConsulting/SSW.YakShaver.Desktop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-electron-app.yml
+++ b/.github/workflows/release-electron-app.yml
@@ -536,6 +536,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target || github.event.release.target_commitish }}
 
       - uses: actions/setup-node@v6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ YakShaver is a desktop AI agent with the following capabilities:
 - **APIs**: `googleapis`, `@microsoft/microsoft-graph-client`, `google-auth-library`, `@azure/msal-node`
 - **Video/Media**: `@ffmpeg-installer/ffmpeg`, `youtube-dl-exec`
 - **Telemetry**: `applicationinsights`
+- **CI/Release tooling**: `js-yaml` for update manifest merge validation
 
 ## Project Structure
 
@@ -534,6 +535,14 @@ Button variants: `default`, `destructive`, `outline`, `secondary`, `ghost`, `lin
 
 - **External**: Configure via Settings UI (persisted to `mcp-servers.json`)
 - **Internal**: Add to `src/backend/services/mcp/internal/` and register in MCP orchestrator
+
+### Updating Release Workflows
+
+- macOS arm64 and x64 builds generate separate ZIPs but must publish a single update manifest
+  (`latest-mac.yml` for stable releases or `beta.{PR}-mac.yml` for PR releases). Use
+  `scripts/merge-mac-update-manifests.js` to merge and validate the two generated mac manifests.
+- Windows update manifests are separate (`latest.yml` or `beta.{PR}.yml`) and must not be merged with
+  macOS manifests.
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "electron": "^39.2.7",
         "electron-builder": "^26.0.12",
         "electron-rebuild": "^3.2.9",
+        "js-yaml": "^4.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
         "wait-on": "^9.0.3"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "electron": "^39.2.7",
     "electron-builder": "^26.0.12",
     "electron-rebuild": "^3.2.9",
+    "js-yaml": "^4.1.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18",
     "wait-on": "^9.0.3"

--- a/scripts/merge-mac-update-manifests.js
+++ b/scripts/merge-mac-update-manifests.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+const yaml = require("js-yaml");
+
+const ARCHES = ["arm64", "x64"];
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseArgs(args) {
+  const options = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const key = arg.slice(2);
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    options[key] = value;
+    index += 1;
+  }
+
+  return options;
+}
+
+function loadManifest(manifestPath) {
+  const manifest = yaml.load(fs.readFileSync(manifestPath, "utf8"));
+  if (!isRecord(manifest)) {
+    throw new Error(`Manifest is not a YAML object: ${manifestPath}`);
+  }
+
+  return manifest;
+}
+
+function toFileEntries(manifest) {
+  if (Array.isArray(manifest.files)) {
+    return manifest.files;
+  }
+
+  if (typeof manifest.path === "string" && typeof manifest.sha512 === "string") {
+    return [
+      {
+        url: manifest.path,
+        sha512: manifest.sha512,
+      },
+    ];
+  }
+
+  throw new Error("Manifest must include a files array or legacy path/sha512 fields");
+}
+
+function normalizeUrlPath(url) {
+  return url.replace(/\\/g, "/");
+}
+
+function isMacZipForArch(file, arch) {
+  if (!isRecord(file) || typeof file.url !== "string") {
+    return false;
+  }
+
+  return normalizeUrlPath(file.url).endsWith(`-${arch}-mac.zip`);
+}
+
+function findMacZipEntry(manifest, arch, manifestPath) {
+  const entries = toFileEntries(manifest).filter((file) => isMacZipForArch(file, arch));
+
+  if (entries.length !== 1) {
+    throw new Error(
+      `${manifestPath} must contain exactly one ${arch} mac ZIP entry; found ${entries.length}`,
+    );
+  }
+
+  const entry = entries[0];
+  if (!isRecord(entry) || typeof entry.url !== "string" || typeof entry.sha512 !== "string") {
+    throw new Error(`${manifestPath} ${arch} entry must include url and sha512`);
+  }
+
+  return { ...entry };
+}
+
+function assertSingleArchManifest(manifest, expectedArch, manifestPath) {
+  findMacZipEntry(manifest, expectedArch, manifestPath);
+
+  for (const arch of ARCHES) {
+    if (arch === expectedArch) {
+      continue;
+    }
+
+    const unexpectedEntries = toFileEntries(manifest).filter((file) => isMacZipForArch(file, arch));
+    if (unexpectedEntries.length > 0) {
+      throw new Error(`${manifestPath} is expected to be ${expectedArch}, but contains ${arch}`);
+    }
+  }
+}
+
+function validateMergedManifest(manifest, manifestPath) {
+  const entriesByArch = new Map(
+    ARCHES.map((arch) => [arch, findMacZipEntry(manifest, arch, manifestPath)]),
+  );
+
+  const fileEntries = toFileEntries(manifest);
+  const windowsEntries = fileEntries.filter(
+    (file) => isRecord(file) && typeof file.url === "string" && file.url.endsWith(".exe"),
+  );
+
+  if (windowsEntries.length > 0) {
+    throw new Error(`${manifestPath} must not include Windows installer entries`);
+  }
+
+  return entriesByArch;
+}
+
+function mergeMacUpdateManifests({ arm64Manifest, x64Manifest, output }) {
+  assertSingleArchManifest(arm64Manifest, "arm64", "arm64 manifest");
+  assertSingleArchManifest(x64Manifest, "x64", "x64 manifest");
+
+  if (arm64Manifest.version !== x64Manifest.version) {
+    throw new Error(
+      `Mac manifests must have the same version: ${arm64Manifest.version} != ${x64Manifest.version}`,
+    );
+  }
+
+  const arm64Entry = findMacZipEntry(arm64Manifest, "arm64", "arm64 manifest");
+  const x64Entry = findMacZipEntry(x64Manifest, "x64", "x64 manifest");
+  const merged = {
+    ...arm64Manifest,
+    files: [arm64Entry, x64Entry],
+    path: arm64Entry.url,
+    sha512: arm64Entry.sha512,
+  };
+
+  if (arm64Entry.sha2) {
+    merged.sha2 = arm64Entry.sha2;
+  } else {
+    delete merged.sha2;
+  }
+
+  validateMergedManifest(merged, output);
+
+  return merged;
+}
+
+function writeManifest(manifestPath, manifest) {
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, yaml.dump(manifest, { lineWidth: 120, noRefs: true }), "utf8");
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const requiredOptions = ["arm64", "x64", "output"];
+  for (const option of requiredOptions) {
+    if (!options[option]) {
+      throw new Error(`Missing required --${option} option`);
+    }
+  }
+
+  const merged = mergeMacUpdateManifests({
+    arm64Manifest: loadManifest(options.arm64),
+    x64Manifest: loadManifest(options.x64),
+    output: options.output,
+  });
+
+  writeManifest(options.output, merged);
+  console.log(`Merged macOS update manifest written to ${options.output}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  mergeMacUpdateManifests,
+  validateMergedManifest,
+};


### PR DESCRIPTION
…idation

> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

Codex GPT5.5 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

- #819  

> 2. What was changed?

Fix macOS updates mix up  architecture 

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->

The old pipeline builds the arm64 and x64 separately, whichever build finishes the last will overwrite the latest-mac.yml (in this case the x64). Electron auto updater need to check latest-mac.yml, it only sees the x64 version .zip. That's why it will overwrite the arm64 version after update.
<img width="826" height="250" alt="Screenshot 2026-05-06 at 12 13 03 pm" src="https://github.com/user-attachments/assets/5083f67a-351c-4c3c-9762-f805c0c83211" />

**Figure: the old latest-mac.yml, only contains x64**

The fix added a merge logic in the end of building pipeline, so the lates-mac.yml will contain both arm64 and x64. Electron auto update will be able to pick the correct version.
<img width="828" height="235" alt="Screenshot 2026-05-06 at 12 14 15 pm" src="https://github.com/user-attachments/assets/5437985a-5ada-49e8-810c-5fa1875f2358" />

**Figure: after the change, it contains arm64 and x64**
