### PR TITLE
XS✔ ◾ Fix #676: Make uploaded video URL clickable in upload result

### DIFF
--- a/src/ui/src/components/video/UploadResult.test.tsx
+++ b/src/ui/src/components/video/UploadResult.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { UploadStatus, type VideoUploadResult } from "../../types";
+import { UploadResult } from "./UploadResult";
+
+// #676: the uploaded video URL must be a clickable link (not plain text) that
+// opens externally. The app's BrowserWindow setWindowOpenHandler routes any
+// http(s) target="_blank" anchor through shell.openExternal, so asserting the
+// URL renders as an anchor with href + target="_blank" proves the AC.
+
+const successResult: VideoUploadResult = {
+  success: true,
+  origin: "upload",
+  data: {
+    videoId: "Ql9Voo74sCg",
+    url: "https://www.youtube.com/watch?v=Ql9Voo74sCg",
+    title: "My recording",
+    description: "A description",
+    duration: 24,
+  },
+};
+
+describe("UploadResult (#676)", () => {
+  it("renders the uploaded video URL as a clickable link that opens in the browser", () => {
+    render(<UploadResult result={successResult} status={UploadStatus.SUCCESS} />);
+
+    const link = screen.getByRole("link", {
+      name: "https://www.youtube.com/watch?v=Ql9Voo74sCg",
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "https://www.youtube.com/watch?v=Ql9Voo74sCg");
+    // target="_blank" is what the main process intercepts to open the default browser.
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("does not render a link while the upload is still in progress (no URL yet)", () => {
+    render(<UploadResult result={successResult} status={UploadStatus.UPLOADING} />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(/uploading to youtube/i)).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/components/video/UploadResult.tsx
+++ b/src/ui/src/components/video/UploadResult.tsx
@@ -71,7 +71,19 @@ const VideoCard = ({
       {!uploading && (
         <CardContent>
           <div className="p-3 bg-white/5 rounded-md flex items-center justify-between border border-white/10">
-            <p className="text-sm truncate flex-1 min-w-0">{url}</p>
+            {url ? (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Open in browser"
+                className="text-sm truncate flex-1 min-w-0 text-blue-300 hover:text-blue-200 hover:underline"
+              >
+                {url}
+              </a>
+            ) : (
+              <p className="text-sm truncate flex-1 min-w-0">{url}</p>
+            )}
             <div className="flex items-center gap-1 ml-2">
               <Button
                 type="button"


### PR DESCRIPTION
Closes #676

## Pain
When a video is uploaded, the upload-result card shows the video URL as plain, non-clickable text. Users have to select, copy, and paste it into a browser — slow and error-prone.

## Fix
Render the uploaded video URL in the upload-result card (`UploadResult.tsx`) as an accessible anchor instead of a `<p>`. The anchor uses `target="_blank"` + `rel="noopener noreferrer"`, which the main process `setWindowOpenHandler` (`src/backend/index.ts`) already routes through `shell.openExternal` for http(s) URLs — the app's existing external-link pattern. No new IPC/handler invented. The existing Copy + Open-in-browser icon buttons are unchanged.

## Acceptance Criteria
- [x] AC1: Users can click the uploaded video URL and open it in their default browser.

## Test
Added `UploadResult.test.tsx` (jsdom + RTL): asserts the URL renders as a link with the correct `href`, `target="_blank"`, and `noopener` rel on success, and that no link renders while still uploading.

## Notes
- Could not run `npm run build`/vitest locally (pruned node_modules); verified via code reading + Biome (`@biomejs/biome@2.3.11 check --write`, clean). Did not run the live app or record video per constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)