### PR TITLE
XS⚠️ ◾ Standardize Settings page headers + remove redundant global header (#879)

### DIFF
--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -1,7 +1,14 @@
 import { Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "../ui/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "../ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
 import { ScrollArea } from "../ui/scroll-area";
 import { AccountSettingsPanel } from "./account/AccountSettingsPanel";
 import { AdvancedSettingsPanel } from "./advanced/AdvancedSettingsPanel";
@@ -162,14 +169,13 @@ export function SettingsDialog() {
       </DialogTrigger>
 
       <DialogContent className="w-[min(800px,72vw)] max-w-none sm:max-w-none h-[85vh] overflow-hidden flex flex-col">
-        <DialogHeader className="mb-2 flex-shrink-0">
-          <DialogTitle className="text-2xl font-semibold flex items-center gap-2">
-            <Settings className="h-5 w-5" />
-            Settings
-          </DialogTitle>
-          <p className="text-muted-foreground text-sm">
-            Configure YakShaver preferences and integrations.
-          </p>
+        {/* #879: the global "Settings" header was redundant with each panel's own
+            title (SettingsPageHeader). It's now visually hidden — kept only for
+            Radix Dialog accessibility (aria-labelledby/aria-describedby + screen
+            readers). The active tab name makes the accessible title specific. */}
+        <DialogHeader className="sr-only">
+          <DialogTitle>{activeTab ? `Settings — ${activeTab.label}` : "Settings"}</DialogTitle>
+          <DialogDescription>Configure YakShaver preferences and integrations.</DialogDescription>
         </DialogHeader>
 
         <div className="flex gap-6 flex-1 min-h-0 overflow-hidden">

--- a/src/ui/src/components/settings/SettingsPageHeader.tsx
+++ b/src/ui/src/components/settings/SettingsPageHeader.tsx
@@ -1,0 +1,27 @@
+import type { LucideIcon } from "lucide-react";
+
+interface SettingsPageHeaderProps {
+  /** Optional leading icon for the page. */
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+}
+
+/**
+ * Consistent header for every Settings panel (#879): an optional leading icon,
+ * the page title, and a description — aligned the same way on every page.
+ *
+ * The Settings dialog no longer renders a global "Settings" title (it was
+ * redundant with these per-page titles), so this is the visible page heading.
+ */
+export function SettingsPageHeader({ icon: Icon, title, description }: SettingsPageHeaderProps) {
+  return (
+    <div className="space-y-1">
+      <h2 className="flex items-center gap-2 text-xl font-semibold">
+        {Icon ? <Icon className="h-5 w-5 shrink-0" aria-hidden="true" /> : null}
+        {title}
+      </h2>
+      {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/account/AccountSettingsPanel.tsx
+++ b/src/ui/src/components/settings/account/AccountSettingsPanel.tsx
@@ -1,3 +1,5 @@
+import { CircleUserRound } from "lucide-react";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 import { ResetAccountSetting } from "./ResetAccountSetting";
 import { SetupWizardSetting } from "./SetupWizardSetting";
 import { TelemetryUsageDataSetting } from "./TelemetryUsageDataSetting";
@@ -13,12 +15,11 @@ export function AccountSettingsPanel({ isActive }: AccountSettingsPanelProps) {
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Account</h2>
-        <p className="text-sm text-muted-foreground">
-          Manage your YakShaver account settings and preferences.
-        </p>
-      </div>
+      <SettingsPageHeader
+        icon={CircleUserRound}
+        title="Account"
+        description="Manage your YakShaver account settings and preferences."
+      />
 
       <TelemetryUsageDataSetting />
       <SetupWizardSetting />

--- a/src/ui/src/components/settings/advanced/AdvancedSettingsPanel.tsx
+++ b/src/ui/src/components/settings/advanced/AdvancedSettingsPanel.tsx
@@ -1,7 +1,9 @@
+import { FlaskConical } from "lucide-react";
 import { useId } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { useAdvancedSettings } from "@/contexts/AdvancedSettingsContext";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 
 export function AdvancedSettingsPanel() {
   const { isYoutubeUrlWorkflowEnabled, setYoutubeUrlWorkflowEnabled } = useAdvancedSettings();
@@ -9,13 +11,11 @@ export function AdvancedSettingsPanel() {
 
   return (
     <div className="flex flex-col gap-6">
-      <header className="flex flex-col gap-1">
-        <h2 className="text-xl font-semibold">Advanced Settings</h2>
-        <p className="text-sm text-muted-foreground">
-          Toggle experimental workflows and power-user options. These settings affect how controls
-          appear in the main workspace.
-        </p>
-      </header>
+      <SettingsPageHeader
+        icon={FlaskConical}
+        title="Advanced Settings"
+        description="Toggle experimental workflows and power-user options. These settings affect how controls appear in the main workspace."
+      />
 
       <Card>
         <CardHeader className="space-y-1">

--- a/src/ui/src/components/settings/custom-prompt/CustomPromptManager.tsx
+++ b/src/ui/src/components/settings/custom-prompt/CustomPromptManager.tsx
@@ -1,3 +1,4 @@
+import { MessageSquareText } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CustomPrompt } from "@/types";
 import { usePromptManager } from "../../../hooks/usePromptManager";
@@ -6,6 +7,7 @@ import { DeleteConfirmDialog } from "../../dialogs/DeleteConfirmDialog";
 import { UnsavedChangesDialog } from "../../dialogs/UnsavedChangesDialog";
 import { Button } from "../../ui/button";
 import { Separator } from "../../ui/separator";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 import { PromptForm } from "./PromptForm";
 import { PromptListView } from "./PromptListView";
 import type { PromptFormValues } from "./schema";
@@ -364,13 +366,11 @@ export function CustomPromptSettingsPanel({
     <>
       <div className="flex h-full min-h-0 flex-col gap-4 overflow-hidden">
         {viewMode === "list" && (
-          <header className="flex flex-col gap-1">
-            <h2 className="text-xl font-semibold">Custom Prompt Manager</h2>
-            <p className="text-muted-foreground text-sm">
-              Manage your custom prompts. Use a template to get started quickly, or create your own
-              prompt.
-            </p>
-          </header>
+          <SettingsPageHeader
+            icon={MessageSquareText}
+            title="Custom Prompts"
+            description="Manage your custom prompts. Use a template to get started quickly, or create your own prompt."
+          />
         )}
         <div className="flex-1">
           <div className="w-full overflow-x-hidden">{renderContent()}</div>

--- a/src/ui/src/components/settings/general/GeneralSettingsPanel.tsx
+++ b/src/ui/src/components/settings/general/GeneralSettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { Settings2 } from "lucide-react";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 import { KeyMappingSetting } from "./KeyMappingSetting";
 import { StartupSetting } from "./StartupSetting";
 import { ToolApprovalSetting } from "./ToolApprovalSetting";
@@ -10,13 +11,11 @@ interface GeneralSettingsPanelProps {
 export function GeneralSettingsPanel({ isActive }: GeneralSettingsPanelProps) {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold flex items-center gap-2">
-          <Settings2 className="h-5 w-5" />
-          General
-        </h2>
-        <p className="text-sm text-muted-foreground">Configure general application settings.</p>
-      </div>
+      <SettingsPageHeader
+        icon={Settings2}
+        title="General"
+        description="Configure general application settings."
+      />
 
       <ToolApprovalSetting isActive={isActive} />
       <KeyMappingSetting isActive={isActive} />

--- a/src/ui/src/components/settings/llm/LLMSettingsPanel.tsx
+++ b/src/ui/src/components/settings/llm/LLMSettingsPanel.tsx
@@ -1,3 +1,5 @@
+import { Brain } from "lucide-react";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 import { LanguageModelSetting } from "./LanguageModelSetting";
 import { TranscriptionModelSetting } from "./TranscriptionModelSetting";
 
@@ -8,12 +10,11 @@ interface LLMSettingsPanelProps {
 export function LLMSettingsPanel({ isActive }: LLMSettingsPanelProps) {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Model Settings</h2>
-        <p className="text-sm text-muted-foreground">
-          Configure provider API keys for language and transcription models.
-        </p>
-      </div>
+      <SettingsPageHeader
+        icon={Brain}
+        title="Model Settings"
+        description="Configure provider API keys for language and transcription models."
+      />
 
       <LanguageModelSetting isActive={isActive} />
       <TranscriptionModelSetting isActive={isActive} />

--- a/src/ui/src/components/settings/mcp/McpServerManager.tsx
+++ b/src/ui/src/components/settings/mcp/McpServerManager.tsx
@@ -1,4 +1,4 @@
-import { Globe } from "lucide-react";
+import { Globe, Plug } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { HealthStatusInfo } from "@/types";
@@ -14,6 +14,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "../../ui/alert-dialog";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 import { McpAzureDevOpsCard } from "./devops/mcp-devops-card";
 import { McpGitHubCard } from "./github/mcp-github-card";
 import { McpJiraCard } from "./jira/mcp-jira-card";
@@ -297,6 +298,15 @@ export function McpSettingsPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      {viewMode === "detailed" ? (
+        <div className="mb-4">
+          <SettingsPageHeader
+            icon={Plug}
+            title="MCP Settings"
+            description="Connect backlog providers and built-in tools for creating work items."
+          />
+        </div>
+      ) : null}
       <div className="grid grid-cols-1 gap-4 mb-4">
         {sortedServers.map((server) => {
           if (server.id === McpGitHubCard.Id) {

--- a/src/ui/src/components/settings/release-channels/ReleaseChannelSettingsPanel.tsx
+++ b/src/ui/src/components/settings/release-channels/ReleaseChannelSettingsPanel.tsx
@@ -1,3 +1,5 @@
+import { Package } from "lucide-react";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 import { GitHubTokenSetting } from "./GitHubTokenSetting";
 import { ReleaseChannelSetting } from "./ReleaseChannelSetting";
 
@@ -8,12 +10,11 @@ interface ReleaseChannelSettingsPanelProps {
 export function ReleaseChannelSettingsPanel({ isActive }: ReleaseChannelSettingsPanelProps) {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Releases</h2>
-        <p className="text-sm text-muted-foreground">
-          Configure update channels and GitHub access for PR releases.
-        </p>
-      </div>
+      <SettingsPageHeader
+        icon={Package}
+        title="Releases"
+        description="Configure update channels and GitHub access for PR releases."
+      />
 
       <ReleaseChannelSetting isActive={isActive} />
       <GitHubTokenSetting isActive={isActive} />

--- a/src/ui/src/components/settings/video-host/VideoHostSettingsPanel.tsx
+++ b/src/ui/src/components/settings/video-host/VideoHostSettingsPanel.tsx
@@ -1,4 +1,6 @@
+import { Youtube } from "lucide-react";
 import { YouTubeConnection } from "../../auth/YouTubeConnection";
+import { SettingsPageHeader } from "../SettingsPageHeader";
 
 interface VideoHostSettingsPanelProps {
   isActive: boolean;
@@ -11,10 +13,11 @@ export function VideoHostSettingsPanel({ isActive }: VideoHostSettingsPanelProps
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Video Host</h2>
-        <p className="text-sm text-white/70">Choose a platform to host your videos.</p>
-      </div>
+      <SettingsPageHeader
+        icon={Youtube}
+        title="Video Host"
+        description="Choose a platform to host your videos."
+      />
 
       <div className="grid gap-4">
         <YouTubeConnection buttonSize="lg" />


### PR DESCRIPTION
Closes #879. A #872 sub-issue (Settings UX) from @designbyalex.

## What changed
**AC3 — remove the redundant global header.** `SettingsDialog` rendered a global "⚙ Settings" `DialogTitle` + "Configure YakShaver preferences and integrations." subtitle that duplicated every panel's own heading. It's now **visually hidden** (`sr-only`) but retained for Radix Dialog accessibility — the `DialogTitle` reflects the **active tab** (`Settings — Account`) and a `DialogDescription` satisfies `aria-describedby`.

**AC4 — one consistent page header everywhere.** New shared **`SettingsPageHeader`** (icon + title + description, aligned identically) applied to **all eight** panels:
General · Video Host · Model Settings · MCP Settings · Custom Prompts · Advanced · Account · Releases.
- Previously some panels had an icon, most didn't, and markup varied (`div.space-y-2` vs `header`); now uniform.
- The MCP header is gated to the **detailed** (settings) view so the onboarding **compact** MCP view is unaffected.
- Fixed Video Host's inconsistent description colour (`text-white/70` → `text-muted-foreground`).

## Deferred (with rationale) — AC11 + AC10
- **AC11 (conditional Reset/Clear)** and **AC10 (save consistency)** mostly live in the **destructive-action settings** (GitHub token, LLM keys, Reset Account) — the exact files **#877 (PR #886)** is changing. Implementing them here would collide. **Audited and deferred** to a follow-up once #886 lands, to avoid merge conflicts. (The Reset Account action is intentionally always-shown — resetting to default is always applicable.)

## Overlap note (merge sequencing)
This touches `SettingsDialog.tsx` / the panels, which sibling sub-issues also touch in **different** spots: **#884** (#876, adds `.settings-44` to `DialogContent`), **#885** (#869, dispatches a refresh event on close), **#886** (#877, destructive actions). No logical conflict — minor textual merge resolution at most.

## Validation
- `biome` 2.3.11 clean. `build`/`vitest` run on CI.
- Not live-verified from the isolated worktree (dev app renders the main tree) — a maintainer should eyeball the eight panel headers + confirm the dialog still has an accessible name.
