### PR TITLE
XS⚠️ ◾ 858-progress-steps-delay-after-recording

### DIFF
--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -251,6 +251,8 @@ export class ProcessVideoIPCHandlers {
     try {
       const workflowManager = this.getOrCreateWorkflowManager(effectiveShaveId);
       this.workflowManagers.set(workflowManager.getWorkflowId(), workflowManager);
+      // put a delay here to ensure the workflow panel is rendered before emitting any progress updates, so that the initial state is received and displayed correctly. This is a workaround
+      //await new Promise((resolve) => setTimeout(resolve, 500));
 
       this.lastVideoFilePath = filePath;
       this.trackTempFile(filePath, effectiveShaveId);
@@ -812,3 +814,4 @@ export class ProcessVideoIPCHandlers {
     }
   }
 }
+

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -251,8 +251,6 @@ export class ProcessVideoIPCHandlers {
     try {
       const workflowManager = this.getOrCreateWorkflowManager(effectiveShaveId);
       this.workflowManagers.set(workflowManager.getWorkflowId(), workflowManager);
-      // put a delay here to ensure the workflow panel is rendered before emitting any progress updates, so that the initial state is received and displayed correctly. This is a workaround
-      //await new Promise((resolve) => setTimeout(resolve, 500));
 
       this.lastVideoFilePath = filePath;
       this.trackTempFile(filePath, effectiveShaveId);

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -812,4 +812,3 @@ export class ProcessVideoIPCHandlers {
     }
   }
 }
-

--- a/src/ui/src/components/recording/ScreenRecorder.tsx
+++ b/src/ui/src/components/recording/ScreenRecorder.tsx
@@ -3,6 +3,7 @@ import { CircleStopIcon, Upload } from "lucide-react";
 import { type ChangeEvent, useCallback, useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { useShaveManager } from "@/hooks/useShaveManager";
+import { useWorkflowNavigation } from "@/hooks/useWorkflowNavigation";
 import { cn } from "@/lib/utils";
 import { ipcClient } from "@/services/ipc-client";
 import { formatErrorMessage } from "@/utils";
@@ -104,6 +105,7 @@ function RecordButton({
 }
 
 export function ScreenRecorder({ showButtonOnly = false, className = "" }: ScreenRecorderProps) {
+  const navigateToWorkflow = useWorkflowNavigation({ listen: false });
   const { authState, setUploadResult, setUploadStatus } = useYouTubeAuth();
   const { isYoutubeUrlWorkflowEnabled } = useAdvancedSettings();
   const { isRecording, isProcessing, start, stop } = useScreenRecording();
@@ -399,6 +401,7 @@ export function ScreenRecorder({ showButtonOnly = false, className = "" }: Scree
             </Button>
             <Button
               onClick={() => {
+                navigateToWorkflow();
                 handleProcessYoutubeUrl();
                 setYoutubeDialogOpen(false);
               }}

--- a/src/ui/src/components/recording/VideoPreviewModal.tsx
+++ b/src/ui/src/components/recording/VideoPreviewModal.tsx
@@ -1,6 +1,7 @@
 import type { ToolApprovalMode } from "@shared/types/user-settings";
 import { ArrowRight, RotateCcw } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useWorkflowNavigation } from "@/hooks/useWorkflowNavigation";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -44,6 +45,7 @@ export function VideoPreviewModal({
   onContinue,
   onDurationLoad,
 }: VideoPreviewModalProps) {
+  const navigateToWorkflow = useWorkflowNavigation({ listen: false });
   const [videoUrl, setVideoUrl] = useState("");
   const [showConfirmExit, setShowConfirmExit] = useState(false);
   const [autoApproveChecked, setAutoApproveChecked] = useState(false);
@@ -148,7 +150,10 @@ export function VideoPreviewModal({
               </Button>
               <Button
                 variant="default"
-                onClick={() => onContinue(autoApproveChecked)}
+                onClick={() => {
+                  navigateToWorkflow();
+                  onContinue(autoApproveChecked);
+                }}
                 disabled={audioCheck.status === "checking" || audioCheck.status === "no_audio"}
               >
                 <ArrowRight className="w-4 h-4" />

--- a/src/ui/src/hooks/useWorkflowNavigation.ts
+++ b/src/ui/src/hooks/useWorkflowNavigation.ts
@@ -1,16 +1,29 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
-export function useWorkflowNavigation() {
+interface UseWorkflowNavigationOptions {
+  listen?: boolean;
+}
+
+export function useWorkflowNavigation(options?: UseWorkflowNavigationOptions) {
   const navigate = useNavigate();
   const location = useLocation();
+  const listen = options?.listen ?? true;
+
+  const navigateToWorkflow = useCallback(() => {
+    if (location.pathname !== "/workflow") {
+      navigate("/workflow");
+    }
+  }, [navigate, location.pathname]);
 
   useEffect(() => {
-    const cleanup = window.electronAPI.workflow.onProgressNeo(() => {
-      if (location.pathname !== "/workflow") {
-        navigate("/workflow");
-      }
-    });
+    if (!listen) {
+      return;
+    }
+
+    const cleanup = window.electronAPI.workflow.onProgressNeo(navigateToWorkflow);
     return cleanup;
-  }, [navigate, location.pathname]);
+  }, [listen, navigateToWorkflow]);
+
+  return navigateToWorkflow;
 }


### PR DESCRIPTION

> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

Github Copilot 

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

- #858  

> 2. What was changed?

changed the way YakShaver mount `WorkFlowProgressPanel`


TL;DR
Race condition, backend progress step event emits before the `WorkFlowProgressPanel` UI is mounted and rendered casing missing the first progress step starting signal.

Issue:
`WorkFlowProgressPanel` mount triggered by the `workflow:progress-neo` channel event. So when the first event emitted by the backend `process-video-handler`, `WorkFlowProgressPanel` will be mounted, but by the time it's rendered, it already missed the first progress step event, i.e "uploading video" / "downloading video" until the second step event emitted,`WorkFlowProgressPanel` will refresh the progress step. That's why there's a delay to show the steps
 
Fix:
wire up the `WorkFlowProgressPanel` to the `Process Link` / `Shave it` button, so the UI is proactively mounted and rendered before the backend starts to emit progress step event, so the UI won't miss and event.



> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
