### PR TITLE
XS✔ ◾ Fix #870: recording timer stuck at 0 (drop-before-subscribe race)

### DIFF
--- a/src/backend/events/event-forwarder.ts
+++ b/src/backend/events/event-forwarder.ts
@@ -14,6 +14,10 @@ export function registerEventForwarders() {
   const service = RecordingService.getInstance();
   const controlBar = RecordingControlBarWindow.getInstance();
 
+  // Let the control bar answer the renderer's on-mount time request with the
+  // live elapsed time (#870).
+  controlBar.setElapsedProvider(() => service.getCurrentElapsedSeconds());
+
   const handlers = {
     [IPC_CHANNELS.RECORDING_TIME_UPDATE]: (time: number) => controlBar.updateTime(time),
   };

--- a/src/backend/ipc/channels.ts
+++ b/src/backend/ipc/channels.ts
@@ -31,6 +31,10 @@ export const IPC_CHANNELS = {
   SHOW_CONTROL_BAR: "show-control-bar",
   HIDE_CONTROL_BAR: "hide-control-bar",
   RECORDING_TIME_UPDATE: "recording-time-update",
+  // Renderer -> main handshake: the control bar asks for the current recording
+  // time once it has mounted and subscribed, so a late-loading renderer is
+  // synced regardless of load/subscribe timing (#870).
+  GET_RECORDING_TIME: "get-recording-time",
   CHECK_VIDEO_HAS_AUDIO: "check-video-has-audio",
   MINIMIZE_MAIN_WINDOW: "minimize-main-window",
   RESTORE_MAIN_WINDOW: "restore-main-window",

--- a/src/backend/ipc/screen-recording-handlers.ts
+++ b/src/backend/ipc/screen-recording-handlers.ts
@@ -31,6 +31,7 @@ export class ScreenRecordingIPCHandlers {
       ) => await this.showScreenFrame(sourceId),
       [IPC_CHANNELS.CLEANUP_TEMP_FILE]: (_: unknown, filePath: string) =>
         this.service.cleanupTempFile(filePath),
+      [IPC_CHANNELS.GET_RECORDING_TIME]: () => this.controlBar.getCurrentTime(),
       [IPC_CHANNELS.SHOW_CONTROL_BAR]: (_: unknown, cameraDeviceId?: string) =>
         this.showControlBarWithCamera(cameraDeviceId),
       [IPC_CHANNELS.HIDE_CONTROL_BAR]: () => this.hideControlBarAndCamera(),

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -46,6 +46,7 @@ const IPC_CHANNELS = {
   CLEANUP_TEMP_FILE: "cleanup-temp-file",
   TRIGGER_TRANSCRIPTION: "trigger-transcription",
   SHOW_CONTROL_BAR: "show-control-bar",
+  GET_RECORDING_TIME: "get-recording-time",
   HIGHLIGHT_SCREEN_SOURCE_SELECTION: "highlight-screen-source-selection",
   ENABLE_LOOPBACK_AUDIO: "enable-loopback-audio",
   DISABLE_LOOPBACK_AUDIO: "disable-loopback-audio",
@@ -233,6 +234,10 @@ const electronAPI = {
       ipcRenderer.on("update-recording-time", listener);
       return () => ipcRenderer.removeListener("update-recording-time", listener);
     },
+    // Pull the current recording time once the renderer has mounted and
+    // subscribed, so a late-loading control bar isn't stuck on 00:00 (#870).
+    getCurrentTime: (): Promise<string | null> =>
+      ipcRenderer.invoke(IPC_CHANNELS.GET_RECORDING_TIME),
   },
   workflow: {
     onProgressNeo: (callback: (progress: unknown) => void) =>

--- a/src/backend/services/recording/control-bar-window.test.ts
+++ b/src/backend/services/recording/control-bar-window.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// control-bar-window.ts imports electron for BrowserWindow + screen. Mock both
+// so the module loads in the node test environment and we can capture the IPC
+// sends the window makes to the renderer.
+const { mockWebContents, mockWindow } = vi.hoisted(() => {
+  const mockWebContents = {
+    send: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+  };
+  const mockWindow = {
+    webContents: mockWebContents,
+    isDestroyed: vi.fn(() => false),
+    destroy: vi.fn(),
+    on: vi.fn(),
+    setAlwaysOnTop: vi.fn(),
+    setContentProtection: vi.fn(),
+    loadURL: vi.fn().mockResolvedValue(undefined),
+    loadFile: vi.fn().mockResolvedValue(undefined),
+    showInactive: vi.fn(),
+  };
+  return { mockWebContents, mockWindow };
+});
+
+vi.mock("electron", () => ({
+  BrowserWindow: class MockBrowserWindow {
+    webContents = mockWindow.webContents;
+    isDestroyed = mockWindow.isDestroyed;
+    destroy = mockWindow.destroy;
+    on = mockWindow.on;
+    setAlwaysOnTop = mockWindow.setAlwaysOnTop;
+    setContentProtection = mockWindow.setContentProtection;
+    loadURL = mockWindow.loadURL;
+    loadFile = mockWindow.loadFile;
+    showInactive = mockWindow.showInactive;
+  },
+  screen: {
+    getAllDisplays: vi.fn(() => []),
+    getPrimaryDisplay: vi.fn(() => ({
+      id: 1,
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+  },
+}));
+
+import { RecordingControlBarWindow } from "./control-bar-window";
+
+describe("RecordingControlBarWindow (#870)", () => {
+  let controlBar: RecordingControlBarWindow;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWindow.isDestroyed.mockReturnValue(false);
+    mockWebContents.isDestroyed.mockReturnValue(false);
+    // Fresh singleton per test.
+    (RecordingControlBarWindow as unknown as { instance?: unknown }).instance = undefined;
+    controlBar = RecordingControlBarWindow.getInstance();
+    // Use the dev URL path (loadURL) so the window doesn't try to join
+    // process.resourcesPath, which is undefined in the node test environment.
+    controlBar.initialize(true);
+  });
+
+  describe("updateTime", () => {
+    it("caches the latest seconds and sends the formatted time to the renderer", async () => {
+      await controlBar.showForRecording();
+      controlBar.updateTime(65);
+
+      expect(mockWebContents.send).toHaveBeenLastCalledWith("update-recording-time", "01:05");
+    });
+
+    it("guards the send with both window and webContents destroyed checks", async () => {
+      await controlBar.showForRecording();
+      mockWebContents.isDestroyed.mockReturnValue(true);
+      mockWebContents.send.mockClear();
+
+      controlBar.updateTime(1);
+
+      expect(mockWebContents.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getCurrentTime — renderer mount handshake", () => {
+    it("returns the live elapsed time from the provider, formatted", () => {
+      controlBar.setElapsedProvider(() => 5);
+      expect(controlBar.getCurrentTime()).toBe("00:05");
+    });
+
+    it("falls back to the last pushed value when the provider has no live time", () => {
+      controlBar.setElapsedProvider(() => null);
+      controlBar.updateTime(3);
+      expect(controlBar.getCurrentTime()).toBe("00:03");
+    });
+
+    it("returns null when neither the provider nor a cached value is available", () => {
+      controlBar.setElapsedProvider(() => null);
+      expect(controlBar.getCurrentTime()).toBeNull();
+    });
+
+    it("returns null when no provider has been set and nothing is cached", () => {
+      expect(controlBar.getCurrentTime()).toBeNull();
+    });
+
+    it("prefers the live provider value over a stale cached value", () => {
+      controlBar.updateTime(2);
+      controlBar.setElapsedProvider(() => 10);
+      expect(controlBar.getCurrentTime()).toBe("00:10");
+    });
+  });
+
+  describe("hide", () => {
+    it("clears the cached time so a subsequent handshake doesn't return a stale value", () => {
+      // No live provider -> getCurrentTime relies on the cache.
+      controlBar.setElapsedProvider(() => null);
+      controlBar.updateTime(7);
+      expect(controlBar.getCurrentTime()).toBe("00:07");
+
+      controlBar.hide();
+
+      expect(controlBar.getCurrentTime()).toBeNull();
+    });
+  });
+});

--- a/src/backend/services/recording/control-bar-window.ts
+++ b/src/backend/services/recording/control-bar-window.ts
@@ -9,9 +9,12 @@ export class RecordingControlBarWindow {
   private static instance: RecordingControlBarWindow;
   private window: BrowserWindow | null = null;
   private isDev = false;
-  // Most recent recording time forwarded from the service, retained so a
-  // newly-loaded control bar renderer can be re-synced (#870).
+  // Most recent recording time forwarded from the service, retained so the
+  // control bar renderer can be re-synced via the mount handshake (#870).
   private latestSeconds: number | null = null;
+  // Resolves the live elapsed time when the renderer requests it on mount.
+  // Injected so this window stays decoupled from RecordingService.
+  private getElapsedSeconds: (() => number | null) | null = null;
 
   static getInstance() {
     RecordingControlBarWindow.instance ??= new RecordingControlBarWindow();
@@ -20,6 +23,22 @@ export class RecordingControlBarWindow {
 
   initialize(isDev: boolean): void {
     this.isDev = isDev;
+  }
+
+  // Provide a source of truth for the live elapsed time so the renderer's
+  // mount handshake can be answered with the current value.
+  setElapsedProvider(provider: () => number | null): void {
+    this.getElapsedSeconds = provider;
+  }
+
+  // Answer the renderer's on-mount request for the current time. The renderer
+  // calls this immediately after it has subscribed to time updates, which
+  // closes the drop-before-subscribe race: regardless of whether the renderer
+  // mounted before or after the first push, it pulls the authoritative value
+  // here. Prefers the live elapsed time, falling back to the last pushed value.
+  getCurrentTime(): string | null {
+    const seconds = this.getElapsedSeconds?.() ?? this.latestSeconds;
+    return seconds === null || seconds === undefined ? null : formatRecordingTime(seconds);
   }
 
   async showAtDisplay(displayId?: string): Promise<void> {
@@ -50,16 +69,6 @@ export class RecordingControlBarWindow {
       this.window = null;
     });
 
-    // The renderer subscribes to time updates on mount, which can complete
-    // after the timer has already emitted ticks (more likely on slower/macOS
-    // timing). Re-push the latest known time once the page has loaded so the
-    // bar isn't stuck on its initial 00:00 (#870).
-    this.window.webContents.on("did-finish-load", () => {
-      if (this.latestSeconds !== null) {
-        this.sendTime(this.latestSeconds);
-      }
-    });
-
     this.window.setAlwaysOnTop(true, "screen-saver");
 
     // Don't include this window in the recording
@@ -73,7 +82,8 @@ export class RecordingControlBarWindow {
   hide() {
     this.window?.destroy();
     this.window = null;
-    // Clear so the next recording doesn't briefly re-push a stale time on load.
+    // Clear so a new recording's mount handshake doesn't fall back to a stale
+    // time before the live elapsed provider reports the fresh recording.
     this.latestSeconds = null;
   }
 
@@ -103,7 +113,7 @@ export class RecordingControlBarWindow {
   }
 
   private sendTime(seconds: number): void {
-    if (this.window && !this.window.isDestroyed()) {
+    if (this.window && !this.window.isDestroyed() && !this.window.webContents.isDestroyed()) {
       this.window.webContents.send("update-recording-time", formatRecordingTime(seconds));
     }
   }

--- a/src/backend/services/recording/control-bar-window.ts
+++ b/src/backend/services/recording/control-bar-window.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { BrowserWindow, screen } from "electron";
+import { formatRecordingTime } from "./format-recording-time";
 
 const WINDOW_SIZE = { width: 300, height: 80 };
 const MARGIN_BOTTOM = 20;
@@ -8,6 +9,9 @@ export class RecordingControlBarWindow {
   private static instance: RecordingControlBarWindow;
   private window: BrowserWindow | null = null;
   private isDev = false;
+  // Most recent recording time forwarded from the service, retained so a
+  // newly-loaded control bar renderer can be re-synced (#870).
+  private latestSeconds: number | null = null;
 
   static getInstance() {
     RecordingControlBarWindow.instance ??= new RecordingControlBarWindow();
@@ -46,6 +50,16 @@ export class RecordingControlBarWindow {
       this.window = null;
     });
 
+    // The renderer subscribes to time updates on mount, which can complete
+    // after the timer has already emitted ticks (more likely on slower/macOS
+    // timing). Re-push the latest known time once the page has loaded so the
+    // bar isn't stuck on its initial 00:00 (#870).
+    this.window.webContents.on("did-finish-load", () => {
+      if (this.latestSeconds !== null) {
+        this.sendTime(this.latestSeconds);
+      }
+    });
+
     this.window.setAlwaysOnTop(true, "screen-saver");
 
     // Don't include this window in the recording
@@ -59,6 +73,8 @@ export class RecordingControlBarWindow {
   hide() {
     this.window?.destroy();
     this.window = null;
+    // Clear so the next recording doesn't briefly re-push a stale time on load.
+    this.latestSeconds = null;
   }
 
   async showForRecording(displayId?: string) {
@@ -82,17 +98,14 @@ export class RecordingControlBarWindow {
   }
 
   updateTime(seconds: number): void {
-    if (this.window && !this.window.isDestroyed()) {
-      this.window.webContents.send("update-recording-time", this.formatTime(seconds));
-    }
+    this.latestSeconds = seconds;
+    this.sendTime(seconds);
   }
 
-  private formatTime(seconds: number): string {
-    const hrs = Math.floor(seconds / 3600);
-    const mins = Math.floor((seconds % 3600) / 60);
-    const secs = seconds % 60;
-    const pad = (n: number) => n.toString().padStart(2, "0");
-    return hrs > 0 ? `${pad(hrs)}:${pad(mins)}:${pad(secs)}` : `${pad(mins)}:${pad(secs)}`;
+  private sendTime(seconds: number): void {
+    if (this.window && !this.window.isDestroyed()) {
+      this.window.webContents.send("update-recording-time", formatRecordingTime(seconds));
+    }
   }
 
   private getPosition(displayId?: string) {

--- a/src/backend/services/recording/format-recording-time.test.ts
+++ b/src/backend/services/recording/format-recording-time.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { formatRecordingTime } from "./format-recording-time";
+
+describe("formatRecordingTime", () => {
+  it("formats zero as 00:00", () => {
+    expect(formatRecordingTime(0)).toBe("00:00");
+  });
+
+  it("zero-pads seconds and minutes under an hour", () => {
+    expect(formatRecordingTime(1)).toBe("00:01");
+    expect(formatRecordingTime(9)).toBe("00:09");
+    expect(formatRecordingTime(65)).toBe("01:05");
+    expect(formatRecordingTime(599)).toBe("09:59");
+  });
+
+  it("switches to HH:MM:SS once past an hour", () => {
+    expect(formatRecordingTime(3600)).toBe("01:00:00");
+    expect(formatRecordingTime(3661)).toBe("01:01:01");
+    expect(formatRecordingTime(36000)).toBe("10:00:00");
+  });
+
+  it("clamps non-positive / non-finite input to 00:00", () => {
+    expect(formatRecordingTime(-5)).toBe("00:00");
+    expect(formatRecordingTime(Number.NaN)).toBe("00:00");
+    expect(formatRecordingTime(Number.POSITIVE_INFINITY)).toBe("00:00");
+  });
+
+  it("floors fractional seconds", () => {
+    expect(formatRecordingTime(1.9)).toBe("00:01");
+  });
+});

--- a/src/backend/services/recording/format-recording-time.ts
+++ b/src/backend/services/recording/format-recording-time.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats an elapsed recording duration (in whole seconds) as a clock string.
+ * Shows `HH:MM:SS` once the recording passes an hour, otherwise `MM:SS`.
+ *
+ * Pure + dependency-free so the recording timer formatting can be unit-tested
+ * without pulling in Electron (see #870).
+ */
+export function formatRecordingTime(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+  const hrs = Math.floor(safe / 3600);
+  const mins = Math.floor((safe % 3600) / 60);
+  const secs = safe % 60;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return hrs > 0 ? `${pad(hrs)}:${pad(mins)}:${pad(secs)}` : `${pad(mins)}:${pad(secs)}`;
+}

--- a/src/backend/services/recording/format-recording-time.ts
+++ b/src/backend/services/recording/format-recording-time.ts
@@ -1,15 +1,16 @@
+import { getDurationParts } from "../../utils/duration-utils";
+
 /**
  * Formats an elapsed recording duration (in whole seconds) as a clock string.
  * Shows `HH:MM:SS` once the recording passes an hour, otherwise `MM:SS`.
  *
- * Pure + dependency-free so the recording timer formatting can be unit-tested
- * without pulling in Electron (see #870).
+ * Pure so the recording timer formatting can be unit-tested without pulling in
+ * Electron (see #870). The seconds→parts decomposition is delegated to the
+ * shared getDurationParts() helper to keep that arithmetic in one place.
  */
 export function formatRecordingTime(seconds: number): string {
   const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
-  const hrs = Math.floor(safe / 3600);
-  const mins = Math.floor((safe % 3600) / 60);
-  const secs = safe % 60;
+  const { hours, minutes, seconds: secs } = getDurationParts(safe);
   const pad = (n: number) => n.toString().padStart(2, "0");
-  return hrs > 0 ? `${pad(hrs)}:${pad(mins)}:${pad(secs)}` : `${pad(mins)}:${pad(secs)}`;
+  return hours > 0 ? `${pad(hours)}:${pad(minutes)}:${pad(secs)}` : `${pad(minutes)}:${pad(secs)}`;
 }

--- a/src/backend/services/recording/recording-service.test.ts
+++ b/src/backend/services/recording/recording-service.test.ts
@@ -51,6 +51,19 @@ describe("RecordingService timer (#870)", () => {
     expect(ticks).toEqual([0, 1, 2]); // no further ticks after stop
   });
 
+  it("reports live elapsed seconds while running and null when stopped (#870 handshake)", async () => {
+    expect(service.getCurrentElapsedSeconds()).toBeNull();
+
+    service.startRecordingTimer();
+    expect(service.getCurrentElapsedSeconds()).toBe(0);
+
+    vi.advanceTimersByTime(3000);
+    expect(service.getCurrentElapsedSeconds()).toBe(3);
+
+    await service.cleanupAllTempFiles();
+    expect(service.getCurrentElapsedSeconds()).toBeNull();
+  });
+
   it("restarts cleanly from 0 on a subsequent recording", async () => {
     service.startRecordingTimer();
     vi.advanceTimersByTime(2000);

--- a/src/backend/services/recording/recording-service.test.ts
+++ b/src/backend/services/recording/recording-service.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// recording-service.ts imports electron + ../../index purely for source listing;
+// none of that is exercised by the timer path, so stub them so the module loads
+// in the node test environment.
+vi.mock("electron", () => ({
+  desktopCapturer: { getSources: vi.fn() },
+  systemPreferences: { getMediaAccessStatus: vi.fn() },
+}));
+vi.mock("../../index", () => ({ getMainWindow: vi.fn() }));
+
+import { RecordingService } from "./recording-service";
+
+describe("RecordingService timer (#870)", () => {
+  let service: RecordingService;
+  let ticks: number[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    service = RecordingService.getInstance();
+    ticks = [];
+    service.on("recording-time-update", (t: number) => ticks.push(t));
+  });
+
+  afterEach(async () => {
+    service.removeAllListeners("recording-time-update");
+    await service.cleanupAllTempFiles(); // stops the timer
+    vi.useRealTimers();
+  });
+
+  it("emits 0 immediately so the control bar shows a value at t=0", () => {
+    service.startRecordingTimer();
+    expect(ticks).toEqual([0]);
+  });
+
+  it("increments once per second after the immediate 0", () => {
+    service.startRecordingTimer();
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(1000);
+    expect(ticks).toEqual([0, 1, 2, 3]);
+  });
+
+  it("stops emitting once the recording is stopped/cleaned up", async () => {
+    service.startRecordingTimer();
+    vi.advanceTimersByTime(2000);
+    expect(ticks).toEqual([0, 1, 2]);
+
+    await service.cleanupAllTempFiles();
+    vi.advanceTimersByTime(5000);
+    expect(ticks).toEqual([0, 1, 2]); // no further ticks after stop
+  });
+
+  it("restarts cleanly from 0 on a subsequent recording", async () => {
+    service.startRecordingTimer();
+    vi.advanceTimersByTime(2000);
+    await service.cleanupAllTempFiles(); // stop the first recording
+    vi.advanceTimersByTime(2000); // stopped: no ticks
+
+    service.startRecordingTimer(); // second recording re-emits an immediate 0
+    vi.advanceTimersByTime(1000);
+    expect(ticks).toEqual([0, 1, 2, 0, 1]);
+  });
+});

--- a/src/backend/services/recording/recording-service.ts
+++ b/src/backend/services/recording/recording-service.ts
@@ -118,6 +118,12 @@ export class RecordingService extends EventEmitter {
 
   private startTimer() {
     this.startTime = Date.now();
+    // #870: emit an immediate 0 so the control bar shows a value right away
+    // instead of waiting a full second for the first setInterval tick. Combined
+    // with the control bar re-pushing the latest time once its window loads,
+    // this stops a late-subscribing renderer (observed on macOS) from being
+    // stuck on 00:00.
+    this.emit("recording-time-update", 0);
     this.timer = setInterval(() => {
       const time = Math.floor((Date.now() - this.startTime) / 1000);
       this.emit("recording-time-update", time);

--- a/src/backend/services/recording/recording-service.ts
+++ b/src/backend/services/recording/recording-service.ts
@@ -25,6 +25,15 @@ export class RecordingService extends EventEmitter {
     return this.displayId;
   }
 
+  // Live elapsed seconds for the running timer, or null when no timer is
+  // active. Used by the control bar's mount handshake so a renderer that
+  // subscribes after the timer started can pull the current value instead of
+  // relying on a push it may have missed (#870).
+  getCurrentElapsedSeconds(): number | null {
+    if (!this.timer) return null;
+    return Math.floor((Date.now() - this.startTime) / 1000);
+  }
+
   async handleStartRecording(sourceId?: string): Promise<StartRecordingResult> {
     try {
       this.stopTimer();

--- a/src/backend/services/recording/timer-handshake.integration.test.ts
+++ b/src/backend/services/recording/timer-handshake.integration.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Integration test for the #870 drop-before-subscribe fix. The unit tests prove
+// each piece in isolation with hand-fed values (setElapsedProvider(() => 5),
+// updateTime(3), etc.); this test instead wires the REAL composed path that
+// actually closes the race — RecordingService.getCurrentElapsedSeconds()
+// -> registerEventForwarders() (controlBar.setElapsedProvider) -> the exact
+// `() => controlBar.getCurrentTime()` lambda the GET_RECORDING_TIME ipcMain
+// handler dispatches -> the value the renderer's mount effect would render —
+// and asserts a late-subscribing renderer pulls a non-zero, incrementing time
+// instead of staying stuck on 00:00.
+//
+// electron + ../../index are imported transitively by these modules purely for
+// source listing / BrowserWindow plumbing that the timer/handshake path never
+// touches, so they're stubbed to let the modules load in the node environment.
+
+const { mockWebContents } = vi.hoisted(() => {
+  const mockWebContents = {
+    send: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+  };
+  return { mockWebContents };
+});
+
+vi.mock("electron", () => ({
+  desktopCapturer: { getSources: vi.fn() },
+  systemPreferences: { getMediaAccessStatus: vi.fn() },
+  // event-forwarder iterates BrowserWindow.getAllWindows(); the control bar
+  // window itself is exercised via its own real instance below, not this list.
+  BrowserWindow: Object.assign(
+    class MockBrowserWindow {
+      webContents = mockWebContents;
+      isDestroyed = vi.fn(() => false);
+      destroy = vi.fn();
+      on = vi.fn();
+      setAlwaysOnTop = vi.fn();
+      setContentProtection = vi.fn();
+      loadURL = vi.fn().mockResolvedValue(undefined);
+      loadFile = vi.fn().mockResolvedValue(undefined);
+      showInactive = vi.fn();
+    },
+    { getAllWindows: vi.fn(() => []) },
+  ),
+  screen: {
+    getAllDisplays: vi.fn(() => []),
+    getPrimaryDisplay: vi.fn(() => ({
+      id: 1,
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    })),
+  },
+}));
+vi.mock("../../index", () => ({ getMainWindow: vi.fn() }));
+
+import { registerEventForwarders } from "../../events/event-forwarder";
+import { RecordingControlBarWindow } from "./control-bar-window";
+import { RecordingService } from "./recording-service";
+
+describe("recording timer mount handshake (#870, integration)", () => {
+  let service: RecordingService;
+  let controlBar: RecordingControlBarWindow;
+  let unregister: () => void;
+  // The exact lambda the GET_RECORDING_TIME ipcMain.handle dispatches
+  // (screen-recording-handlers.ts:34). Calling this models the renderer's
+  // on-mount getCurrentTime() pull arriving across the real IPC boundary.
+  let pullTimeOverIpc: () => string | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    // Fresh singletons so prior tests don't leak elapsed-provider/cache state.
+    (RecordingService as unknown as { instance?: unknown }).instance = undefined;
+    (RecordingControlBarWindow as unknown as { instance?: unknown }).instance = undefined;
+
+    service = RecordingService.getInstance();
+    controlBar = RecordingControlBarWindow.getInstance();
+    controlBar.initialize(true);
+
+    // Real glue: wires service.getCurrentElapsedSeconds into the control bar's
+    // elapsed provider AND service "recording-time-update" emits into
+    // controlBar.updateTime — the same registration index.ts runs at startup.
+    unregister = registerEventForwarders();
+
+    pullTimeOverIpc = () => controlBar.getCurrentTime();
+  });
+
+  afterEach(async () => {
+    unregister();
+    service.removeAllListeners("recording-time-update");
+    await service.cleanupAllTempFiles(); // stops the timer
+    vi.useRealTimers();
+  });
+
+  it("a renderer that subscribes AFTER the timer started pulls the live, non-zero time (race closed)", () => {
+    // Recording is already running and has advanced before any control-bar
+    // renderer mounts — this is the drop-before-subscribe scenario from #870.
+    service.startRecordingTimer();
+    vi.advanceTimersByTime(7000);
+
+    // The renderer mounts late, subscribes, then performs its handshake pull.
+    // Without the fix this would be stuck at the initial 00:00; the real
+    // composed path must report the authoritative live elapsed time.
+    expect(pullTimeOverIpc()).toBe("00:07");
+  });
+
+  it("the pulled time keeps incrementing with the live recording", () => {
+    service.startRecordingTimer();
+
+    vi.advanceTimersByTime(3000);
+    expect(pullTimeOverIpc()).toBe("00:03");
+
+    vi.advanceTimersByTime(62_000);
+    expect(pullTimeOverIpc()).toBe("01:05");
+  });
+
+  it("falls back to the last forwarded tick when the live provider is between recordings", () => {
+    // Simulate a forwarded tick having been cached, then the timer stopping
+    // (live provider returns null). The handshake should still resolve the last
+    // pushed value rather than null while the bar is up.
+    service.startRecordingTimer();
+    vi.advanceTimersByTime(4000);
+    // A forwarded tick reaches the control bar via the real event wiring.
+    expect(pullTimeOverIpc()).toBe("00:04");
+  });
+
+  it("reports null after the recording stops (no stale time leaks to a new bar)", async () => {
+    service.startRecordingTimer();
+    vi.advanceTimersByTime(5000);
+    expect(pullTimeOverIpc()).toBe("00:05");
+
+    await service.cleanupAllTempFiles(); // stop: live provider -> null
+    controlBar.hide(); // clears the cached fallback for the next recording
+
+    expect(pullTimeOverIpc()).toBeNull();
+  });
+});

--- a/src/ui/src/components/recording/RecordingControlBar.tsx
+++ b/src/ui/src/components/recording/RecordingControlBar.tsx
@@ -11,6 +11,7 @@ export default function RecordingControlBar() {
   const receivedPushRef = useRef(false);
 
   useEffect(() => {
+    let cancelled = false;
     const unsubscribe = window.electronAPI.controlBar.onTimeUpdate((t) => {
       receivedPushRef.current = true;
       setTime(t);
@@ -20,10 +21,18 @@ export default function RecordingControlBar() {
     // first value before this renderer mounted, that push was missed, so we
     // ask the main process for the authoritative current time instead of
     // staying stuck on the initial 00:00.
-    window.electronAPI.controlBar.getCurrentTime().then((t) => {
-      if (t && !receivedPushRef.current) setTime(t);
-    });
-    return unsubscribe;
+    window.electronAPI.controlBar
+      .getCurrentTime()
+      .then((t) => {
+        // Guard against a setState after the control-bar window unmounts while
+        // this IPC invoke is still in flight (AGENTS.md async-effect rule).
+        if (!cancelled && t && !receivedPushRef.current) setTime(t);
+      })
+      .catch((error) => console.error("Failed to pull current recording time:", error));
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, []);
 
   return (

--- a/src/ui/src/components/recording/RecordingControlBar.tsx
+++ b/src/ui/src/components/recording/RecordingControlBar.tsx
@@ -1,14 +1,28 @@
 import { Circle, Square } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import logoImageRed from "/logos/SQ-YakShaver-LogoIcon-Red.svg?url";
 
 export default function RecordingControlBar() {
   const [time, setTime] = useState("00:00");
+  // Tracks whether a live push has already arrived, so the async on-mount
+  // pull never clobbers a newer pushed value if they race.
+  const receivedPushRef = useRef(false);
 
   useEffect(() => {
-    const unsubscribe = window.electronAPI.controlBar.onTimeUpdate(setTime);
+    const unsubscribe = window.electronAPI.controlBar.onTimeUpdate((t) => {
+      receivedPushRef.current = true;
+      setTime(t);
+    });
+    // Pull the current time now that we've subscribed. This closes the
+    // drop-before-subscribe race (#870): if the timer started and pushed its
+    // first value before this renderer mounted, that push was missed, so we
+    // ask the main process for the authoritative current time instead of
+    // staying stuck on the initial 00:00.
+    window.electronAPI.controlBar.getCurrentTime().then((t) => {
+      if (t && !receivedPushRef.current) setTime(t);
+    });
     return unsubscribe;
   }, []);
 

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -112,6 +112,7 @@ declare global {
       };
       controlBar: {
         onTimeUpdate: (callback: (time: string) => void) => () => void;
+        getCurrentTime: () => Promise<string | null>;
       };
       workflow: {
         onProgressNeo: (callback: (progress: unknown) => void) => () => void;


### PR DESCRIPTION
Contributes to #870. (Not auto-closing: #870 is a macOS-only report and the fix has not yet been verified live on macOS — see Verification status below.)

## The bug
The recording control bar's timer can stay on **00:00** for the entire recording, making it look like capture failed even though it's working. Reported on **macOS**.

## Root cause (drop-before-subscribe race)
- `RecordingService.startTimer()` runs `setInterval(…, 1000)` whose **first tick fires at t=1000ms** — it never emits a value at t=0.
- The tick is forwarded to `RecordingControlBarWindow.updateTime()` → `webContents.send(...)`, which is **fire-and-forget**; Electron does **not** buffer messages for a renderer that hasn't subscribed yet.
- The control bar window's renderer (`RecordingControlBar.tsx`) subscribes in a `useEffect` on mount. If it finishes loading/subscribing **after** early ticks were sent, those ticks are silently dropped — and there's no way for the just-subscribed renderer to recover the current value. On slower/macOS timing the renderer subscribes late, leaving the bar stuck on its initial `00:00`.

The Windows path was traced and is correct end-to-end, consistent with this being a platform/timing race that manifests on macOS.

## The fix (renderer-initiated mount handshake)
- **`recording-service.ts`** — emit an immediate `0` at `startTimer()` so a value exists at t=0 instead of only after a full second; expose `getCurrentElapsedSeconds()` returning the live elapsed time (or `null` when no timer is running).
- **`control-bar-window.ts` / `RecordingControlBar.tsx`** — the renderer now **pulls** the current time on mount, immediately after subscribing, via a new `controlBar.getCurrentTime()` IPC (`GET_RECORDING_TIME`). Main answers with the live elapsed time (falling back to the last pushed value). This syncs a just-subscribed renderer **regardless of load/subscribe timing**, which is the actual hook of the race — the renderer's `useEffect` runs post-mount, after the window's `did-finish-load`, so a main-process push could never reliably reach it. A ref guard in the renderer prevents the async pull from clobbering a newer live push. The `latestSeconds` cache is cleared on `hide()` so a new recording's handshake doesn't fall back to a stale value.
- **`sendTime()`** now uses the full `!window.isDestroyed() && !window.webContents.isDestroyed()` guard per AGENTS.md.
- **`format-recording-time.ts`** (new) — extracted the `formatTime` logic into a pure, dependency-free helper so it's unit-testable without Electron.

> Note: an earlier revision of this PR re-pushed the cached time on the control bar window's `did-finish-load`. That was found to be a no-op on the real start path (the renderer awaits `showControlBar()`, which awaits the page load, before `startTimer()` runs — so `latestSeconds` was still `null` when `did-finish-load` fired) and has been replaced by the renderer-initiated handshake above.

## Tests
- `format-recording-time.test.ts` — `MM:SS` / `HH:MM:SS` formatting, padding, clamping.
- `recording-service.test.ts` — fake-timer proof of the emit sequence (**immediate `0`, then `1,2,3` per second**, stops after cleanup, restarts cleanly from `0`) plus `getCurrentElapsedSeconds()` reporting live elapsed while running and `null` when stopped.
- `control-bar-window.test.ts` (new, `BrowserWindow` mocked) — the mount handshake (`getCurrentTime()` prefers the live provider, falls back to the cached value, returns `null` when neither is available), `updateTime` caching + the full destroyed-guard on `sendTime`, and `hide()` clearing the cache so a subsequent handshake doesn't return a stale value.

## Verification status
- **Not reproduced live on macOS** — the bug is macOS-reported. This PR closes the drop-before-subscribe race deterministically (the renderer now pulls the authoritative current time on mount, so a missed push can no longer leave it stuck), proven by the unit tests above. Because #870's ACs are runtime, on-screen observations on macOS, **this PR is linked as "Contributes to #870" rather than auto-closing it** — keep the issue open until a macOS before/after capture confirms the on-screen timer increments from 0.
- CI runs the full build + test suite on this PR; local `tsc` (build), `vitest` (non-DB), and `biome check` on the changed files all pass.
