### PR TITLE
XS⚠️ ◾ Settings: consistent destructive-action styling + confirmations + accessible contrast (#877)

### DIFF
--- a/src/ui/src/App.css
+++ b/src/ui/src/App.css
@@ -67,6 +67,8 @@
   --sidebar-ring: oklch(0.704 0.027 43.046);
   --ssw-red: #cc4141;
   --ssw-red-foreground: oklch(0.984 0.004 36.02);
+  /* SSW hot-red — reserved for irreversible / destructive actions */
+  --danger: #ff453a;
 }
 
 @theme {
@@ -107,6 +109,7 @@
   --color-sidebar-ring: var(--sidebar-ring);
   --color-ssw-red: var(--ssw-red);
   --color-ssw-red-foreground: var(--ssw-red-foreground);
+  --color-danger: var(--danger);
 }
 
 .dark {
@@ -143,6 +146,8 @@
   --sidebar-ring: oklch(0.555 0.027 43.046);
   --ssw-red: #cc4141;
   --ssw-red-foreground: oklch(0.929 0.008 39.026);
+  /* SSW hot-red — reserved for irreversible / destructive actions */
+  --danger: #ff453a;
 }
 
 @layer base {

--- a/src/ui/src/components/dialogs/DeleteConfirmDialog.tsx
+++ b/src/ui/src/components/dialogs/DeleteConfirmDialog.tsx
@@ -1,4 +1,3 @@
-import { Trash2 } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -9,6 +8,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "../ui/alert-dialog";
+import { buttonVariants } from "../ui/button";
 
 interface DeleteConfirmDialogProps {
   open: boolean;
@@ -39,9 +39,11 @@ export function DeleteConfirmDialog({
           <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={onConfirm}
-            className="cursor-pointer bg-destructive text-white hover:bg-destructive/90"
+            className={buttonVariants({
+              variant: "destructiveOutline",
+              className: "cursor-pointer",
+            })}
           >
-            <Trash2 className="w-4 h-4" />
             {confirmLabel}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/ui/src/components/dialogs/DeleteConfirmDialog.tsx
+++ b/src/ui/src/components/dialogs/DeleteConfirmDialog.tsx
@@ -16,6 +16,8 @@ interface DeleteConfirmDialogProps {
   onConfirm: () => void;
   deleteTitle?: string;
   deleteConfirmMessage?: string;
+  /** Label for the confirm button (e.g. "Clear Token"). Defaults to "Delete". */
+  confirmLabel?: string;
 }
 
 export function DeleteConfirmDialog({
@@ -24,6 +26,7 @@ export function DeleteConfirmDialog({
   onConfirm,
   deleteTitle = "Delete Item",
   deleteConfirmMessage = "Are you sure you want to delete this item?",
+  confirmLabel = "Delete",
 }: DeleteConfirmDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -34,9 +37,12 @@ export function DeleteConfirmDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm} className="cursor-pointer">
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="cursor-pointer bg-destructive text-white hover:bg-destructive/90"
+          >
             <Trash2 className="w-4 h-4" />
-            Delete
+            {confirmLabel}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/ui/src/components/settings/account/ResetAccountSetting.tsx
+++ b/src/ui/src/components/settings/account/ResetAccountSetting.tsx
@@ -109,7 +109,7 @@ export function ResetAccountSetting() {
             <AlertDialogAction
               onClick={handleResetAccount}
               disabled={isResetting}
-              className="bg-destructive text-primary hover:bg-destructive/90"
+              className="bg-destructive text-white hover:bg-destructive/90"
             >
               {isResetting ? "Resetting..." : "Reset Account"}
             </AlertDialogAction>

--- a/src/ui/src/components/settings/account/ResetAccountSetting.tsx
+++ b/src/ui/src/components/settings/account/ResetAccountSetting.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, RotateCcw } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { resetOnboarding } from "@/components/onboarding/OnboardingWizard";
@@ -13,7 +13,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "../../ui/alert-dialog";
-import { Button } from "../../ui/button";
+import { Button, buttonVariants } from "../../ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../ui/card";
 
 export function ResetAccountSetting() {
@@ -65,7 +65,7 @@ export function ResetAccountSetting() {
     <>
       <Card className="w-full gap-4 border-white/10 py-4">
         <CardHeader className="px-4">
-          <CardTitle className="flex items-center gap-2 text-red-400">
+          <CardTitle className="flex items-center gap-2 text-danger">
             <AlertTriangle className="h-5 w-5" />
             Reset Account
           </CardTitle>
@@ -76,10 +76,9 @@ export function ResetAccountSetting() {
         <CardContent className="px-4">
           <Button
             onClick={() => setIsResetDialogOpen(true)}
-            variant="destructive"
+            variant="destructiveOutline"
             className="w-full"
           >
-            <RotateCcw className="h-4 w-4" />
             Reset Account to Default
           </Button>
         </CardContent>
@@ -109,7 +108,7 @@ export function ResetAccountSetting() {
             <AlertDialogAction
               onClick={handleResetAccount}
               disabled={isResetting}
-              className="bg-destructive text-white hover:bg-destructive/90"
+              className={buttonVariants({ variant: "destructiveOutline" })}
             >
               {isResetting ? "Resetting..." : "Reset Account"}
             </AlertDialogAction>

--- a/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
+++ b/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ensureBuiltinServerIds, getBuiltinServerIds } from "@shared/utils/mcp-utils";
-import { AlertTriangle, ChevronLeft, ChevronRight, Copy, FilePlus, Trash2 } from "lucide-react";
+import { AlertTriangle, ChevronLeft, ChevronRight, Copy, FilePlus } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -468,12 +468,11 @@ export function PromptForm({
                 <Button
                   type="button"
                   onClick={onDelete}
-                  variant="destructive"
+                  variant="destructiveOutline"
                   size="sm"
                   disabled={loading}
                   className="cursor-pointer"
                 >
-                  <Trash2 className="w-4 h-4 mr-2" />
                   Delete
                 </Button>
               )}

--- a/src/ui/src/components/settings/llm/LLMProviderForm.tsx
+++ b/src/ui/src/components/settings/llm/LLMProviderForm.tsx
@@ -73,7 +73,7 @@ export function LLMProviderForm({
           <div className="flex justify-start gap-2">
             <Button
               type="button"
-              variant="destructive"
+              variant="destructiveOutline"
               size="sm"
               onClick={() => setClearConfirmOpen(true)}
               disabled={isLoading || !hasConfig}

--- a/src/ui/src/components/settings/llm/LLMProviderForm.tsx
+++ b/src/ui/src/components/settings/llm/LLMProviderForm.tsx
@@ -1,6 +1,8 @@
 import type { ModelConfig } from "@shared/types/llm";
 import { Loader2 } from "lucide-react";
+import { useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
+import { DeleteConfirmDialog } from "@/components/dialogs/DeleteConfirmDialog";
 import { LLMProviderFields, type ProviderOption } from "@/components/llm/LLMProviderFields";
 import type { HealthStatusInfo } from "../../../types";
 import { Button } from "../../ui/button";
@@ -32,56 +34,67 @@ export function LLMProviderForm({
 }: LLMProviderFormProps) {
   const provider = form.watch("provider");
   const isAzureProvider = provider === "azure";
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
-        <LLMProviderFields
-          control={form.control}
-          providerField="provider"
-          apiKeyField="apiKey"
-          providerOptions={providerOptions}
-          onProviderChange={(value) => handleProviderChange(value as LLMProvider)}
-          healthStatus={healthStatus}
-          apiKeyDescription="Stored securely on this device."
-          apiKeyPlaceholder={isAzureProvider ? "Azure OpenAI API Key" : "sk-..."}
-          selectContentClassName="z-[70]"
-        />
+    <>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+          <LLMProviderFields
+            control={form.control}
+            providerField="provider"
+            apiKeyField="apiKey"
+            providerOptions={providerOptions}
+            onProviderChange={(value) => handleProviderChange(value as LLMProvider)}
+            healthStatus={healthStatus}
+            apiKeyDescription="Stored securely on this device."
+            apiKeyPlaceholder={isAzureProvider ? "Azure OpenAI API Key" : "sk-..."}
+            selectContentClassName="z-[70]"
+          />
 
-        {isAzureProvider && (
-          <div className="grid gap-3">
-            <FormField
-              control={form.control}
-              name="resourceName"
-              render={({ field }) => (
-                <FormItem className="flex flex-col gap-2">
-                  <FormLabel className="text-white">Resource Name</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="my-azure-ai-001" type="text" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          {isAzureProvider && (
+            <div className="grid gap-3">
+              <FormField
+                control={form.control}
+                name="resourceName"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col gap-2">
+                    <FormLabel className="text-white">Resource Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="my-azure-ai-001" type="text" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          )}
+
+          <div className="flex justify-start gap-2">
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={() => setClearConfirmOpen(true)}
+              disabled={isLoading || !hasConfig}
+            >
+              Clear Config
+            </Button>
+            <Button type="submit" size="sm" disabled={isLoading}>
+              {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Save
+            </Button>
           </div>
-        )}
-
-        <div className="flex justify-start gap-2">
-          <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            onClick={onClear}
-            disabled={isLoading || !hasConfig}
-          >
-            Clear Config
-          </Button>
-          <Button type="submit" size="sm" disabled={isLoading}>
-            {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-            Save
-          </Button>
-        </div>
-      </form>
-    </Form>
+        </form>
+      </Form>
+      <DeleteConfirmDialog
+        open={clearConfirmOpen}
+        onOpenChange={setClearConfirmOpen}
+        onConfirm={onClear}
+        deleteTitle="Clear model configuration"
+        deleteConfirmMessage="This removes the saved API key and model configuration for this provider. You will need to re-enter it to use this model."
+        confirmLabel="Clear Config"
+      />
+    </>
   );
 }

--- a/src/ui/src/components/settings/mcp/McpServerForm.tsx
+++ b/src/ui/src/components/settings/mcp/McpServerForm.tsx
@@ -536,7 +536,7 @@ export function McpServerFormWrapper({
         <div className="flex w-full items-center">
           {onDelete && !hideDeleteServerButton && (
             <div className="flex flex-1 justify-start">
-              <Button variant="destructive" onClick={onDelete}>
+              <Button variant="destructiveOutline" onClick={onDelete}>
                 Delete Server
               </Button>
             </div>

--- a/src/ui/src/components/settings/mcp/McpServerManager.tsx
+++ b/src/ui/src/components/settings/mcp/McpServerManager.tsx
@@ -14,6 +14,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "../../ui/alert-dialog";
+import { buttonVariants } from "../../ui/button";
 import { McpAzureDevOpsCard } from "./devops/mcp-devops-card";
 import { McpGitHubCard } from "./github/mcp-github-card";
 import { McpJiraCard } from "./jira/mcp-jira-card";
@@ -405,7 +406,12 @@ export function McpSettingsPanel({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDeleteConfirm}>Delete Server</AlertDialogAction>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className={buttonVariants({ variant: "destructiveOutline" })}
+            >
+              Delete Server
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/ui/src/components/settings/release-channels/GitHubTokenSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/GitHubTokenSetting.tsx
@@ -206,7 +206,7 @@ export function GitHubTokenSetting({ isActive }: GitHubTokenSettingProps) {
               <div className="flex gap-3 justify-end pt-2">
                 {hasToken && (
                   <Button
-                    variant="destructive"
+                    variant="destructiveOutline"
                     onClick={() => setClearConfirmOpen(true)}
                     disabled={isSaving}
                   >

--- a/src/ui/src/components/settings/release-channels/GitHubTokenSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/GitHubTokenSetting.tsx
@@ -1,6 +1,7 @@
 import { Eye, EyeOff } from "lucide-react";
 import { useCallback, useEffect, useId, useState } from "react";
 import { toast } from "sonner";
+import { DeleteConfirmDialog } from "@/components/dialogs/DeleteConfirmDialog";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ipcClient } from "@/services/ipc-client";
 import type { HealthStatusInfo } from "@/types";
@@ -21,6 +22,7 @@ export function GitHubTokenSetting({ isActive }: GitHubTokenSettingProps) {
   const [token, setToken] = useState<string>("");
   const [hasToken, setHasToken] = useState<boolean>(false);
   const [showToken, setShowToken] = useState<boolean>(false);
+  const [clearConfirmOpen, setClearConfirmOpen] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [healthStatus, setHealthStatus] = useState<HealthStatusInfo | null>(null);
@@ -142,82 +144,91 @@ export function GitHubTokenSetting({ isActive }: GitHubTokenSettingProps) {
   }, []);
 
   return (
-    <Card className="w-full gap-4 border-white/10 py-4">
-      <CardHeader className="px-4">
-        <CardTitle>GitHub Token</CardTitle>
-        <CardDescription>
-          Add a personal access token so YakShaver can list and download PR releases.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4 px-4">
-        {isLoading ? (
-          <div className="text-muted-foreground text-center py-8">Loading...</div>
-        ) : (
-          <>
-            {hasToken && (
-              <div className="flex items-center gap-3">
-                <p className="text-white/80 text-sm">Token Status:</p>
-                <span className="text-green-400 text-sm font-mono">Saved</span>
-                <HealthStatus
-                  isChecking={healthStatus?.isChecking ?? false}
-                  isHealthy={healthStatus?.isHealthy ?? false}
-                  successMessage={healthStatus?.successMessage}
-                  successDetails={verifyDetails ?? undefined}
-                  error={healthStatus?.error}
-                  isDisabled={!hasToken}
-                />
-              </div>
-            )}
-            {!hasToken && (
-              <p className="text-white/80 text-sm">
-                Status: <span className="text-ssw-red">No Token Saved</span>
-              </p>
-            )}
-            <div className="flex flex-col gap-2">
-              <Label htmlFor={inputId}>GitHub Personal Access Token</Label>
-              <div className="relative">
-                <Input
-                  id={inputId}
-                  type={showToken ? "text" : "password"}
-                  value={token}
-                  onChange={(e) => setToken(e.target.value)}
-                  placeholder={hasToken ? "Token is saved (hidden)" : "ghp_xxxxxxxxxxxxxxxxxxxx"}
-                  disabled={isSaving}
-                />
-                {token && (
-                  <button
-                    type="button"
-                    onClick={toggleShowToken}
-                    className="absolute right-3 top-1/2 -translate-y-1/2"
-                    aria-label={showToken ? "Hide token" : "Show token"}
-                  >
-                    {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                )}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                The token is encrypted and stored locally on your device
-              </p>
-            </div>
-
-            <div className="flex gap-3 justify-end pt-2">
+    <>
+      <Card className="w-full gap-4 border-white/10 py-4">
+        <CardHeader className="px-4">
+          <CardTitle>GitHub Token</CardTitle>
+          <CardDescription>
+            Add a personal access token so YakShaver can list and download PR releases.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 px-4">
+          {isLoading ? (
+            <div className="text-muted-foreground text-center py-8">Loading...</div>
+          ) : (
+            <>
               {hasToken && (
-                <Button
-                  variant="destructive"
-                  onClick={handleClear}
-                  disabled={isSaving}
-                  className="bg-neutral-800 text-white border-neutral-700 hover:bg-neutral-800/80 hover:text-white/80"
-                >
-                  Clear Token
-                </Button>
+                <div className="flex items-center gap-3">
+                  <p className="text-white/80 text-sm">Token Status:</p>
+                  <span className="text-green-400 text-sm font-mono">Saved</span>
+                  <HealthStatus
+                    isChecking={healthStatus?.isChecking ?? false}
+                    isHealthy={healthStatus?.isHealthy ?? false}
+                    successMessage={healthStatus?.successMessage}
+                    successDetails={verifyDetails ?? undefined}
+                    error={healthStatus?.error}
+                    isDisabled={!hasToken}
+                  />
+                </div>
               )}
-              <Button onClick={handleSave} disabled={isSaving || !token.trim()}>
-                {isSaving ? "Saving..." : "Save Token"}
-              </Button>
-            </div>
-          </>
-        )}
-      </CardContent>
-    </Card>
+              {!hasToken && (
+                <p className="text-white/80 text-sm">
+                  Status: <span className="text-ssw-red">No Token Saved</span>
+                </p>
+              )}
+              <div className="flex flex-col gap-2">
+                <Label htmlFor={inputId}>GitHub Personal Access Token</Label>
+                <div className="relative">
+                  <Input
+                    id={inputId}
+                    type={showToken ? "text" : "password"}
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    placeholder={hasToken ? "Token is saved (hidden)" : "ghp_xxxxxxxxxxxxxxxxxxxx"}
+                    disabled={isSaving}
+                  />
+                  {token && (
+                    <button
+                      type="button"
+                      onClick={toggleShowToken}
+                      className="absolute right-3 top-1/2 -translate-y-1/2"
+                      aria-label={showToken ? "Hide token" : "Show token"}
+                    >
+                      {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  The token is encrypted and stored locally on your device
+                </p>
+              </div>
+
+              <div className="flex gap-3 justify-end pt-2">
+                {hasToken && (
+                  <Button
+                    variant="destructive"
+                    onClick={() => setClearConfirmOpen(true)}
+                    disabled={isSaving}
+                  >
+                    Clear Token
+                  </Button>
+                )}
+                <Button onClick={handleSave} disabled={isSaving || !token.trim()}>
+                  {isSaving ? "Saving..." : "Save Token"}
+                </Button>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+      <DeleteConfirmDialog
+        open={clearConfirmOpen}
+        onOpenChange={setClearConfirmOpen}
+        onConfirm={handleClear}
+        deleteTitle="Clear GitHub Token"
+        deleteConfirmMessage="This removes the saved GitHub token from this device. You will need to re-enter it to use GitHub features."
+        confirmLabel="Clear Token"
+      />
+    </>
   );
 }

--- a/src/ui/src/components/ui/button.tsx
+++ b/src/ui/src/components/ui/button.tsx
@@ -12,8 +12,12 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        // Outlined danger variant — reserved for irreversible / destructive
+        // actions. Quieter than a solid-red primary; deepens on interaction.
+        // Uses the SSW hot-red token (--danger / #ff453a). The button itself
+        // never confirms — it only signals danger and triggers a confirm step.
         destructiveOutline:
-          "border border-destructive/50 text-white bg-destructive/10 shadow-xs hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+          "min-h-11 border border-danger/60 text-white bg-danger/8 shadow-xs transition-colors duration-150 hover:bg-danger/15 focus-visible:ring-danger/40 focus-visible:border-danger",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",


### PR DESCRIPTION
Part of #872 (designbyalex Settings UX). Makes destructive actions in Settings use a consistent distinct destructive color, require a clearly-worded confirmation modal, and fixes a confirm-button contrast bug. ACs #7, #8, #9, #15.

## Audit (every destructive action in Settings)
| Action | Before | Change |
|---|---|---|
| **Reset Account** (`account/ResetAccountSetting`) | destructive variant + AlertDialog ✓, but confirm button `text-primary` on `bg-destructive` | **Fixed contrast** → `text-white` (AC15) |
| **Clear GitHub Token** (`release-channels/GitHubTokenSetting`) | `variant="destructive"` **overridden to neutral grey**; **no confirmation** | **Restored destructive color** (AC7/8) + **added confirmation modal** (AC9) |
| **Clear Config / model key** (`llm/LLMProviderForm`) | destructive variant ✓, but **no confirmation** | **Added confirmation modal** (AC9) |
| **Remove MCP server** (`mcp/McpServerManager`) | destructive variant + AlertDialog ✓ | already correct — no change |
| **Delete custom prompt** (`custom-prompt/CustomPromptManager`) | `DeleteConfirmDialog`, but its confirm button used the default (primary-ish) color | now destructive-coloured via the shared component |

## Shared improvement
`dialogs/DeleteConfirmDialog` now renders its confirm button with the **destructive color** (`bg-destructive text-white`) and accepts a **`confirmLabel`** prop — so it's reusable for "Clear Token"/"Clear Config" and fixes the color/contrast (AC8/15) for **every** caller at once.

## Validation
- `npx @biomejs/biome@2.3.11 check` clean on all changed files.
- build + vitest run on CI.
- Not live-verified from the isolated worktree (dev app renders the main tree) — a maintainer should eyeball the new confirm dialogs (GitHub token, LLM clear) and the destructive button colors.

Scoped to destructive actions only — sibling #872 sub-issues (#876 a11y, #878 config-health, #879 layout) are separate PRs.
