### PR TITLE
XS✔ ◾ Fix screen frame overlay lingering after recording stops (#805)

### DIFF
--- a/src/backend/ipc/screen-recording-handlers.test.ts
+++ b/src/backend/ipc/screen-recording-handlers.test.ts
@@ -1,0 +1,72 @@
+import { ipcMain } from "electron";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { CameraWindow } from "../services/recording/camera-window";
+import { RecordingControlBarWindow } from "../services/recording/control-bar-window";
+import { CountdownWindow } from "../services/recording/countdown-window";
+import { RecordingService } from "../services/recording/recording-service";
+import { ScreenFrameWindow } from "../services/recording/screen-frame-window";
+import { IPC_CHANNELS } from "./channels";
+import { ScreenRecordingIPCHandlers } from "./screen-recording-handlers";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}));
+
+vi.mock("../index", () => ({
+  getMainWindow: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../services/ffmpeg/ffmpeg-service");
+vi.mock("../services/recording/camera-window");
+vi.mock("../services/recording/control-bar-window");
+vi.mock("../services/recording/countdown-window");
+vi.mock("../services/recording/recording-service");
+vi.mock("../services/recording/screen-frame-window");
+
+describe("ScreenRecordingIPCHandlers", () => {
+  let cameraWindow: { hide: Mock };
+  let controlBar: { hideWithSuccess: Mock };
+  let screenFrameWindow: { hide: Mock };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    cameraWindow = { hide: vi.fn() };
+    controlBar = { hideWithSuccess: vi.fn().mockReturnValue({ success: true }) };
+    screenFrameWindow = { hide: vi.fn() };
+
+    // @ts-expect-error - mock implementation
+    CameraWindow.getInstance.mockReturnValue(cameraWindow);
+    // @ts-expect-error - mock implementation
+    RecordingControlBarWindow.getInstance.mockReturnValue(controlBar);
+    // @ts-expect-error - mock implementation
+    CountdownWindow.getInstance.mockReturnValue({});
+    // @ts-expect-error - mock implementation
+    RecordingService.getInstance.mockReturnValue({});
+    // @ts-expect-error - mock implementation
+    ScreenFrameWindow.getInstance.mockReturnValue(screenFrameWindow);
+
+    new ScreenRecordingIPCHandlers();
+  });
+
+  function getHandler(channel: string) {
+    const call = (ipcMain.handle as Mock).mock.calls.find((c) => c[0] === channel);
+    if (!call) throw new Error(`Handler not registered for ${channel}`);
+    return call[1] as (...args: unknown[]) => unknown;
+  }
+
+  // Regression guard for issue #805: the screen frame overlay was left on-screen after
+  // recording stopped because HIDE_CONTROL_BAR did not destroy the screen frame window.
+  it("destroys the screen frame overlay when the control bar is hidden", async () => {
+    const handler = getHandler(IPC_CHANNELS.HIDE_CONTROL_BAR);
+
+    const result = await handler({});
+
+    expect(result).toEqual({ success: true });
+    expect(cameraWindow.hide).toHaveBeenCalledTimes(1);
+    expect(controlBar.hideWithSuccess).toHaveBeenCalledTimes(1);
+    expect(screenFrameWindow.hide).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/backend/ipc/screen-recording-handlers.ts
+++ b/src/backend/ipc/screen-recording-handlers.ts
@@ -95,6 +95,10 @@ export class ScreenRecordingIPCHandlers {
   private hideControlBarAndCamera() {
     this.cameraWindow.hide();
     this.controlBar.hideWithSuccess();
+    // The screen frame overlay is shown during source selection/recording but is not torn down
+    // by the control-bar stop path. Destroy it here so it doesn't linger after recording stops
+    // (otherwise an empty frame overlay remains on-screen until the app quits).
+    this.screenFrameWindow.hide();
     return { success: true };
   }
 


### PR DESCRIPTION
Closes #805

## Root cause
The screen frame / selection overlay (`ScreenFrameWindow`) is shown during source selection and recording. On stop, it was only destroyed on the control-bar stop path (`stopRecordingFromControlBar`, which calls `this.screenFrameWindow.hide()` directly).

However, the **primary** renderer-driven stop flow is different: `useScreenRecording.stop()` -> `screenRecording.hideControlBar()` -> IPC `HIDE_CONTROL_BAR` -> `hideControlBarAndCamera()`. That handler tore down the camera window and the control bar but **never** the screen frame overlay. As a result, after the first recording an empty frame overlay remained on-screen until the app was quit (Cmd/Ctrl+Q).

## Fix
Destroy the screen frame overlay inside `hideControlBarAndCamera()`, mirroring the existing window-cleanup pattern (it already tears the camera + control bar down together; the frame is the symmetric counterpart of `showScreenFrame`). `ScreenFrameWindow.hide()` is idempotent (`this.window?.destroy()` is a no-op once null), so the control-bar stop path which already hides it is unaffected, and a second recording works.

## Test
Added `src/backend/ipc/screen-recording-handlers.test.ts` — a focused regression test that invokes the registered `HIDE_CONTROL_BAR` handler and asserts the camera, control bar, **and** screen frame windows are all torn down.

## Verification note
node_modules is pruned in this environment, so vitest/build were not run locally; the change was validated by code reading + `biome check` (clean). **This needs live verification on a real recording** — please confirm the overlay actually clears after stopping a recording (and that a second recording still shows + clears the frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)