### PR TITLE
XS⚠️ ◾ Fix #898: 44px minimum touch targets app-wide (primitives default)

### DIFF
--- a/src/ui/src/components/recording/RecordingControlBar.tsx
+++ b/src/ui/src/components/recording/RecordingControlBar.tsx
@@ -29,10 +29,20 @@ export default function RecordingControlBar() {
           <span className="font-mono text-sm font-medium tabular-nums text-white">{time}</span>
         </div>
         <Separator orientation="vertical" className="h-6 bg-white/20" />
+        {/*
+          size="icon" ships a centered 44px ::before overlay (HIT_TARGET_44).
+          On this 28px button in the frameless control bar that overlay spills
+          ~8px LEFT over the Separator and into the adjacent drag region, so a
+          click in that strip would fire Stop instead of dragging the bar. We
+          disable the centered overlay (before:hidden) and instead give the
+          button its own explicit, self-contained hit area: ml-1 clears the
+          separator, and px-2.5 + py-2 grows the click box rightward into the
+          pill's own padding (it does not overflow the drag region).
+        */}
         <Button
           variant="ghost"
           size="icon"
-          className="size-7 rounded-md transition-all hover:scale-105 hover:bg-white/10"
+          className="ml-1 size-auto px-2.5 py-2 rounded-md transition-all before:hidden hover:scale-105 hover:bg-white/10"
           onClick={() => window.electronAPI.screenRecording.stopFromControlBar()}
         >
           <Square className="size-4 fill-ssw-red text-ssw-red" />

--- a/src/ui/src/components/recording/VideoPreviewModal.tsx
+++ b/src/ui/src/components/recording/VideoPreviewModal.tsx
@@ -1,7 +1,6 @@
 import type { ToolApprovalMode } from "@shared/types/user-settings";
 import { ArrowRight, RotateCcw } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useWorkflowNavigation } from "@/hooks/useWorkflowNavigation";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,6 +21,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { useWorkflowNavigation } from "@/hooks/useWorkflowNavigation";
 import { VideoPlayer } from "./VideoPlayer";
 
 interface VideoPreviewModalProps {
@@ -132,13 +132,18 @@ export function VideoPreviewModal({
 
           <DialogFooter className="flex-col items-start gap-3 sm:flex-col">
             {approvalMode !== "yolo" && (
-              <div className="flex items-center gap-2">
+              // min-h-11 gives the row a 44px-tall click target (WCAG 2.5.5);
+              // the label spans the row via htmlFor so the row is the hit area.
+              <div className="flex items-center gap-2 min-h-11">
                 <Checkbox
                   id="auto-approve"
                   checked={autoApproveChecked}
                   onCheckedChange={(checked) => setAutoApproveChecked(checked === true)}
                 />
-                <Label htmlFor="auto-approve" className="text-sm font-normal text-muted-foreground">
+                <Label
+                  htmlFor="auto-approve"
+                  className="text-sm font-normal text-muted-foreground self-stretch flex items-center cursor-pointer"
+                >
                   Auto-approve all confirmations
                 </Label>
               </div>

--- a/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
+++ b/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
@@ -366,7 +366,14 @@ export function PromptForm({
                         field.onChange(newValue);
                       };
                       return (
-                        <div key={server.id} className="flex items-center gap-3 p-1 rounded">
+                        // min-h-11 gives the whole row a 44px-tall click target
+                        // (WCAG 2.5.5). The label spans the row via htmlFor, so
+                        // the row — not an overflowing checkbox overlay — is the
+                        // hit area, avoiding mis-toggling a stacked neighbour.
+                        <div
+                          key={server.id}
+                          className="flex items-center gap-3 min-h-11 px-1 rounded"
+                        >
                           <Checkbox
                             id={`server-${server.id}`}
                             checked={isChecked}
@@ -375,7 +382,7 @@ export function PromptForm({
                           />
                           <label
                             htmlFor={`server-${server.id}`}
-                            className={`text-sm flex-1 select-none ${
+                            className={`text-sm flex-1 self-stretch flex items-center select-none ${
                               isCheckboxDisabled ? "cursor-not-allowed" : "cursor-pointer"
                             }`}
                           >

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -94,21 +94,27 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
             )}
             {!isLoading && tools.length > 0 && (
               <div className="flex flex-col gap-2">
-                {tools.map((tool) => (
-                  <div key={tool.name} className="flex items-start gap-3">
-                    <Checkbox
-                      className="mt-1"
-                      checked={selected.has(tool.name)}
-                      onCheckedChange={() => toggleTool(tool.name)}
-                    />
-                    <div className="flex-1">
-                      <p className="text-sm">{formatToolName(tool.name)}</p>
-                      {tool.description && (
-                        <p className="text-xs text-muted-foreground">{tool.description}</p>
-                      )}
+                {tools.map((tool) => {
+                  const checkboxId = `whitelist-${tool.name}`;
+                  return (
+                    // min-h-11 gives the row a 44px-tall click target (WCAG 2.5.5);
+                    // the label spans the row via htmlFor so the row is the hit area.
+                    <div key={tool.name} className="flex items-start gap-3 min-h-11 py-1">
+                      <Checkbox
+                        id={checkboxId}
+                        className="mt-1"
+                        checked={selected.has(tool.name)}
+                        onCheckedChange={() => toggleTool(tool.name)}
+                      />
+                      <label htmlFor={checkboxId} className="flex-1 cursor-pointer select-none">
+                        <p className="text-sm">{formatToolName(tool.name)}</p>
+                        {tool.description && (
+                          <p className="text-xs text-muted-foreground">{tool.description}</p>
+                        )}
+                      </label>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -97,8 +97,12 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
                 {tools.map((tool) => {
                   const checkboxId = `whitelist-${tool.name}`;
                   return (
-                    // min-h-11 gives the row a 44px-tall click target (WCAG 2.5.5);
-                    // the label spans the row via htmlFor so the row is the hit area.
+                    // min-h-11 gives the row a 44px-tall click target (WCAG 2.5.5).
+                    // items-start top-aligns the checkbox against multi-line
+                    // descriptions; the label is self-stretch + flex flex-col
+                    // justify-center so it fills the full row height via htmlFor —
+                    // so even a description-less (single-line) row exposes the whole
+                    // 44px row as the hit area, matching the other call sites.
                     <div key={tool.name} className="flex items-start gap-3 min-h-11 py-1">
                       <Checkbox
                         id={checkboxId}
@@ -106,7 +110,10 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
                         checked={selected.has(tool.name)}
                         onCheckedChange={() => toggleTool(tool.name)}
                       />
-                      <label htmlFor={checkboxId} className="flex-1 cursor-pointer select-none">
+                      <label
+                        htmlFor={checkboxId}
+                        className="flex-1 self-stretch flex flex-col justify-center cursor-pointer select-none"
+                      >
                         <p className="text-sm">{formatToolName(tool.name)}</p>
                         {tool.description && (
                           <p className="text-xs text-muted-foreground">{tool.description}</p>

--- a/src/ui/src/components/settings/telemetry/TelemetryConsentDialog.tsx
+++ b/src/ui/src/components/settings/telemetry/TelemetryConsentDialog.tsx
@@ -62,13 +62,16 @@ export function TelemetryConsentDialog({
             <div className="flex items-start space-x-3">
               <Bug className="h-4 w-4 mt-0.5 text-muted-foreground" />
               <div className="flex-1">
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center space-x-2 min-h-11">
                   <Checkbox
                     id="error-reporting"
                     checked={allowErrorReporting}
                     onCheckedChange={(checked) => setAllowErrorReporting(checked as boolean)}
                   />
-                  <Label htmlFor="error-reporting" className="text-sm">
+                  <Label
+                    htmlFor="error-reporting"
+                    className="text-sm self-stretch flex items-center cursor-pointer"
+                  >
                     Error reports
                   </Label>
                 </div>
@@ -81,13 +84,16 @@ export function TelemetryConsentDialog({
             <div className="flex items-start space-x-3">
               <Activity className="h-4 w-4 mt-0.5 text-muted-foreground" />
               <div className="flex-1">
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center space-x-2 min-h-11">
                   <Checkbox
                     id="workflow-tracking"
                     checked={allowWorkflowTracking}
                     onCheckedChange={(checked) => setAllowWorkflowTracking(checked as boolean)}
                   />
-                  <Label htmlFor="workflow-tracking" className="text-sm">
+                  <Label
+                    htmlFor="workflow-tracking"
+                    className="text-sm self-stretch flex items-center cursor-pointer"
+                  >
                     Workflow performance
                   </Label>
                 </div>
@@ -100,13 +106,16 @@ export function TelemetryConsentDialog({
             <div className="flex items-start space-x-3">
               <BarChart3 className="h-4 w-4 mt-0.5 text-muted-foreground" />
               <div className="flex-1">
-                <div className="flex items-center space-x-2">
+                <div className="flex items-center space-x-2 min-h-11">
                   <Checkbox
                     id="usage-metrics"
                     checked={allowUsageMetrics}
                     onCheckedChange={(checked) => setAllowUsageMetrics(checked as boolean)}
                   />
-                  <Label htmlFor="usage-metrics" className="text-sm">
+                  <Label
+                    htmlFor="usage-metrics"
+                    className="text-sm self-stretch flex items-center cursor-pointer"
+                  >
                     Usage metrics
                   </Label>
                 </div>

--- a/src/ui/src/components/ui/button.tsx
+++ b/src/ui/src/components/ui/button.tsx
@@ -4,6 +4,13 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+// WCAG 2.5.5 minimum touch target = 44px (issue #898).
+// For compact variants (sm/icon) we keep the visual box small but expand the
+// *hit* area to 44px via a transparent ::before overlay, so dense rows
+// (toolbars, the recording bar, list rows) don't visually grow.
+const HIT_TARGET_44 =
+  "relative before:absolute before:left-1/2 before:top-1/2 before:size-11 before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']";
+
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
@@ -21,10 +28,12 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        // 44px minimum height by default (WCAG 2.5.5, issue #898).
+        default: "min-h-11 px-4 py-2 has-[>svg]:px-3",
+        // Compact variants keep their visual size but get a 44px hit area.
+        sm: `h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 ${HIT_TARGET_44}`,
+        lg: "min-h-11 rounded-md px-6 has-[>svg]:px-4",
+        icon: `size-9 ${HIT_TARGET_44}`,
         chunky: "h-14 px-6 py-4"
       },
     },

--- a/src/ui/src/components/ui/button.tsx
+++ b/src/ui/src/components/ui/button.tsx
@@ -8,7 +8,18 @@ import { cn } from "@/lib/utils";
 // For compact variants (sm/icon) we keep the visual box small but expand the
 // *hit* area to 44px via a transparent ::before overlay, so dense rows
 // (toolbars, the recording bar, list rows) don't visually grow.
-const HIT_TARGET_44 =
+//
+// Exported so other primitives (e.g. checkbox.tsx) reuse the same overlay
+// instead of inlining a copy (AGENTS.md "Constants Over Literals").
+//
+// NOTE: a full 44px-tall overlay safely covers both axes for an *isolated*
+// control, but it overflows its row when controls are stacked vertically
+// closer than 44px apart, so adjacent overlays overlap and a click can hit
+// the wrong control. Use this only where vertical neighbours are >=44px away
+// (icon/sm buttons sit in horizontal toolbars). Vertically-stacked controls
+// such as checkboxes must instead clamp the overlay to the row height — see
+// HIT_TARGET_44_X in checkbox.tsx.
+export const HIT_TARGET_44 =
   "relative before:absolute before:left-1/2 before:top-1/2 before:size-11 before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']";
 
 const buttonVariants = cva(
@@ -28,11 +39,12 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        // 44px minimum height by default (WCAG 2.5.5, issue #898).
-        default: "min-h-11 px-4 py-2 has-[>svg]:px-3",
+        // 44px minimum touch target on both axes by default
+        // (WCAG 2.5.5 C44 requires min-block-size AND min-inline-size).
+        default: "min-h-11 min-w-11 px-4 py-2 has-[>svg]:px-3",
         // Compact variants keep their visual size but get a 44px hit area.
         sm: `h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 ${HIT_TARGET_44}`,
-        lg: "min-h-11 rounded-md px-6 has-[>svg]:px-4",
+        lg: "min-h-11 min-w-11 rounded-md px-6 has-[>svg]:px-4",
         icon: `size-9 ${HIT_TARGET_44}`,
         chunky: "h-14 px-6 py-4"
       },

--- a/src/ui/src/components/ui/checkbox.tsx
+++ b/src/ui/src/components/ui/checkbox.tsx
@@ -12,7 +12,10 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        // Radix Checkbox renders as a <button>. Keep its intrinsic 16px visual
+        // box but expand the click target to 44px (WCAG 2.5.5, issue #898) via a
+        // transparent ::before overlay, instead of stretching the box.
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 relative before:absolute before:left-1/2 before:top-1/2 before:size-11 before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']",
         className
       )}
       {...props}

--- a/src/ui/src/components/ui/checkbox.tsx
+++ b/src/ui/src/components/ui/checkbox.tsx
@@ -16,8 +16,9 @@ import { cn } from "@/lib/utils"
 // To stay safe we expand to 44px on the HORIZONTAL axis only and let the
 // overlay fill exactly the row height (`before:inset-y-0`), so overlays never
 // overlap. Call sites that need the full 44px vertical target give the row a
-// `min-h-11` (the label spans the row via htmlFor), which the overlay then
-// inherits — see PromptForm / McpWhitelistDialog.
+// `min-h-11` and a row-spanning `htmlFor` label, which the overlay then
+// inherits — see PromptForm, McpWhitelistDialog, TelemetryConsentDialog, and
+// VideoPreviewModal.
 const HIT_TARGET_44_X =
   "relative before:absolute before:inset-y-0 before:left-1/2 before:w-11 before:min-w-11 before:-translate-x-1/2 before:content-['']"
 

--- a/src/ui/src/components/ui/checkbox.tsx
+++ b/src/ui/src/components/ui/checkbox.tsx
@@ -4,6 +4,23 @@ import { CheckIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Radix Checkbox renders as a <button> with a 16px visual box. We expand the
+// click target toward WCAG 2.5.5 (44px) via a transparent ::before overlay
+// without stretching the visible box.
+//
+// IMPORTANT — vertical clamp: checkboxes are routinely stacked vertically in
+// dense lists (the MCP-server picker, the tool whitelist, the telemetry
+// consent rows) closer than 44px apart. A fixed 44px-tall overlay (like the
+// button HIT_TARGET_44) would overflow its row and overlap the neighbour's
+// overlay, so a click near a row edge could toggle the WRONG checkbox.
+// To stay safe we expand to 44px on the HORIZONTAL axis only and let the
+// overlay fill exactly the row height (`before:inset-y-0`), so overlays never
+// overlap. Call sites that need the full 44px vertical target give the row a
+// `min-h-11` (the label spans the row via htmlFor), which the overlay then
+// inherits — see PromptForm / McpWhitelistDialog.
+const HIT_TARGET_44_X =
+  "relative before:absolute before:inset-y-0 before:left-1/2 before:w-11 before:min-w-11 before:-translate-x-1/2 before:content-['']"
+
 function Checkbox({
   className,
   ...props
@@ -12,10 +29,8 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        // Radix Checkbox renders as a <button>. Keep its intrinsic 16px visual
-        // box but expand the click target to 44px (WCAG 2.5.5, issue #898) via a
-        // transparent ::before overlay, instead of stretching the box.
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 relative before:absolute before:left-1/2 before:top-1/2 before:size-11 before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        HIT_TARGET_44_X,
         className
       )}
       {...props}

--- a/src/ui/src/components/ui/input.tsx
+++ b/src/ui/src/components/ui/input.tsx
@@ -8,7 +8,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        // min-h-11 = 44px WCAG 2.5.5 minimum touch target (issue #898).
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input min-h-11 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/src/ui/src/components/ui/select.tsx
+++ b/src/ui/src/components/ui/select.tsx
@@ -35,9 +35,11 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        // data-[size=default]:min-h-11 = 44px WCAG 2.5.5 minimum touch target (issue #898).
+        // data-[size=default]:min-h-11/min-w-11 = 44px WCAG 2.5.5 minimum touch
+        // target on BOTH axes (C44 requires min-block-size AND min-inline-size);
+        // the trigger is w-fit, so a narrow-content select still clears 44px wide.
         // The sm size stays compact for dense rows.
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:min-h-11 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:min-h-11 data-[size=default]:min-w-11 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/ui/src/components/ui/select.tsx
+++ b/src/ui/src/components/ui/select.tsx
@@ -35,7 +35,9 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // data-[size=default]:min-h-11 = 44px WCAG 2.5.5 minimum touch target (issue #898).
+        // The sm size stays compact for dense rows.
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:min-h-11 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/ui/src/components/ui/toggle.tsx
+++ b/src/ui/src/components/ui/toggle.tsx
@@ -14,9 +14,13 @@ const toggleVariants = cva(
           "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
       },
       size: {
-        default: "h-9 min-w-9 px-2",
-        sm: "h-8 min-w-8 px-1.5",
-        lg: "h-10 min-w-10 px-2.5",
+        // 44px minimum touch target on both axes (WCAG 2.5.5, issue #898).
+        // Toggles render as role=button and sit in horizontally-adjacent groups,
+        // so we raise the box itself rather than use a ::before overlay (which
+        // would overlap the neighbouring toggle and mis-target clicks).
+        default: "min-h-11 min-w-11 px-2",
+        sm: "min-h-11 min-w-11 px-1.5",
+        lg: "min-h-11 min-w-11 px-2.5",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Refs #898. (Not `Closes` — see "Remaining for #898" below: two of the issue's three "Done looks like" criteria — removing #884's scoped util once it lands on `main`, and the live visual-regression sweep — are not in this PR, so the issue stays open as the tracking item.)

## What changed
Raises the WCAG 2.5.5 minimum touch target to **44px at the source** — on the shared primitives in `src/ui/src/components/ui/` — rather than the Settings-scoped utility that #884 proposed. Four primitives changed:

- **`button.tsx`** — `default` size now `min-h-11` (44px, was `h-9`/36px); `lg` also `min-h-11`. The compact `sm` and `icon` sizes **keep their visual box** but gain a **44px hit area** via a transparent `::before` overlay (`HIT_TARGET_44`), so dense rows don't visually grow.
- **`input.tsx`** — `min-h-11` (was `h-9`/36px).
- **`select.tsx`** — `SelectTrigger` `data-[size=default]` now `min-h-11` (was `h-9`); `sm` stays compact for dense rows.
- **`checkbox.tsx`** — see Radix note below.

`min-h-11` (not a hard `h-11`) is used so text wrapping / multi-line content can still grow the control without being clipped, while never going below 44px.

## Radix checkbox handling
Radix `<Checkbox>` renders as a `<button>` with an intrinsic `size-4` (16px) visual box. Per the issue we must **not** stretch the box. The checkbox keeps its 16px appearance and gains an expanded click target via a transparent `::before` overlay that is 44px **wide** and **clamped to the row height** (`before:inset-y-0`), so stacked checkboxes never overlap; dense rows give the row itself `min-h-11` for the full 44px-tall target (see "Review findings addressed"). `role=switch` toggles (`switch.tsx`) are **intentionally excluded**. There is no `radio-group` primitive in this repo.

## #884's scoped utility
#884's Settings-scoped `min-h-11` / `:is()` arbitrary-variant util is **not on `main` yet** (it lives on `feat/876-...`), so there's nothing to delete in this PR. Once both land, that scoped util is **redundant and removable** — the app-wide default here covers Settings.

## Verification (unit-level)
- `npm run build` (tsc + vite) — **green**.
- dist CSS proof — `.min-h-11{min-height:calc(var(--spacing)*11)}` with `--spacing:.25rem` = **44px**; the hit-target pseudo rules emit too: `.before\:size-11:before{width/height:calc(var(--spacing)*11)}` (44×44px) and `.before\:min-h-11/min-w-11:before`.
- `vitest run` — **43/43 passed**.
- Biome 2.3.11 — the 4 changed files live under `components/ui`, which the repo `biome.json` intentionally excludes (vendored shadcn); they follow existing file style. The one repo-wide Biome error (`VideoPreviewModal.tsx` import sort) is **pre-existing on `main`**, not from this change.

## Review findings addressed
Confirmed review findings from the adversarial pass are fixed in this PR:

- **DRY / single-source (button.tsx ↔ checkbox.tsx)** — `HIT_TARGET_44` is now **exported** from `button.tsx`; the byte-for-byte duplicate string in `checkbox.tsx` is gone. The checkbox uses its own clamped overlay (below) rather than re-inlining the literal.
- **Stacked-checkbox mis-targeting (HIGH)** — a fixed 44px-tall `::before` overlay overflowed its row and overlapped the neighbour's overlay in dense vertical lists (the MCP-server picker, the tool whitelist), so a click near a row edge could toggle the **wrong** checkbox. Fixed two ways: the checkbox overlay now expands **horizontally** (44px wide) and is **clamped to the row height** (`before:inset-y-0`) so overlays never overlap; and the dense MCP-server rows in `PromptForm.tsx` are now `min-h-11` with a row-spanning `htmlFor` label, making the whole 44px-tall row the click target.
- **Height-only fix → both axes (button/select)** — WCAG 2.5.5 C44 requires `min-block-size` **and** `min-inline-size`. `button` `default`/`lg` and the default `SelectTrigger` now add `min-w-11` alongside `min-h-11`.
- **Toggle primitive left sub-44px** — `toggle.tsx` (`default`/`sm`/`lg`) now meets 44px on both axes via `min-h-11 min-w-11` (box-raise, not an overlay, since toggles sit in horizontally-adjacent groups where an overlay would overlap neighbours).

## Remaining for #898 (why this is `Refs`, not `Closes`)
Two of #898's three acceptance criteria are intentionally **not** in this PR and keep the issue open:

1. **Remove #884's scoped `min-h-11` util.** #884 is still **open** and not on `main`, so there is nothing to delete here yet. To be done once #884 lands.
2. **Live visual-regression sweep + walkthrough video.** Deferred to the serial live-app lane. Surfaces to eyeball for blow-out / overlap once live: `RecordingControlBar`, `ScreenRecorder`, `ShaveAction`/`ShaveFilters` rows, `SettingsDialog` + the `size="sm"`-heavy settings forms, onboarding `StepFooter`/`WorkflowStepCard`, the command palette, and the checkbox lists above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
