### PR TITLE
XS✔ ◾ Move toast notifications to bottom-center (#784)

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { HashRouter, Route, Routes } from "react-router-dom";
-import { Toaster, toast } from "sonner";
+import { toast } from "sonner";
 import "./App.css";
+import { AppToaster } from "./components/common/AppToaster";
 import { DownloadProgressToast } from "./components/common/DownloadProgressToast";
 import { TelemetryConsentInitializer } from "./components/common/TelemetryConsentInitializer";
 import { Layout } from "./components/layout/Layout";
@@ -33,7 +34,7 @@ export default function App() {
         <TelemetryConsentInitializer>
           <InteractionProvider>
             <div className="relative min-h-screen text-white">
-              <Toaster />
+              <AppToaster />
               <DownloadProgressToast />
               <OnboardingWizard onVisibilityChange={setIsOnboardingVisible} />
               <div className="fixed inset-0 bg-[url('/background/YakShaver-Background.jpg')] bg-cover bg-center bg-no-repeat"></div>

--- a/src/ui/src/components/common/AppToaster.test.tsx
+++ b/src/ui/src/components/common/AppToaster.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { APP_TOAST_POSITION, AppToaster } from "./AppToaster";
+
+describe("AppToaster (#784)", () => {
+  it("exposes bottom-center as the toast position (AC1/AC3)", () => {
+    // The exported constant is the contract the App wires into sonner's <Toaster>.
+    expect(APP_TOAST_POSITION).toBe("bottom-center");
+  });
+
+  it("renders the sonner toaster anchored bottom-center, not bottom-right (AC1/AC2)", () => {
+    const { container } = render(<AppToaster />);
+
+    // sonner emits the rendered container with data-sonner-toaster and splits the
+    // position into x/y axis attributes.
+    const toaster = container.querySelector("[data-sonner-toaster]");
+    expect(toaster).not.toBeNull();
+    expect(toaster?.getAttribute("data-y-position")).toBe("bottom");
+    expect(toaster?.getAttribute("data-x-position")).toBe("center");
+    // explicitly assert it is NOT the old bottom-right default
+    expect(toaster?.getAttribute("data-x-position")).not.toBe("right");
+  });
+});

--- a/src/ui/src/components/common/AppToaster.test.tsx
+++ b/src/ui/src/components/common/AppToaster.test.tsx
@@ -1,5 +1,15 @@
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock sonner's <Toaster> so we assert the `position` prop AppToaster passes —
+// without depending on sonner's internal rendering, which portals and doesn't emit
+// the [data-sonner-toaster] element in jsdom until a toast actually fires.
+vi.mock("sonner", () => ({
+  Toaster: (props: { position?: string }) => (
+    <div data-testid="app-toaster" data-position={props.position ?? ""} />
+  ),
+}));
+
 import { APP_TOAST_POSITION, AppToaster } from "./AppToaster";
 
 describe("AppToaster (#784)", () => {
@@ -8,16 +18,10 @@ describe("AppToaster (#784)", () => {
     expect(APP_TOAST_POSITION).toBe("bottom-center");
   });
 
-  it("renders the sonner toaster anchored bottom-center, not bottom-right (AC1/AC2)", () => {
-    const { container } = render(<AppToaster />);
-
-    // sonner emits the rendered container with data-sonner-toaster and splits the
-    // position into x/y axis attributes.
-    const toaster = container.querySelector("[data-sonner-toaster]");
-    expect(toaster).not.toBeNull();
-    expect(toaster?.getAttribute("data-y-position")).toBe("bottom");
-    expect(toaster?.getAttribute("data-x-position")).toBe("center");
-    // explicitly assert it is NOT the old bottom-right default
-    expect(toaster?.getAttribute("data-x-position")).not.toBe("right");
+  it("passes bottom-center (not the bottom-right default) to sonner's Toaster (AC1/AC2)", () => {
+    render(<AppToaster />);
+    const pos = screen.getByTestId("app-toaster").getAttribute("data-position");
+    expect(pos).toBe("bottom-center");
+    expect(pos).not.toBe("bottom-right");
   });
 });

--- a/src/ui/src/components/common/AppToaster.test.tsx
+++ b/src/ui/src/components/common/AppToaster.test.tsx
@@ -1,27 +1,45 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-
-// Mock sonner's <Toaster> so we assert the `position` prop AppToaster passes —
-// without depending on sonner's internal rendering, which portals and doesn't emit
-// the [data-sonner-toaster] element in jsdom until a toast actually fires.
-vi.mock("sonner", () => ({
-  Toaster: (props: { position?: string }) => (
-    <div data-testid="app-toaster" data-position={props.position ?? ""} />
-  ),
-}));
-
+import { render, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { toast } from "sonner";
+import { afterEach, describe, expect, it } from "vitest";
 import { APP_TOAST_POSITION, AppToaster } from "./AppToaster";
 
+// These tests render the REAL sonner <Toaster> (no mock) and fire an actual
+// toast() so sonner mounts its portal and emits [data-sonner-toaster]. We then
+// assert the rendered anchor attributes, proving the toast is anchored
+// bottom-center (and not the default bottom-right) — the outcome #784 claims —
+// rather than just verifying the prop pass-through.
+
+afterEach(() => {
+  // Clear any toasts queued by a test so its portal doesn't leak into the next.
+  toast.dismiss();
+});
+
 describe("AppToaster (#784)", () => {
-  it("exposes bottom-center as the toast position (AC1/AC3)", () => {
-    // The exported constant is the contract the App wires into sonner's <Toaster>.
+  it("exposes bottom-center as the toast position contract (AC1/AC3)", () => {
+    // The exported constant is the contract App wires into sonner's <Toaster>.
     expect(APP_TOAST_POSITION).toBe("bottom-center");
   });
 
-  it("passes bottom-center (not the bottom-right default) to sonner's Toaster (AC1/AC2)", () => {
+  it("renders the toast anchored bottom-center, not bottom-right (AC1/AC2)", async () => {
     render(<AppToaster />);
-    const pos = screen.getByTestId("app-toaster").getAttribute("data-position");
-    expect(pos).toBe("bottom-center");
-    expect(pos).not.toBe("bottom-right");
+
+    act(() => {
+      toast("Yak shaved");
+    });
+
+    // Sonner only mounts [data-sonner-toaster] once a toast actually fires.
+    const toaster = await waitFor(() => {
+      const el = document.querySelector("[data-sonner-toaster]");
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    // Assert the real rendered anchor sonner computed from the position prop —
+    // not a pass-through of our own constant.
+    expect(toaster.getAttribute("data-y-position")).toBe("bottom");
+    expect(toaster.getAttribute("data-x-position")).toBe("center");
+    // Explicitly guard against a regression back to the default bottom-right.
+    expect(toaster.getAttribute("data-x-position")).not.toBe("right");
   });
 });

--- a/src/ui/src/components/common/AppToaster.tsx
+++ b/src/ui/src/components/common/AppToaster.tsx
@@ -1,0 +1,14 @@
+import { Toaster } from "sonner";
+
+/**
+ * App-wide toast container.
+ *
+ * Per the SSW toast-notification rule (https://www.ssw.com.au/rules/toast-notifications)
+ * and issue #784, toasts render in the bottom-center of the window — the least
+ * obstructive location — rather than sonner's default bottom-right.
+ */
+export const APP_TOAST_POSITION = "bottom-center" as const;
+
+export function AppToaster() {
+  return <Toaster position={APP_TOAST_POSITION} />;
+}


### PR DESCRIPTION
Closes #784

## What
Toast notifications now render in the **bottom-center** of the app window instead of sonner's default **bottom-right** corner, per the [SSW toast-notification rule](https://www.ssw.com.au/rules/toast-notifications).

## Why
The app's `<Toaster>` in `App.tsx` had no `position` prop, so sonner fell back to `bottom-right`. The rule (and issue #784) require bottom-center as the least obstructive location.

## How
- Added `AppToaster` (`src/ui/src/components/common/AppToaster.tsx`) — a thin wrapper that renders sonner's `<Toaster position="bottom-center" />` and exports the position as a constant.
- Swapped `<Toaster />` for `<AppToaster />` in `App.tsx`.
- Added a jsdom/RTL unit test asserting the rendered toaster is anchored `data-y-position="bottom"` / `data-x-position="center"` (and explicitly not `right`).

No conflicting CSS or other custom sonner positioning was found. The bottom-right `DownloadProgressToast` is a separate, purpose-built download-progress card (not a sonner toast) and is intentionally left unchanged.

## Acceptance criteria
- [x] AC1 — toasts display bottom-center
- [x] AC2 — toasts no longer appear bottom-right
- [x] AC3 — aligns with the SSW toast UX rule
- [x] AC4 — UI-only position change; no overlap with critical UI introduced

## Caveat
Not live-verified (UI-only position change; app not run locally). Behaviour is covered by the new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)