### PR TITLE
XS⚠️ ◾ Fix #876: 44px min touch targets in Settings (scoped, no app-wide change)

### DIFF
--- a/src/ui/src/App.css
+++ b/src/ui/src/App.css
@@ -178,16 +178,3 @@
 .animate-tick-pop {
   animation: tick-pop 0.4s ease-out forwards;
 }
-
-/* #876: 44px minimum touch targets inside the Settings dialog (WCAG 2.5.5).
-   Scoped to `.settings-44` so it does NOT enlarge buttons/inputs app-wide.
-   Buttons and text inputs share one min height so they align; compact
-   toggle switches keep their size. */
-.settings-44 button:not([role="switch"]),
-.settings-44 select,
-.settings-44 input:not([type="checkbox"]):not([type="radio"]) {
-  min-height: 44px;
-}
-.settings-44 button:not([role="switch"]) {
-  min-width: 44px;
-}

--- a/src/ui/src/App.css
+++ b/src/ui/src/App.css
@@ -178,3 +178,16 @@
 .animate-tick-pop {
   animation: tick-pop 0.4s ease-out forwards;
 }
+
+/* #876: 44px minimum touch targets inside the Settings dialog (WCAG 2.5.5).
+   Scoped to `.settings-44` so it does NOT enlarge buttons/inputs app-wide.
+   Buttons and text inputs share one min height so they align; compact
+   toggle switches keep their size. */
+.settings-44 button:not([role="switch"]),
+.settings-44 select,
+.settings-44 input:not([type="checkbox"]):not([type="radio"]) {
+  min-height: 44px;
+}
+.settings-44 button:not([role="switch"]) {
+  min-width: 44px;
+}

--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -161,7 +161,7 @@ export function SettingsDialog() {
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="w-[min(800px,72vw)] max-w-none sm:max-w-none h-[85vh] overflow-hidden flex flex-col [&_button:not([role=switch])]:min-h-11 [&_button:not([role=switch])]:min-w-11 [&_input:not([type=checkbox]):not([type=radio])]:min-h-11 [&_select]:min-h-11">
+      <DialogContent className="w-[min(800px,72vw)] max-w-none sm:max-w-none h-[85vh] overflow-hidden flex flex-col [&_:is(button:not([role=switch]),select,input:not([type=checkbox]):not([type=radio]))]:min-h-11 [&_button:not([role=switch])]:min-w-11">
         <DialogHeader className="mb-2 flex-shrink-0">
           <DialogTitle className="text-2xl font-semibold flex items-center gap-2">
             <Settings className="h-5 w-5" />

--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -161,7 +161,7 @@ export function SettingsDialog() {
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="settings-44 w-[min(800px,72vw)] max-w-none sm:max-w-none h-[85vh] overflow-hidden flex flex-col">
+      <DialogContent className="w-[min(800px,72vw)] max-w-none sm:max-w-none h-[85vh] overflow-hidden flex flex-col [&_button:not([role=switch])]:min-h-11 [&_button:not([role=switch])]:min-w-11 [&_input:not([type=checkbox]):not([type=radio])]:min-h-11 [&_select]:min-h-11">
         <DialogHeader className="mb-2 flex-shrink-0">
           <DialogTitle className="text-2xl font-semibold flex items-center gap-2">
             <Settings className="h-5 w-5" />

--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -161,7 +161,7 @@ export function SettingsDialog() {
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="w-[min(800px,72vw)] max-w-none sm:max-w-none h-[85vh] overflow-hidden flex flex-col">
+      <DialogContent className="settings-44 w-[min(800px,72vw)] max-w-none sm:max-w-none h-[85vh] overflow-hidden flex flex-col">
         <DialogHeader className="mb-2 flex-shrink-0">
           <DialogTitle className="text-2xl font-semibold flex items-center gap-2">
             <Settings className="h-5 w-5" />


### PR DESCRIPTION
Closes #876. Part of #872 (Settings UX).

## Problem
Interactive controls in the Settings dialog were below the 44px WCAG 2.5.5 minimum touch-target size: `Button` sizes are `sm` 32px / `default` 36px / `lg` 40px / `icon` 36px, and `Input` is 36px. Settings uses **37 buttons + 12 inputs**, mostly `size="sm"`.

## Approach — scoped, not app-wide
The shared `Button`/`Input` are used across the entire app, so bumping their default heights would enlarge every button/toolbar everywhere (big unintended visual change + regression risk). Editing all 49 call sites would be a large, non-reusable diff.

Instead: a **single scoped CSS rule** + **one wrapper class** on the Settings `DialogContent`:
- `.settings-44 button:not([role="switch"]), select, input(text)` → `min-height: 44px`
- `.settings-44 button:not([role="switch"])` → `min-width: 44px`

This makes every interactive control inside Settings meet 44px and gives buttons + text inputs **one shared min height so they align** — reusable for any settings page, with **zero change to controls elsewhere in the app**. Compact toggle switches (`role="switch"`) are excluded so they keep their pill size.

## ACs
- ✅ ≥44px min target for Settings controls
- ✅ Buttons + inputs share a consistent height / align
- ✅ Reusable at the shared level (one class + rule), not patched per-instance
- ✅ No app-wide button change (scoped to `.settings-44`)

## Verification
Biome clean; build/vitest via CI. **Not yet live-verified in the running app** — the dev app renders from the main tree (a different branch), so a clean live drive wasn't possible from the isolated worktree. The change is a scoped CSS `min-height/width` with flex-centered content (low regression risk); a reviewer/maintainer running this branch should eyeball dense rows (e.g. MCP cards, LLM key rows) to confirm no layout breakage.
