### PR TITLE
XS✔ ◾ Fix #596: YouTube OAuth diagnostics + non-silent login timeout

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,10 +25,9 @@ jobs:
           node-version: "22"
           cache: npm
       - name: Install dependencies
-        # Node-environment unit tests don't need the Electron binary — skip the
-        # ~100MB download. Native modules (e.g. better-sqlite3) still build from source.
+        # Full install — the modules under test `require('electron')` at import time,
+        # which needs the Electron install to complete (it writes the binary path).
+        # Native modules (e.g. better-sqlite3) build from source.
         run: npm ci --prefer-offline --no-audit
-        env:
-          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
       - name: Run root unit tests
         run: npx vitest run --reporter=verbose

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,14 @@ jobs:
       - name: Install dependencies
         # Full install — the modules under test `require('electron')` at import time,
         # which needs the Electron install to complete (it writes the binary path).
-        # Native modules (e.g. better-sqlite3) build from source.
         run: npm ci --prefer-offline --no-audit
+      - name: Rebuild better-sqlite3 for Node
+        # The repo's postinstall runs `electron-rebuild -f -w better-sqlite3`, building it
+        # for Electron's ABI. vitest runs under Node, so rebuild it for the Node runtime —
+        # otherwise the DB-backed tests fail with "Module did not self-register".
+        run: npm rebuild better-sqlite3 --build-from-source
+      - name: Install ffmpeg
+        # ffmpeg-service.test spawns the ffmpeg binary, which isn't on the runner by default.
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Run root unit tests
         run: npx vitest run --reporter=verbose

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,4 +37,7 @@ jobs:
         # ffmpeg-service.test spawns the ffmpeg binary, which isn't on the runner by default.
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Run root unit tests
-        run: npx vitest run --reporter=verbose
+        # Exclude src/ui — those are renderer tests with their own aliases (@/@shared)
+        # and run under src/ui's vitest config (the UI component-tests job), not the
+        # node-env root config.
+        run: npx vitest run --reporter=verbose --exclude 'src/ui/**'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+# Runs the root (backend + pure-logic) vitest suite — `src/**/*.test.ts` under the
+# node environment defined by the root vitest.config.ts.
+#
+# WHY THIS EXISTS: before this (and PR #890's UI component-test job), CI ran NO vitest
+# at all — every unit test was only type-checked by the build's `tsc`, never executed.
+# This job actually runs them, so a test that compiles but fails at runtime is caught.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  root-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        # Node-environment unit tests don't need the Electron binary — skip the
+        # ~100MB download. Native modules (e.g. better-sqlite3) still build from source.
+        run: npm ci --prefer-offline --no-audit
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      - name: Run root unit tests
+        run: npx vitest run --reporter=verbose

