### PR TITLE
XS✔ ◾ Fix #719: GitHub issue title shows only ✨ instead of the video title

### DIFF
--- a/src/backend/constants/prompts.test.ts
+++ b/src/backend/constants/prompts.test.ts
@@ -24,4 +24,10 @@ describe("SHARED_ISSUE_CREATION_RULES — issue title rules (#719)", () => {
     expect(SHARED_ISSUE_CREATION_RULES).toMatch(/title field/i);
     expect(SHARED_ISSUE_CREATION_RULES).toMatch(/into the issue body/i);
   });
+
+  // Per @tomek-i on #719: when no template exists, fall back to a sensible basic title.
+  it("provides a sensible-default fallback when the repo has NO template", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/no template/i);
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/fall back to a sensible default/i);
+  });
 });

--- a/src/backend/constants/prompts.test.ts
+++ b/src/backend/constants/prompts.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { SHARED_ISSUE_CREATION_RULES } from "./prompts";
+
+// Regression guard for #719: "GitHub issue created with ✨ as title instead of
+// video title". The issue title is produced by the LLM following
+// SHARED_ISSUE_CREATION_RULES. Before the fix, rule 5 only told the model to
+// keep the template's fixed emoji prefix (e.g. "✨" / "🐛 Bug -") but never told
+// it to substitute the {{ PLACEHOLDER }} parts with a real, video-derived title,
+// so the model emitted just the bare emoji as the title and pushed the real
+// title into the body. These assertions lock in the corrected instructions.
+describe("SHARED_ISSUE_CREATION_RULES — issue title rules (#719)", () => {
+  it("instructs the model to replace template placeholders with video-derived content", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/replace EVERY placeholder/i);
+    expect(SHARED_ISSUE_CREATION_RULES).toContain("{{ FEATURE NAME }}");
+  });
+
+  it("forbids an emoji-only / fixed-words-only title", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/ONLY an emoji/i);
+    // The literal sparkle from the bug report must be called out as invalid.
+    expect(SHARED_ISSUE_CREATION_RULES).toContain('NEVER just "✨"');
+  });
+
+  it("warns against pushing the real title into the body instead of the title field", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/title field/i);
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/into the issue body/i);
+  });
+});