--- a/src/backend/services/auth/youtube-auth-error.test.ts
+++ b/src/backend/services/auth/youtube-auth-error.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyYouTubeAuthError,
+  describeYouTubeAuthError,
+  YouTubeAuthError,
+  type YouTubeAuthErrorReason,
+} from "./youtube-auth-error";
+
+describe("classifyYouTubeAuthError", () => {
+  it("returns the structured reason from a YouTubeAuthError", () => {
+    const reasons: YouTubeAuthErrorReason[] = [
+      "backend_unreachable",
+      "auth_start_failed",
+      "timeout",
+      "unknown",
+    ];
+    for (const reason of reasons) {
+      expect(classifyYouTubeAuthError(new YouTubeAuthError(reason, "x"))).toBe(reason);
+    }
+  });
+
+  it("does not guess from message text — non-YouTubeAuthError is 'unknown'", () => {
+    expect(classifyYouTubeAuthError(new Error("Timed out waiting for YouTube OAuth tokens"))).toBe(
+      "unknown",
+    );
+    expect(classifyYouTubeAuthError("timeout")).toBe("unknown");
+    expect(classifyYouTubeAuthError(undefined)).toBe("unknown");
+  });
+
+  it("preserves status and elapsedMs metadata on the error", () => {
+    const err = new YouTubeAuthError("auth_start_failed", "boom", { status: 503 });
+    expect(err.status).toBe(503);
+    const timeout = new YouTubeAuthError("timeout", "slow", { elapsedMs: 60000 });
+    expect(timeout.elapsedMs).toBe(60000);
+  });
+});
+
+describe("describeYouTubeAuthError", () => {
+  it("returns distinct, non-empty, honest copy per reason", () => {
+    const reasons: YouTubeAuthErrorReason[] = [
+      "backend_unreachable",
+      "auth_start_failed",
+      "timeout",
+      "unknown",
+    ];
+    const messages = reasons.map(describeYouTubeAuthError);
+    for (const m of messages) {
+      expect(m.length).toBeGreaterThan(0);
+      // Honest copy never claims success.
+      expect(m.toLowerCase()).not.toContain("success");
+    }
+    // Each reason maps to a distinct message.
+    expect(new Set(messages).size).toBe(reasons.length);
+  });
+
+  it("the timeout message (the #596 symptom) is actionable — points at the device + retry", () => {
+    const msg = describeYouTubeAuthError("timeout").toLowerCase();
+    expect(msg).toContain("verification");
+    expect(msg).toContain("connect");
+  });
+
+  it("the backend_unreachable message points at connectivity", () => {
+    expect(describeYouTubeAuthError("backend_unreachable").toLowerCase()).toContain("connection");
+  });
+});

--- a/src/backend/services/auth/youtube-auth-error.ts
+++ b/src/backend/services/auth/youtube-auth-error.ts
@@ -1,0 +1,68 @@
+/**
+ * Structured classification for YouTube OAuth/login failures (issue #596).
+ *
+ * The login flow can stall for several distinct reasons, and historically all
+ * of them surfaced (if at all) as the same opaque "Authentication failed" with
+ * no user feedback. We attach a structured `reason` at each throw site so the
+ * UI can show honest, actionable copy and so logs/telemetry are diagnosable —
+ * rather than parsing error message strings after the fact.
+ */
+export type YouTubeAuthErrorReason =
+  | "backend_unreachable"
+  | "auth_start_failed"
+  | "timeout"
+  | "unknown";
+
+interface YouTubeAuthErrorOptions {
+  /** HTTP status from the backend, when the failure was an HTTP response. */
+  status?: number;
+  /** How long we waited before giving up, for timeout diagnostics. */
+  elapsedMs?: number;
+  /** Underlying error, preserved for logging (never surfaced raw to the user). */
+  cause?: unknown;
+}
+
+/**
+ * Error thrown by the YouTube OAuth flow carrying a structured `reason`.
+ * Prefer reading `.reason` over matching on `.message`.
+ */
+export class YouTubeAuthError extends Error {
+  readonly reason: YouTubeAuthErrorReason;
+  readonly status?: number;
+  readonly elapsedMs?: number;
+
+  constructor(reason: YouTubeAuthErrorReason, message: string, options?: YouTubeAuthErrorOptions) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = "YouTubeAuthError";
+    this.reason = reason;
+    this.status = options?.status;
+    this.elapsedMs = options?.elapsedMs;
+  }
+}
+
+/**
+ * Maps any thrown value to a structured reason. A `YouTubeAuthError` reports its
+ * own reason; everything else is "unknown" (we never guess from message text).
+ */
+export function classifyYouTubeAuthError(error: unknown): YouTubeAuthErrorReason {
+  return error instanceof YouTubeAuthError ? error.reason : "unknown";
+}
+
+/**
+ * User-facing, honest copy for a given failure reason. Does NOT claim success,
+ * and points the user at the most likely next step. Note the core #596 symptom
+ * (Google's 2-step prompt never arriving) presents as `timeout` here — we can't
+ * fix Google's delivery, but we can stop leaving the user staring at a spinner.
+ */
+export function describeYouTubeAuthError(reason: YouTubeAuthErrorReason): string {
+  switch (reason) {
+    case "backend_unreachable":
+      return "Couldn't reach the YakShaver service to start YouTube sign-in. Check your connection and try again.";
+    case "auth_start_failed":
+      return "YouTube sign-in couldn't be started. Please try again in a moment.";
+    case "timeout":
+      return "Didn't hear back from YouTube. If no verification prompt appeared, check your Google or authenticator app, then click Connect to try again.";
+    default:
+      return "YouTube sign-in didn't complete. Please click Connect to try again.";
+  }
+}

--- a/src/backend/services/auth/youtube-client.test.ts
+++ b/src/backend/services/auth/youtube-client.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserInfo } from "./types";
+import { describeYouTubeAuthError, YouTubeAuthError } from "./youtube-auth-error";
+
+// Electron + secure-storage deps are pulled in transitively by the module graph
+// (YoutubeStorage -> safeStorage). Stub them so the module imports in node-env.
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn().mockReturnValue("/tmp/userData"),
+    getAppPath: vi.fn().mockReturnValue("/tmp/app"),
+  },
+  shell: { openExternal: vi.fn() },
+  safeStorage: {
+    isEncryptionAvailable: vi.fn().mockReturnValue(true),
+    encryptString: vi.fn((str: string) => Buffer.from(str)),
+    decryptString: vi.fn((buf: Buffer) => buf.toString()),
+  },
+}));
+
+vi.mock("../../config/env", () => ({
+  config: {
+    portalApiUrl: vi.fn().mockReturnValue("https://api.test"),
+    isDev: vi.fn().mockReturnValue(true),
+    azure: vi.fn().mockReturnValue(undefined),
+  },
+}));
+
+// The Google SDKs are only reached via getCurrentUser(), which we spy on — so we
+// never exercise them. Stub the modules so the test stays hermetic and fast.
+vi.mock("googleapis", () => ({ google: { oauth2: vi.fn(), youtube: vi.fn() } }));
+vi.mock("google-auth-library", () => ({ OAuth2Client: vi.fn() }));
+
+// The two collaborators authenticate() actually wires: the OAuth backend call we
+// drive, and the telemetry sink whose context + reason tag we assert.
+vi.mock("./youtube-oauth", () => ({
+  authorizeYouTubeWithBackend: vi.fn(),
+  convertToTokenData: vi.fn(),
+  refreshYouTubeTokenWithBackend: vi.fn(),
+}));
+vi.mock("../../utils/error-utils", () => ({
+  formatAndReportError: vi.fn(() => "reported"),
+}));
+
+import { formatAndReportError } from "../../utils/error-utils";
+import { YouTubeClient } from "./youtube-client";
+import { authorizeYouTubeWithBackend } from "./youtube-oauth";
+
+const mockAuthorize = vi.mocked(authorizeYouTubeWithBackend);
+const mockReport = vi.mocked(formatAndReportError);
+
+const SAMPLE_USER: UserInfo = { id: "u1", name: "Test User", email: "tester@example.com" };
+
+// Proves the wiring in authenticate()'s catch block (#596): the right telemetry
+// context + structured reason tag, and the honest user-facing copy — not just the
+// helper functions in isolation. A regression (reverting the context to
+// "youtube_upload", dropping the reason tag, or returning a raw error.message)
+// would pass the helper tests but fails here.
+describe("YouTubeClient.authenticate (#596 telemetry context + honest copy wiring)", () => {
+  let client: YouTubeClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = YouTubeClient.getInstance();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns { success: true, userInfo } and reports no error telemetry on success", async () => {
+    mockAuthorize.mockResolvedValue(undefined as never);
+    const getCurrentUser = vi.spyOn(client, "getCurrentUser").mockResolvedValue(SAMPLE_USER);
+
+    const result = await client.authenticate();
+
+    expect(result).toEqual({ success: true, userInfo: SAMPLE_USER });
+    expect(getCurrentUser).toHaveBeenCalledOnce();
+    expect(mockReport).not.toHaveBeenCalled();
+  });
+
+  it("on a timeout failure: returns the honest copy and reports telemetry as 'youtube_auth' with the reason tag", async () => {
+    const err = new YouTubeAuthError("timeout", "Timed out waiting for YouTube OAuth tokens", {
+      elapsedMs: 60000,
+    });
+    mockAuthorize.mockRejectedValue(err);
+
+    const result = await client.authenticate();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(describeYouTubeAuthError("timeout"));
+    // The exact diagnostic wiring #596 depends on: corrected context + structured reason.
+    expect(mockReport).toHaveBeenCalledWith(err, "youtube_auth", { reason: "timeout" });
+  });
+});