--- a/src/backend/constants/prompts.ts
+++ b/src/backend/constants/prompts.ts
@@ -7,6 +7,10 @@ export const SHARED_ISSUE_CREATION_RULES = `3) **Follow Issue Templates**: If th
 5) **Issue Title Rules**:
 - The title MUST strictly follow the template's frontmatter pattern, INCLUDING ANY EMOJIS.
 - Do not omit fixed words (e.g., "🐛 Bug -") or substitute emojis.
+- **CRITICAL — Fill in the placeholders**: The template title contains placeholders such as \`{{ FEATURE NAME }}\`, \`{{ FEATURE DESCRIPTION }}\`, or \`{{ TITLE }}\`. You MUST replace EVERY placeholder with a concise, specific summary derived from the video transcription. Keep the template's fixed words and emojis, but the rest of the title MUST describe what the video is actually about.
+- A title that is ONLY an emoji, ONLY the fixed words, or that still contains any leftover \`{{ ... }}\` placeholder is INVALID. The final title MUST contain real, descriptive words from the video — NEVER just "✨" or "🐛 Bug -" on their own.
+- Example: for a feature template \`✨ {{ FEATURE NAME }} - {{ FEATURE DESCRIPTION }}\` about adding dark mode, a correct title is \`✨ Dark mode - Add a dark theme toggle to settings\`, NOT \`✨\`.
+- The descriptive summary belongs in the TITLE field. Do NOT leave the title as a bare emoji/prefix and push the actual title text into the issue body instead.
 
 6) **Issue Body Formatting**:
 - Preserve the template's section headings and checklist items exactly.

--- a/src/backend/constants/prompts.ts
+++ b/src/backend/constants/prompts.ts
@@ -1,4 +1,4 @@
-export const SHARED_ISSUE_CREATION_RULES = `3) **Follow Issue Templates**: If the target repository has an issue template, you MUST follow it exactly. Use the available tools to verify if a template exists.
+export const SHARED_ISSUE_CREATION_RULES = `3) **Follow Issue Templates**: If the target repository has an issue template, you MUST follow it exactly. Use the available tools to verify if a template exists. **If there is NO template available**, fall back to a sensible default: a clear, concise, descriptive title that summarises the issue or feature from the video (plain words — do NOT invent template emojis or fixed prefixes), and a well-structured body with the key details.
 
 4) **Issue Creation Guidelines**:
 - **Labels**: Always apply the "YakShaver" label IN ADDITION to any labels required by the template.
@@ -11,6 +11,7 @@ export const SHARED_ISSUE_CREATION_RULES = `3) **Follow Issue Templates**: If th
 - A title that is ONLY an emoji, ONLY the fixed words, or that still contains any leftover \`{{ ... }}\` placeholder is INVALID. The final title MUST contain real, descriptive words from the video — NEVER just "✨" or "🐛 Bug -" on their own.
 - Example: for a feature template \`✨ {{ FEATURE NAME }} - {{ FEATURE DESCRIPTION }}\` about adding dark mode, a correct title is \`✨ Dark mode - Add a dark theme toggle to settings\`, NOT \`✨\`.
 - The descriptive summary belongs in the TITLE field. Do NOT leave the title as a bare emoji/prefix and push the actual title text into the issue body instead.
+- **No template**: when the repository has no issue template, the title is still a real, descriptive summary of the video — a plain, concise sentence (no emoji prefix required), never empty, generic, or just a placeholder.
 
 6) **Issue Body Formatting**:
 - Preserve the template's section headings and checklist items exactly.


### PR DESCRIPTION
Closes #719

## Root cause

The GitHub issue title is generated by the LLM in the MCP execution loop. The model follows `SHARED_ISSUE_CREATION_RULES` (in `src/backend/constants/prompts.ts`), which is injected into the orchestrator system prompt via the project prompt (`default-custom-prompt.ts` / `workflow/prompts.ts`).

Rule 5 ("Issue Title Rules") told the model to keep the issue template's fixed emoji prefix — `title: "✨ {{ FEATURE NAME }} - {{ FEATURE DESCRIPTION }}"` for features, `🐛 Bug -` for bugs — "INCLUDING ANY EMOJIS" and to "not omit fixed words". But it never told the model to **substitute the `{{ ... }}` placeholders** with a real, video-derived title. The model kept only the fixed `✨` prefix, dropped the unfilled placeholders, and pushed the actual descriptive title into the issue body — exactly the symptom in the report (title = `✨`, real title in the body).

This rules block was added in #812, which matches the issue's "started happening after the recent update" note. There is no point in our own code where the GitHub issue title is set programmatically — the LLM sets it directly through the backlog-provider MCP tool call — so the correct, robust fix is in the prompt.

## Fix

Strengthened rule 5 in `SHARED_ISSUE_CREATION_RULES` to:
- explicitly require replacing **every** `{{ placeholder }}` with a concise summary derived from the video transcription;
- declare an emoji-only / fixed-words-only / leftover-placeholder title **INVALID** (calls out `"✨"` and `"🐛 Bug -"` by name);
- give a worked before/after example;
- forbid moving the descriptive title into the body instead of the title field.

This single block feeds both the GitHub (desktop) and portal/browser paths, so the behaviour is consistent across views (AC 5).

## Test

Added `src/backend/constants/prompts.test.ts` — a focused regression guard asserting the corrected title instructions are present (placeholder substitution, emoji-only-title forbidden, no-title-in-body).

## Notes / caveat

The fix is a prompt change (the title is non-deterministic LLM output), so it cannot be proven by a unit test alone — the unit test only locks the corrected instructions in place. **Please verify live**: record a YakShaver against a repo whose feature template has the `✨ {{ FEATURE NAME }} - {{ FEATURE DESCRIPTION }}` title and confirm the created issue now has a descriptive title (with the `✨` prefix retained) rather than a bare `✨`, and that the title isn't duplicated in the body (ACs 1-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)