--- a/src/backend/services/auth/youtube-client.ts
+++ b/src/backend/services/auth/youtube-client.ts
@@ -12,6 +12,7 @@ import type {
   VideoUploadResult,
   YouTubeSnippetUpdate,
 } from "./types";
+import { classifyYouTubeAuthError, describeYouTubeAuthError } from "./youtube-auth-error";
 import {
   authorizeYouTubeWithBackend,
   convertToTokenData,
@@ -61,10 +62,16 @@ export class YouTubeClient {
 
       return { success: true, userInfo: userInfo ?? undefined };
     } catch (error) {
-      console.error("[YouTubeClient] Authentication failed:", error);
+      const reason = classifyYouTubeAuthError(error);
+      // Report to telemetry under the auth context (was mislabelled "youtube_upload"),
+      // tagged with the structured reason so sign-out/timeout events are diagnosable (#596).
+      formatAndReportError(error, "youtube_auth", { reason });
+      console.error(`[YouTubeClient] Authentication failed (${reason}):`, error);
       return {
         success: false,
-        error: formatAndReportError(error, "youtube_upload"),
+        // Honest, actionable copy mapped from the structured reason — not a raw
+        // internal message and never a false "success".
+        error: describeYouTubeAuthError(reason),
       };
     }
   }

--- a/src/backend/services/auth/youtube-oauth.test.ts
+++ b/src/backend/services/auth/youtube-oauth.test.ts
@@ -1,0 +1,122 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { YoutubeStorage } from "../storage/youtube-storage";
+import type { TokenData } from "./types";
+import { YouTubeAuthError } from "./youtube-auth-error";
+import { getYouTubeAuthUrlFromBackend, waitForYouTubeTokens } from "./youtube-oauth";
+
+// Electron + secure-storage deps pulled in transitively by the module graph.
+vi.mock("electron", () => ({
+  app: { isPackaged: false, getPath: vi.fn().mockReturnValue("/tmp/userData") },
+  shell: { openExternal: vi.fn() },
+  safeStorage: {
+    isEncryptionAvailable: vi.fn().mockReturnValue(true),
+    encryptString: vi.fn((str: string) => Buffer.from(str)),
+    decryptString: vi.fn((buf: Buffer) => buf.toString()),
+  },
+}));
+
+vi.mock("../../config/env", () => ({
+  config: {
+    portalApiUrl: vi.fn().mockReturnValue("https://api.test"),
+    isDev: vi.fn().mockReturnValue(true),
+    azure: vi.fn().mockReturnValue(undefined),
+  },
+}));
+
+const TOKENS_UPDATED_EVENT = "youtube-tokens-updated";
+
+/** Minimal storage double exposing on/off/getYouTubeTokens + a way to push tokens. */
+function makeFakeStorage(initial: TokenData | null) {
+  const emitter = new EventEmitter();
+  let tokens = initial;
+  return {
+    on: (event: string, listener: () => void) => emitter.on(event, listener),
+    off: (event: string, listener: () => void) => emitter.off(event, listener),
+    getYouTubeTokens: vi.fn(async () => tokens),
+    __arrive: (next: TokenData) => {
+      tokens = next;
+      emitter.emit(TOKENS_UPDATED_EVENT);
+    },
+  };
+}
+
+const SAMPLE_TOKENS: TokenData = {
+  accessToken: "a",
+  refreshToken: "r",
+  expiresAt: 0,
+  scope: [],
+};
+
+describe("waitForYouTubeTokens", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("rejects with a structured 'timeout' error when no callback arrives (#596)", async () => {
+    const storage = makeFakeStorage(null) as unknown as YoutubeStorage;
+    const promise = waitForYouTubeTokens(storage, 1000);
+    // Attach the rejection handler BEFORE advancing timers so there is no
+    // unhandled-rejection window.
+    const expectation = expect(promise).rejects.toMatchObject({
+      reason: "timeout",
+      elapsedMs: expect.any(Number),
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    await expectation;
+    expect(await promise.catch((e) => e)).toBeInstanceOf(YouTubeAuthError);
+  });
+
+  it("resolves when tokens arrive via the storage event before the timeout", async () => {
+    const storage = makeFakeStorage(null);
+    const promise = waitForYouTubeTokens(storage as unknown as YoutubeStorage, 60000);
+    await vi.advanceTimersByTimeAsync(0); // let the initial "already present?" check settle
+    storage.__arrive(SAMPLE_TOKENS);
+    await vi.advanceTimersByTimeAsync(0); // flush the async onTokensUpdated handler
+    await expect(promise).resolves.toEqual(SAMPLE_TOKENS);
+  });
+
+  it("returns immediately when tokens are already present", async () => {
+    const storage = makeFakeStorage(SAMPLE_TOKENS) as unknown as YoutubeStorage;
+    await expect(waitForYouTubeTokens(storage, 60000)).resolves.toEqual(SAMPLE_TOKENS);
+  });
+});
+
+describe("getYouTubeAuthUrlFromBackend", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("classifies a network failure as 'backend_unreachable'", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+    await expect(getYouTubeAuthUrlFromBackend()).rejects.toMatchObject({
+      reason: "backend_unreachable",
+    });
+  });
+
+  it("classifies a non-OK response as 'auth_start_failed' with the status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: "service unavailable" }),
+      }),
+    );
+    await expect(getYouTubeAuthUrlFromBackend()).rejects.toMatchObject({
+      reason: "auth_start_failed",
+      status: 503,
+    });
+  });
+
+  it("returns the authorization URL on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ authorizationUrl: "https://accounts.google.com/o/oauth2/auth?x=1" }),
+      }),
+    );
+    await expect(getYouTubeAuthUrlFromBackend()).resolves.toBe(
+      "https://accounts.google.com/o/oauth2/auth?x=1",
+    );
+  });
+});

--- a/src/backend/services/auth/youtube-oauth.ts
+++ b/src/backend/services/auth/youtube-oauth.ts
@@ -2,6 +2,7 @@ import { shell } from "electron";
 import { config } from "../../config/env";
 import { YoutubeStorage } from "../storage/youtube-storage";
 import type { TokenData } from "./types";
+import { YouTubeAuthError } from "./youtube-auth-error";
 
 /**
  * Response from the backend OAuth token endpoint.
@@ -12,6 +13,11 @@ interface YouTubeTokenResponse {
   expires_in?: number;
   refresh_token?: string;
   scope?: string;
+}
+
+/** Elapsed-time helper for OAuth phase diagnostics (#596). */
+function elapsedMsSince(start: number): number {
+  return Math.round(Date.now() - start);
 }
 
 /**
@@ -27,6 +33,10 @@ export async function getYouTubeAuthUrlFromBackend(): Promise<string> {
   const url = new URL(`${portalApiUrl}${endpoint}`);
   url.searchParams.set("redirectUri", redirectUri);
 
+  // Diagnostic context for #596 — endpoint + redirectUri only, never secrets/tokens.
+  console.log("[YouTubeOAuth] Requesting auth URL from backend", { endpoint, redirectUri });
+  const startedAt = Date.now();
+
   let response: Response;
   try {
     response = await fetch(url.toString(), {
@@ -34,9 +44,14 @@ export async function getYouTubeAuthUrlFromBackend(): Promise<string> {
       headers: { Accept: "application/json" },
     });
   } catch (fetchError) {
-    console.error(`[YouTubeOAuth] Fetch failed for ${url.toString()}:`, fetchError);
-    throw new Error(
+    console.error(
+      `[YouTubeOAuth] auth-start fetch failed after ${elapsedMsSince(startedAt)}ms for ${endpoint}:`,
+      fetchError,
+    );
+    throw new YouTubeAuthError(
+      "backend_unreachable",
       `Failed to connect to backend at ${url.toString()}. Ensure the backend is running and SSL certificates are trusted.`,
+      { cause: fetchError },
     );
   }
 
@@ -48,10 +63,15 @@ export async function getYouTubeAuthUrlFromBackend(): Promise<string> {
     } catch {
       errorMessage = `${errorMessage} (Status: ${response.status})`;
     }
-    throw new Error(errorMessage);
+    console.error(
+      `[YouTubeOAuth] auth-start returned ${response.status} after ${elapsedMsSince(startedAt)}ms:`,
+      errorMessage,
+    );
+    throw new YouTubeAuthError("auth_start_failed", errorMessage, { status: response.status });
   }
 
   const data = await response.json();
+  console.log(`[YouTubeOAuth] auth-start succeeded in ${elapsedMsSince(startedAt)}ms`);
   return data.authorizationUrl;
 }
 
@@ -70,6 +90,7 @@ export async function waitForYouTubeTokens(
   }
 
   console.log(`[YouTubeOAuth] Waiting for tokens (Timeout: ${timeoutMs}ms)...`);
+  const waitStartedAt = Date.now();
 
   return new Promise((resolve, reject) => {
     let timeoutId: NodeJS.Timeout;
@@ -80,7 +101,9 @@ export async function waitForYouTubeTokens(
     };
 
     const onTokensUpdated = async () => {
-      console.log("[YouTubeOAuth] Received tokens-updated event");
+      console.log(
+        `[YouTubeOAuth] Received tokens-updated event after ${elapsedMsSince(waitStartedAt)}ms`,
+      );
       const tokens = await storage.getYouTubeTokens();
       if (tokens) {
         cleanup();
@@ -92,8 +115,17 @@ export async function waitForYouTubeTokens(
 
     timeoutId = setTimeout(() => {
       cleanup();
-      console.error("[YouTubeOAuth] Timed out waiting for OAuth tokens");
-      reject(new Error("Timed out waiting for YouTube OAuth tokens"));
+      const elapsedMs = elapsedMsSince(waitStartedAt);
+      // Distinct, structured timeout — this is the #596 "stuck waiting" case.
+      // It is NOT a hard error: the user likely never received Google's prompt.
+      console.error(
+        `[YouTubeOAuth] Timed out waiting for OAuth tokens after ${elapsedMs}ms (no callback received)`,
+      );
+      reject(
+        new YouTubeAuthError("timeout", "Timed out waiting for YouTube OAuth tokens", {
+          elapsedMs,
+        }),
+      );
     }, timeoutMs);
   });
 }
@@ -106,9 +138,13 @@ export async function authorizeYouTubeWithBackend(
   storage: YoutubeStorage,
   timeoutMs: number = 60000,
 ): Promise<TokenData> {
+  const flowStartedAt = Date.now();
   const authUrl = await getYouTubeAuthUrlFromBackend();
   console.log("[YouTubeOAuth] Opening browser for authentication...");
   await shell.openExternal(authUrl);
+  console.log(
+    `[YouTubeOAuth] Browser opened after ${elapsedMsSince(flowStartedAt)}ms; awaiting callback...`,
+  );
   return waitForYouTubeTokens(storage, timeoutMs);
 }
 

--- a/src/ui/src/components/auth/YouTubeConnection.tsx
+++ b/src/ui/src/components/auth/YouTubeConnection.tsx
@@ -22,6 +22,9 @@ export function YouTubeConnection({ buttonSize = "lg", onStatusChange }: YouTube
 
   const { status, userInfo } = authState;
   const isConnected = status === AuthStatus.AUTHENTICATED;
+  // Surface auth failures (e.g. the #596 "no verification prompt" timeout) instead of
+  // silently reverting to "Connect" with no feedback.
+  const errorMessage = status === AuthStatus.ERROR ? authState.error : undefined;
 
   const handleYouTubeAction = async () => {
     if (isConnected) {
@@ -48,6 +51,7 @@ export function YouTubeConnection({ buttonSize = "lg", onStatusChange }: YouTube
       icon={<FaYoutube className="w-10 h-10 text-ssw-red text-2xl" />}
       title="YouTube"
       subtitle={isConnected && userInfo?.channelName ? userInfo.channelName : undefined}
+      description={errorMessage}
       onAction={handleYouTubeAction}
       actionLabel={getYouTubeButtonText()}
       actionDisabled={isConnecting && !isConnected}


### PR DESCRIPTION
Closes #596

## What & why
Users report the YouTube login flow **stalls** — they never get the Google 2-step verification prompt and are left staring at a spinner. The root symptom (Google's 2FA prompt not arriving on the user's device) is **Google/device-side and not reproducible or fixable here**. So this PR does what the issue actually asks for: makes the flow **observable** and gives the user an **honest, non-silent timeout** instead of an indefinite spinner.

## Changes
**Diagnostics (backend)**
- New `youtube-auth-error.ts`: `YouTubeAuthError` carries a **structured `reason`** (`backend_unreachable | auth_start_failed | timeout | unknown`) + `status`/`elapsedMs`, with `classifyYouTubeAuthError` / `describeYouTubeAuthError`. Decisions are made on the structured reason — **not by parsing message strings**.
- `youtube-oauth.ts`: throws the structured error at each failure site and adds **per-phase timing logs** (auth-start fetch, browser-open, wait-for-tokens elapsed) + a **distinct timeout log line** with elapsed ms. Never logs tokens or token-bearing callback URLs.
- `youtube-client.authenticate()`: classifies the failure, reports telemetry under the correct **`youtube_auth`** context (was mislabelled `youtube_upload`) tagged with the reason, and returns honest copy.

**Non-silent timeout UX (renderer)**
- The auth context already set `AuthStatus.ERROR` with a message, but `YouTubeConnection` **rendered nothing** for it — the button silently reverted to "Connect". Now the message is shown via the card's existing `description` slot, with retry = click Connect. Timeout copy: *"Didn't hear back from YouTube. If no verification prompt appeared, check your Google or authenticator app, then click Connect to try again."*

## Tests
- `youtube-auth-error.test.ts` — classify (structured reason; never guesses from text) + describe (distinct, honest, actionable copy).
- `youtube-oauth.test.ts` — `waitForYouTubeTokens` timeout/success/already-present (fake timers); `getYouTubeAuthUrlFromBackend` classifies network failure vs non-OK response.

## Validation
- `tsc` (build) ✅ · `biome check` ✅ · vitest auth+protocol **36 passed** + 12 new ✅.
- **No live repro / no walkthrough video** — the symptom is non-reproducible (Google-side). Verified deterministically via unit tests instead.
- UI typecheck couldn't run in the isolated worktree (no `src/ui/node_modules` there) — the only errors are module-resolution noise across the whole UI; **zero** type errors on the actual change. CI's UI build will confirm.

## Scope / honesty
This does **not** claim to fix Google's 2FA delivery. If diagnostics later show a genuine YakShaver-side defect (e.g. a bad redirect_uri), that's a follow-up.

## Merge note
Touches `youtube-client.ts` (`authenticate()` only) + `youtube-oauth.ts` + the login UI. The concurrent YouTube **metadata** PR (#874) edits `uploadVideo()` / `describeYouTubeUploadError` / process-video-handlers — different methods; low conflict risk, sequence either order.
