### PR TITLE
S✔ ◾ Fix #808: Desktop shaves missing embedUrl/videoFile (backend backstop)

### DIFF
--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -26,8 +26,8 @@ import { McpWorkflowAdapter } from "../services/workflow/mcp-workflow-adapter";
 import { formatNoWorkItemError } from "../services/workflow/no-work-item-error";
 import { PromptSelectionService } from "../services/workflow/prompt-selection-service";
 import {
+  applyPortalVideoFields,
   applyVideoMetadataPersistence,
-  derivePortalVideoFields,
 } from "../services/workflow/video-metadata-persistence";
 import type { CheckpointData } from "../services/workflow/workflow-checkpoint-service";
 import {
@@ -640,15 +640,12 @@ export class ProcessVideoIPCHandlers {
             // #808: The Tenant view renders its preview from the portal payload's video fields.
             // These were previously left to the LLM to copy out of the system prompt during
             // structured extraction, which intermittently dropped them — the exact "missing
-            // embedUrl/videoFile" symptom #808 reports. Set them deterministically from the
+            // embedUrl/videoFile" symptom #808 reports. Override them deterministically from the
             // same authoritative upload result the local backstop uses, so a successful
             // recording ALWAYS carries the embed URL to the portal regardless of model output.
-            const portalVideoFields = derivePortalVideoFields(youtubeResult);
-            if (portalVideoFields) {
-              workItemDto.uploadedVideoProvider = portalVideoFields.uploadedVideoProvider;
-              workItemDto.uploadedVideoEmbedUrl = portalVideoFields.uploadedVideoEmbedUrl;
-              workItemDto.uploadedVideoUrl = portalVideoFields.uploadedVideoUrl;
-            }
+            // The override + its skip-on-null behaviour lives in applyPortalVideoFields so the
+            // wiring (and that it fires BEFORE the portal POST) is unit-testable.
+            applyPortalVideoFields(workItemDto, youtubeResult);
 
             const portalResult = await SendWorkItemDetailsToPortal(workItemDto);
             if (!portalResult.success) {

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -25,7 +25,10 @@ import { YouTubeDownloadService } from "../services/video/youtube-service";
 import { McpWorkflowAdapter } from "../services/workflow/mcp-workflow-adapter";
 import { formatNoWorkItemError } from "../services/workflow/no-work-item-error";
 import { PromptSelectionService } from "../services/workflow/prompt-selection-service";
-import { decideVideoMetadataPersistence } from "../services/workflow/video-metadata-persistence";
+import {
+  applyVideoMetadataPersistence,
+  derivePortalVideoFields,
+} from "../services/workflow/video-metadata-persistence";
 import type { CheckpointData } from "../services/workflow/workflow-checkpoint-service";
 import {
   type RetryResult,
@@ -634,6 +637,19 @@ export class ProcessVideoIPCHandlers {
             workItemDto.projectId = projectDetails.id;
             workItemDto.projectName = projectDetails.name;
 
+            // #808: The Tenant view renders its preview from the portal payload's video fields.
+            // These were previously left to the LLM to copy out of the system prompt during
+            // structured extraction, which intermittently dropped them — the exact "missing
+            // embedUrl/videoFile" symptom #808 reports. Set them deterministically from the
+            // same authoritative upload result the local backstop uses, so a successful
+            // recording ALWAYS carries the embed URL to the portal regardless of model output.
+            const portalVideoFields = derivePortalVideoFields(youtubeResult);
+            if (portalVideoFields) {
+              workItemDto.uploadedVideoProvider = portalVideoFields.uploadedVideoProvider;
+              workItemDto.uploadedVideoEmbedUrl = portalVideoFields.uploadedVideoEmbedUrl;
+              workItemDto.uploadedVideoUrl = portalVideoFields.uploadedVideoUrl;
+            }
+
             const portalResult = await SendWorkItemDetailsToPortal(workItemDto);
             if (!portalResult.success) {
               console.warn("[ProcessVideo] Portal submission failed:", portalResult.error);
@@ -749,29 +765,9 @@ export class ProcessVideoIPCHandlers {
     }
 
     try {
-      const shaveService = ShaveService.getInstance();
-      const existing = shaveService.getShaveById(shaveId);
-      if (!existing) {
-        return;
-      }
-
-      const action = decideVideoMetadataPersistence(youtubeResult, existing.videoEmbedUrl);
-
-      switch (action.kind) {
-        case "attachVideoSource":
-          // Idempotent: attachVideoSourceToShave returns early if a source already exists.
-          shaveService.attachVideoSourceToShave(shaveId, {
-            title: action.title,
-            sourceUrl: action.sourceUrl,
-            durationSeconds: action.durationSeconds,
-          });
-          break;
-        case "setEmbedUrl":
-          shaveService.updateShave(shaveId, { videoEmbedUrl: action.url });
-          break;
-        case "none":
-          break;
-      }
+      // The decision + ShaveService wiring lives in applyVideoMetadataPersistence so it can be
+      // unit-tested against an in-memory store (proving the no-clobber and write branches).
+      applyVideoMetadataPersistence(ShaveService.getInstance(), shaveId, youtubeResult);
     } catch (err) {
       // Non-fatal — the UI progress listener is the other path to this write.
       console.warn(

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -25,6 +25,7 @@ import { YouTubeDownloadService } from "../services/video/youtube-service";
 import { McpWorkflowAdapter } from "../services/workflow/mcp-workflow-adapter";
 import { formatNoWorkItemError } from "../services/workflow/no-work-item-error";
 import { PromptSelectionService } from "../services/workflow/prompt-selection-service";
+import { decideVideoMetadataPersistence } from "../services/workflow/video-metadata-persistence";
 import type { CheckpointData } from "../services/workflow/workflow-checkpoint-service";
 import {
   type RetryResult,
@@ -437,6 +438,15 @@ export class ProcessVideoIPCHandlers {
     try {
       this.lastVideoFilePath = filePath;
 
+      // #808: Persist the video embed URL / source onto the shave record directly from the
+      // authoritative upload result. The UI normally writes this in response to a workflow
+      // progress event, but that event can be missed or coalesced (e.g. the workflow advances
+      // past `uploading_video` before the renderer subscribes, or the renderer's in-memory
+      // dedup set drops it), leaving the saved shave without `videoEmbedUrl`/`videoFile` and so
+      // with no preview in the Tenant view. Writing it here from the backend guarantees the
+      // field is persisted whenever the upload/download succeeded, regardless of UI timing.
+      this.persistVideoMetadataToShave(shaveId, youtubeResult);
+
       // -- CONVERTING_AUDIO --
       if (shouldRunStage(WorkflowProgressStage.CONVERTING_AUDIO)) {
         currentStage = WorkflowProgressStage.CONVERTING_AUDIO;
@@ -714,6 +724,60 @@ export class ProcessVideoIPCHandlers {
       // Note: Temp files and DB records are NOT cleaned up here on failure.
       // They are preserved for potential retry and cleaned up only on success
       // via cleanupTempFiles() or when user cancels the workflow.
+    }
+  }
+
+  /**
+   * #808: Backstop that persists the authoritative video metadata from the upload/download
+   * result onto the shave record, independent of the UI workflow-progress listener.
+   *
+   * - For uploads (origin !== "external"), the embed URL is `youtubeResult.data.url`; it is
+   *   written to `videoEmbedUrl` only when the shave doesn't already have one, so it never
+   *   clobbers a value the UI (or metadata-update) already set.
+   * - For external sources, a video source row is attached via the idempotent
+   *   `attachVideoSourceToShave` (which is a no-op if a source is already linked).
+   *
+   * Best-effort and fully non-fatal: any failure here must not abort the workflow, since the
+   * UI listener remains a second path to the same write.
+   */
+  private persistVideoMetadataToShave(
+    shaveId: string | undefined,
+    youtubeResult: VideoUploadResult,
+  ): void {
+    if (!shaveId) {
+      return;
+    }
+
+    try {
+      const shaveService = ShaveService.getInstance();
+      const existing = shaveService.getShaveById(shaveId);
+      if (!existing) {
+        return;
+      }
+
+      const action = decideVideoMetadataPersistence(youtubeResult, existing.videoEmbedUrl);
+
+      switch (action.kind) {
+        case "attachVideoSource":
+          // Idempotent: attachVideoSourceToShave returns early if a source already exists.
+          shaveService.attachVideoSourceToShave(shaveId, {
+            title: action.title,
+            sourceUrl: action.sourceUrl,
+            durationSeconds: action.durationSeconds,
+          });
+          break;
+        case "setEmbedUrl":
+          shaveService.updateShave(shaveId, { videoEmbedUrl: action.url });
+          break;
+        case "none":
+          break;
+      }
+    } catch (err) {
+      // Non-fatal — the UI progress listener is the other path to this write.
+      console.warn(
+        "[ProcessVideo] Failed to persist video metadata to shave (non-fatal):",
+        formatAndReportError(err, "persist_video_metadata"),
+      );
     }
   }
 

--- a/src/backend/services/workflow/video-metadata-persistence.test.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.test.ts
@@ -274,7 +274,10 @@ describe("derivePortalVideoFields (#808 Tenant view)", () => {
     });
   });
 
-  it("mirrors a non-YouTube URL with no provider/embed synthesis", () => {
+  it("resolves the embeddable player URL for a Vimeo page URL", () => {
+    // A plain vimeo.com/<id> page URL is NOT iframe-embeddable; the embed form is
+    // player.vimeo.com/video/<id>. The Tenant view renders uploadedVideoEmbedUrl in an
+    // <iframe>, so we must synthesize the player URL rather than mirror the page URL.
     const result: VideoUploadResult = {
       success: true,
       origin: "external",
@@ -287,9 +290,50 @@ describe("derivePortalVideoFields (#808 Tenant view)", () => {
     };
 
     expect(derivePortalVideoFields(result)).toEqual({
-      uploadedVideoProvider: null,
+      uploadedVideoProvider: "vimeo",
       uploadedVideoUrl: "https://vimeo.com/123456",
-      uploadedVideoEmbedUrl: "https://vimeo.com/123456",
+      uploadedVideoEmbedUrl: "https://player.vimeo.com/video/123456",
+    });
+  });
+
+  it("forwards the privacy hash of an unlisted Vimeo URL as the player ?h= param", () => {
+    const result: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "x",
+        title: "t",
+        description: "",
+        url: "https://vimeo.com/123456/ab12cd34ef",
+      },
+    };
+
+    expect(derivePortalVideoFields(result)).toEqual({
+      uploadedVideoProvider: "vimeo",
+      uploadedVideoUrl: "https://vimeo.com/123456/ab12cd34ef",
+      uploadedVideoEmbedUrl: "https://player.vimeo.com/video/123456?h=ab12cd34ef",
+    });
+  });
+
+  it("leaves the embed URL null for an unrecognized provider (Tenant view falls back to a link)", () => {
+    // A page URL we can't turn into an iframe-embeddable form must NOT be put in the embed
+    // field, or the Tenant view renders an <iframe> whose src fails to load. Carry the page URL
+    // as uploadedVideoUrl and leave uploadedVideoEmbedUrl null.
+    const result: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "x",
+        title: "t",
+        description: "",
+        url: "https://example.com/videos/some-clip",
+      },
+    };
+
+    expect(derivePortalVideoFields(result)).toEqual({
+      uploadedVideoProvider: null,
+      uploadedVideoUrl: "https://example.com/videos/some-clip",
+      uploadedVideoEmbedUrl: null,
     });
   });
 

--- a/src/backend/services/workflow/video-metadata-persistence.test.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { VideoUploadResult } from "../auth/types";
 import {
+  applyPortalVideoFields,
   applyVideoMetadataPersistence,
   decideVideoMetadataPersistence,
   derivePortalVideoFields,
+  type PortalVideoFieldTarget,
   type VideoMetadataShaveStore,
 } from "./video-metadata-persistence";
 
@@ -349,5 +351,110 @@ describe("derivePortalVideoFields (#808 Tenant view)", () => {
     } as VideoUploadResult;
 
     expect(derivePortalVideoFields(noUrl)).toBeNull();
+  });
+});
+
+/**
+ * #808 (override-wiring gap, mirrors applyVideoMetadataPersistence): the derivation tests above
+ * only prove what SHOULD be carried on the portal payload. These tests exercise the actual
+ * override the IPC handler applies to the WorkItemDto before SendWorkItemDetailsToPortal — that
+ * (a) the three uploadedVideo* fields are overwritten from the upload result, (b) the dto is
+ * otherwise untouched, and (c) a null derivation leaves the model's values in place. Without this,
+ * a future edit could drop or reorder the override after the portal POST and every test stays
+ * green.
+ */
+describe("applyPortalVideoFields wiring (#808 Tenant view)", () => {
+  /** A representative model-produced WorkItemDto slice with model-guessed video fields. */
+  function makeDto(): PortalVideoFieldTarget & {
+    title: string;
+    description: string;
+  } {
+    return {
+      title: "Model Title",
+      description: "Model description",
+      uploadedVideoProvider: "model-guess",
+      uploadedVideoEmbedUrl: "https://model.example/guessed-embed",
+      uploadedVideoUrl: "https://model.example/guessed-url",
+    };
+  }
+
+  it("overrides the three video fields from the upload result (the deterministic fix)", () => {
+    const dto = makeDto();
+    const upload: VideoUploadResult = {
+      success: true,
+      origin: "upload",
+      data: {
+        videoId: "abcdefghijk",
+        title: "t",
+        description: "",
+        url: "https://www.youtube.com/watch?v=abcdefghijk",
+      },
+    };
+
+    const applied = applyPortalVideoFields(dto, upload);
+
+    expect(applied).toEqual({
+      uploadedVideoProvider: "youtube",
+      uploadedVideoUrl: "https://www.youtube.com/watch?v=abcdefghijk",
+      uploadedVideoEmbedUrl: "https://www.youtube.com/embed/abcdefghijk",
+    });
+    expect(dto.uploadedVideoProvider).toBe("youtube");
+    expect(dto.uploadedVideoUrl).toBe("https://www.youtube.com/watch?v=abcdefghijk");
+    expect(dto.uploadedVideoEmbedUrl).toBe("https://www.youtube.com/embed/abcdefghijk");
+  });
+
+  it("leaves the dto's other (model-produced) fields untouched", () => {
+    const dto = makeDto();
+    const upload: VideoUploadResult = {
+      success: true,
+      origin: "upload",
+      data: {
+        videoId: "abcdefghijk",
+        title: "t",
+        description: "",
+        url: "https://www.youtube.com/watch?v=abcdefghijk",
+      },
+    };
+
+    applyPortalVideoFields(dto, upload);
+
+    expect(dto.title).toBe("Model Title");
+    expect(dto.description).toBe("Model description");
+  });
+
+  it("leaves the model's video values in place when the derivation is null (failed upload)", () => {
+    const dto = makeDto();
+    const failed: VideoUploadResult = { success: false, origin: "upload", error: "x" };
+
+    const applied = applyPortalVideoFields(dto, failed);
+
+    expect(applied).toBeNull();
+    // Never overwrite real model output with nulls.
+    expect(dto.uploadedVideoProvider).toBe("model-guess");
+    expect(dto.uploadedVideoEmbedUrl).toBe("https://model.example/guessed-embed");
+    expect(dto.uploadedVideoUrl).toBe("https://model.example/guessed-url");
+  });
+
+  it("clears the embed URL to null for an unrecognized provider (no broken iframe src)", () => {
+    // The model may have guessed an embed URL; for a provider we can't synthesize an embeddable
+    // form for, the override must REPLACE it with null so the Tenant view falls back to a link
+    // rather than rendering an <iframe> whose src fails to load.
+    const dto = makeDto();
+    const upload: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "x",
+        title: "t",
+        description: "",
+        url: "https://example.com/videos/some-clip",
+      },
+    };
+
+    applyPortalVideoFields(dto, upload);
+
+    expect(dto.uploadedVideoProvider).toBeNull();
+    expect(dto.uploadedVideoUrl).toBe("https://example.com/videos/some-clip");
+    expect(dto.uploadedVideoEmbedUrl).toBeNull();
   });
 });

--- a/src/backend/services/workflow/video-metadata-persistence.test.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { VideoUploadResult } from "../auth/types";
+import { decideVideoMetadataPersistence } from "./video-metadata-persistence";
+
+/**
+ * #808: Desktop-recorded YakShaves intermittently saved without `videoEmbedUrl`/`videoFile`.
+ *
+ * The embed URL used to be written ONLY by the UI in response to a workflow-progress event.
+ * When that event was missed or coalesced, the saved shave had no `videoEmbedUrl`, so the
+ * Tenant view rendered no preview. These tests capture the backend backstop decision that now
+ * guarantees the field is persisted from the authoritative upload result.
+ */
+describe("decideVideoMetadataPersistence (#808)", () => {
+  const successfulUpload: VideoUploadResult = {
+    success: true,
+    origin: "upload",
+    data: {
+      videoId: "abc123",
+      title: "My Recording",
+      description: "",
+      url: "https://youtube.com/watch?v=abc123",
+      duration: 42,
+    },
+  };
+
+  it("persists the embed URL for an uploaded video when the shave has none (the bug)", () => {
+    // This is the regression: the UI never wrote videoEmbedUrl (missed/coalesced progress
+    // event), so the shave's videoEmbedUrl is still unset. The backstop must fill it in.
+    const action = decideVideoMetadataPersistence(successfulUpload, null);
+
+    expect(action).toEqual({
+      kind: "setEmbedUrl",
+      url: "https://youtube.com/watch?v=abc123",
+    });
+  });
+
+  it("treats undefined existing embed URL the same as null", () => {
+    const action = decideVideoMetadataPersistence(successfulUpload, undefined);
+
+    expect(action).toEqual({
+      kind: "setEmbedUrl",
+      url: "https://youtube.com/watch?v=abc123",
+    });
+  });
+
+  it("does NOT clobber an embed URL the UI already wrote", () => {
+    // The UI path won the race and already persisted the URL — backstop must be a no-op so it
+    // never overwrites a (possibly metadata-updated) value.
+    const action = decideVideoMetadataPersistence(
+      successfulUpload,
+      "https://youtube.com/watch?v=already-set",
+    );
+
+    expect(action).toEqual({ kind: "none" });
+  });
+
+  it("attaches a video source for external-origin videos", () => {
+    const externalResult: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "ext1",
+        title: "External Video",
+        description: "",
+        url: "https://youtube.com/watch?v=ext1",
+        duration: 100,
+      },
+    };
+
+    const action = decideVideoMetadataPersistence(externalResult, null);
+
+    expect(action).toEqual({
+      kind: "attachVideoSource",
+      title: "External Video",
+      sourceUrl: "https://youtube.com/watch?v=ext1",
+      durationSeconds: 100,
+    });
+  });
+
+  it("uses -1 for unknown duration on external sources", () => {
+    const externalResult: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "ext2",
+        title: "External Video",
+        description: "",
+        url: "https://youtube.com/watch?v=ext2",
+      },
+    };
+
+    const action = decideVideoMetadataPersistence(externalResult, null);
+
+    expect(action).toEqual({
+      kind: "attachVideoSource",
+      title: "External Video",
+      sourceUrl: "https://youtube.com/watch?v=ext2",
+      durationSeconds: -1,
+    });
+  });
+
+  it("does nothing when the upload did not succeed", () => {
+    const failed: VideoUploadResult = {
+      success: false,
+      origin: "upload",
+      error: "upload failed",
+    };
+
+    expect(decideVideoMetadataPersistence(failed, null)).toEqual({ kind: "none" });
+  });
+
+  it("does nothing when there is no URL even if marked successful", () => {
+    const noUrl = {
+      success: true,
+      origin: "upload",
+      data: { videoId: "x", title: "x", description: "", url: "" },
+    } as VideoUploadResult;
+
+    expect(decideVideoMetadataPersistence(noUrl, null)).toEqual({ kind: "none" });
+  });
+});

--- a/src/backend/services/workflow/video-metadata-persistence.test.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { VideoUploadResult } from "../auth/types";
-import { decideVideoMetadataPersistence } from "./video-metadata-persistence";
+import {
+  applyVideoMetadataPersistence,
+  decideVideoMetadataPersistence,
+  derivePortalVideoFields,
+  type VideoMetadataShaveStore,
+} from "./video-metadata-persistence";
 
 /**
  * #808: Desktop-recorded YakShaves intermittently saved without `videoEmbedUrl`/`videoFile`.
@@ -117,5 +122,188 @@ describe("decideVideoMetadataPersistence (#808)", () => {
     } as VideoUploadResult;
 
     expect(decideVideoMetadataPersistence(noUrl, null)).toEqual({ kind: "none" });
+  });
+});
+
+/**
+ * #808 (one-sided-verification gap): the decision tests above only prove what SHOULD be written.
+ * These tests exercise the actual wiring — applyVideoMetadataPersistence -> ShaveService writes —
+ * against an in-memory fake, proving the backstop really persists the embed URL when missing and
+ * really skips the write when one already exists (no clobber), plus the external-source branch.
+ */
+describe("applyVideoMetadataPersistence wiring (#808)", () => {
+  const successfulUpload: VideoUploadResult = {
+    success: true,
+    origin: "upload",
+    data: {
+      videoId: "abc123",
+      title: "My Recording",
+      description: "",
+      url: "https://www.youtube.com/watch?v=abc123",
+      duration: 42,
+    },
+  };
+
+  function makeStore(existing: { videoEmbedUrl?: string | null } | undefined): {
+    store: VideoMetadataShaveStore;
+    updateShave: ReturnType<typeof vi.fn>;
+    attachVideoSourceToShave: ReturnType<typeof vi.fn>;
+  } {
+    const updateShave = vi.fn();
+    const attachVideoSourceToShave = vi.fn();
+    const store: VideoMetadataShaveStore = {
+      getShaveById: () => existing,
+      updateShave,
+      attachVideoSourceToShave,
+    };
+    return { store, updateShave, attachVideoSourceToShave };
+  }
+
+  it("writes videoEmbedUrl when the shave has none (the backstop fires)", () => {
+    const { store, updateShave, attachVideoSourceToShave } = makeStore({ videoEmbedUrl: null });
+
+    const action = applyVideoMetadataPersistence(store, "shave-1", successfulUpload);
+
+    expect(action).toEqual({ kind: "setEmbedUrl", url: "https://www.youtube.com/watch?v=abc123" });
+    expect(updateShave).toHaveBeenCalledTimes(1);
+    expect(updateShave).toHaveBeenCalledWith("shave-1", {
+      videoEmbedUrl: "https://www.youtube.com/watch?v=abc123",
+    });
+    expect(attachVideoSourceToShave).not.toHaveBeenCalled();
+  });
+
+  it("does NOT write when the shave already has an embed URL (no clobber)", () => {
+    const { store, updateShave, attachVideoSourceToShave } = makeStore({
+      videoEmbedUrl: "https://www.youtube.com/watch?v=already-set",
+    });
+
+    const action = applyVideoMetadataPersistence(store, "shave-1", successfulUpload);
+
+    expect(action).toEqual({ kind: "none" });
+    expect(updateShave).not.toHaveBeenCalled();
+    expect(attachVideoSourceToShave).not.toHaveBeenCalled();
+  });
+
+  it("attaches a video source for external origins (not updateShave)", () => {
+    const external: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "ext1",
+        title: "External Video",
+        description: "",
+        url: "https://www.youtube.com/watch?v=ext1",
+        duration: 100,
+      },
+    };
+    const { store, updateShave, attachVideoSourceToShave } = makeStore({ videoEmbedUrl: null });
+
+    const action = applyVideoMetadataPersistence(store, "shave-1", external);
+
+    expect(action.kind).toBe("attachVideoSource");
+    expect(attachVideoSourceToShave).toHaveBeenCalledWith("shave-1", {
+      title: "External Video",
+      sourceUrl: "https://www.youtube.com/watch?v=ext1",
+      durationSeconds: 100,
+    });
+    expect(updateShave).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when there is no shave id", () => {
+    const { store, updateShave, attachVideoSourceToShave } = makeStore({ videoEmbedUrl: null });
+
+    expect(applyVideoMetadataPersistence(store, undefined, successfulUpload)).toEqual({
+      kind: "none",
+    });
+    expect(updateShave).not.toHaveBeenCalled();
+    expect(attachVideoSourceToShave).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the shave is not found", () => {
+    const { store, updateShave, attachVideoSourceToShave } = makeStore(undefined);
+
+    expect(applyVideoMetadataPersistence(store, "missing", successfulUpload)).toEqual({
+      kind: "none",
+    });
+    expect(updateShave).not.toHaveBeenCalled();
+    expect(attachVideoSourceToShave).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * #808 (Tenant-view payload): the portal WorkItemDto video fields must be set deterministically
+ * from the authoritative upload result — never left to the LLM to copy. These tests prove the
+ * derivation that the IPC handler applies before posting to the portal.
+ */
+describe("derivePortalVideoFields (#808 Tenant view)", () => {
+  it("derives provider/url/embed from a YouTube watch URL", () => {
+    const result: VideoUploadResult = {
+      success: true,
+      origin: "upload",
+      data: {
+        videoId: "abcdefghijk",
+        title: "t",
+        description: "",
+        url: "https://www.youtube.com/watch?v=abcdefghijk",
+      },
+    };
+
+    expect(derivePortalVideoFields(result)).toEqual({
+      uploadedVideoProvider: "youtube",
+      uploadedVideoUrl: "https://www.youtube.com/watch?v=abcdefghijk",
+      uploadedVideoEmbedUrl: "https://www.youtube.com/embed/abcdefghijk",
+    });
+  });
+
+  it("normalizes youtu.be short links to canonical watch + embed forms", () => {
+    const result: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "abcdefghijk",
+        title: "t",
+        description: "",
+        url: "https://youtu.be/abcdefghijk",
+      },
+    };
+
+    expect(derivePortalVideoFields(result)).toEqual({
+      uploadedVideoProvider: "youtube",
+      uploadedVideoUrl: "https://www.youtube.com/watch?v=abcdefghijk",
+      uploadedVideoEmbedUrl: "https://www.youtube.com/embed/abcdefghijk",
+    });
+  });
+
+  it("mirrors a non-YouTube URL with no provider/embed synthesis", () => {
+    const result: VideoUploadResult = {
+      success: true,
+      origin: "external",
+      data: {
+        videoId: "x",
+        title: "t",
+        description: "",
+        url: "https://vimeo.com/123456",
+      },
+    };
+
+    expect(derivePortalVideoFields(result)).toEqual({
+      uploadedVideoProvider: null,
+      uploadedVideoUrl: "https://vimeo.com/123456",
+      uploadedVideoEmbedUrl: "https://vimeo.com/123456",
+    });
+  });
+
+  it("returns null when the upload failed (caller leaves model output untouched)", () => {
+    expect(derivePortalVideoFields({ success: false, origin: "upload", error: "x" })).toBeNull();
+  });
+
+  it("returns null when there is no URL", () => {
+    const noUrl = {
+      success: true,
+      origin: "upload",
+      data: { videoId: "x", title: "x", description: "", url: "" },
+    } as VideoUploadResult;
+
+    expect(derivePortalVideoFields(noUrl)).toBeNull();
   });
 });

--- a/src/backend/services/workflow/video-metadata-persistence.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.ts
@@ -1,0 +1,57 @@
+import type { VideoUploadResult } from "../auth/types";
+
+/**
+ * Describes what (if anything) must be written to the shave record to ensure its video
+ * metadata (videoEmbedUrl / video source) is persisted from an authoritative upload result.
+ *
+ * #808: Desktop-recorded shaves intermittently saved without `videoEmbedUrl`/`videoFile`
+ * because that write happened only on the UI side in response to a workflow-progress event,
+ * which could be missed/coalesced. The backend now uses this decision to write the field
+ * directly from the upload result as a backstop.
+ */
+export type VideoMetadataPersistenceAction =
+  | { kind: "none" }
+  | { kind: "setEmbedUrl"; url: string }
+  | { kind: "attachVideoSource"; title: string; sourceUrl: string; durationSeconds: number };
+
+/**
+ * Pure decision for how to persist video metadata onto a shave record.
+ *
+ * @param youtubeResult The authoritative upload/download result for the video.
+ * @param existingEmbedUrl The shave's currently-persisted videoEmbedUrl (null/undefined if unset).
+ * @returns The write action to apply, or `{ kind: "none" }` when nothing should change.
+ *
+ * Rules (mirror the UI listener in useShaveManager so the two paths agree):
+ * - No-op unless the upload succeeded and produced a usable URL.
+ * - External sources attach a video source row (idempotency is handled downstream by
+ *   attachVideoSourceToShave, which no-ops if a source is already linked).
+ * - Uploads set `videoEmbedUrl`, but only when the shave doesn't already have one — so this
+ *   backstop never clobbers a value already written by the UI or a metadata update.
+ */
+export function decideVideoMetadataPersistence(
+  youtubeResult: VideoUploadResult,
+  existingEmbedUrl: string | null | undefined,
+): VideoMetadataPersistenceAction {
+  if (!youtubeResult.success || !youtubeResult.data?.url) {
+    return { kind: "none" };
+  }
+
+  const { url, title, duration } = youtubeResult.data;
+
+  if (youtubeResult.origin === "external") {
+    return {
+      kind: "attachVideoSource",
+      title,
+      sourceUrl: url,
+      // -1 explicitly indicates unknown duration (mirrors the UI path).
+      durationSeconds: duration ?? -1,
+    };
+  }
+
+  // Upload origin: only fill the embed URL when it isn't already set.
+  if (existingEmbedUrl) {
+    return { kind: "none" };
+  }
+
+  return { kind: "setEmbedUrl", url };
+}

--- a/src/backend/services/workflow/video-metadata-persistence.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.ts
@@ -188,6 +188,49 @@ export function derivePortalVideoFields(
 }
 
 /**
+ * The minimal slice of the portal WorkItemDto that {@link applyPortalVideoFields} overrides — the
+ * three deterministic video fields the Tenant view renders its preview from. Typed structurally
+ * (rather than importing WorkItemDto from the portal module) to keep this workflow helper free of
+ * a portal dependency; the real WorkItemDto is a structural supertype of this.
+ */
+export type PortalVideoFieldTarget = {
+  uploadedVideoProvider: string | null;
+  uploadedVideoEmbedUrl: string | null;
+  uploadedVideoUrl: string | null;
+};
+
+/**
+ * Override the portal WorkItemDto's video fields with the deterministic derivation from the
+ * authoritative upload result, mirroring {@link applyVideoMetadataPersistence} for the local DB.
+ *
+ * #808: The Tenant view renders its preview from the portal payload's `uploadedVideo*` fields.
+ * Those were previously left to the LLM to copy out of the system prompt during structured
+ * extraction, which intermittently dropped them. This applies the deterministic override the IPC
+ * handler performs before `SendWorkItemDetailsToPortal`, extracted so the wiring is unit-testable:
+ * - when the derivation yields fields, all three are overwritten on the dto from the upload result;
+ * - when it returns `null` (no usable URL), the dto is left exactly as the model produced it —
+ *   we never overwrite real model output with nulls.
+ *
+ * Mutates `dto` in place (matching the handler's existing behaviour) and returns the applied
+ * fields, or `null` when nothing was overridden.
+ */
+export function applyPortalVideoFields(
+  dto: PortalVideoFieldTarget,
+  youtubeResult: VideoUploadResult,
+): PortalVideoFields | null {
+  const fields = derivePortalVideoFields(youtubeResult);
+  if (!fields) {
+    return null;
+  }
+
+  dto.uploadedVideoProvider = fields.uploadedVideoProvider;
+  dto.uploadedVideoEmbedUrl = fields.uploadedVideoEmbedUrl;
+  dto.uploadedVideoUrl = fields.uploadedVideoUrl;
+
+  return fields;
+}
+
+/**
  * Resolves the iframe-embeddable Vimeo player URL from a Vimeo page URL, else null.
  *
  * A plain `vimeo.com/<id>` page URL is NOT iframe-embeddable; Vimeo's embeddable form is

--- a/src/backend/services/workflow/video-metadata-persistence.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.ts
@@ -1,3 +1,4 @@
+import { normalizeYouTubeUrl } from "../../utils/youtube-url-utils";
 import type { VideoUploadResult } from "../auth/types";
 
 /**
@@ -54,4 +55,133 @@ export function decideVideoMetadataPersistence(
   }
 
   return { kind: "setEmbedUrl", url };
+}
+
+/**
+ * Minimal slice of ShaveService that {@link applyVideoMetadataPersistence} depends on, so the
+ * wiring (action -> ShaveService write) can be exercised against an in-memory fake.
+ */
+export interface VideoMetadataShaveStore {
+  getShaveById(id: string): { videoEmbedUrl?: string | null } | undefined;
+  updateShave(id: string, data: { videoEmbedUrl: string }): unknown;
+  attachVideoSourceToShave(
+    id: string,
+    videoSource: { title: string; sourceUrl: string; durationSeconds: number },
+  ): unknown;
+}
+
+/**
+ * Apply the video-metadata persistence backstop for a shave: read the shave's current embed URL,
+ * {@link decideVideoMetadataPersistence decide} what (if anything) to write, and perform the
+ * corresponding ShaveService write.
+ *
+ * Extracted from the IPC handler so the wiring is unit-testable: a successful upload with no
+ * existing embed URL MUST call `updateShave({ videoEmbedUrl })`; one whose shave already has an
+ * embed URL MUST NOT (no clobber); external origins attach a (downstream-idempotent) source.
+ *
+ * Returns the action that was applied (useful for assertions/logging). No-ops — returning
+ * `{ kind: "none" }` — when there's no shave id, no shave, or nothing to persist.
+ */
+export function applyVideoMetadataPersistence(
+  store: VideoMetadataShaveStore,
+  shaveId: string | undefined,
+  youtubeResult: VideoUploadResult,
+): VideoMetadataPersistenceAction {
+  if (!shaveId) {
+    return { kind: "none" };
+  }
+
+  const existing = store.getShaveById(shaveId);
+  if (!existing) {
+    return { kind: "none" };
+  }
+
+  const action = decideVideoMetadataPersistence(youtubeResult, existing.videoEmbedUrl);
+
+  switch (action.kind) {
+    case "attachVideoSource":
+      // Idempotent: attachVideoSourceToShave returns early if a source already exists.
+      store.attachVideoSourceToShave(shaveId, {
+        title: action.title,
+        sourceUrl: action.sourceUrl,
+        durationSeconds: action.durationSeconds,
+      });
+      break;
+    case "setEmbedUrl":
+      store.updateShave(shaveId, { videoEmbedUrl: action.url });
+      break;
+    case "none":
+      break;
+  }
+
+  return action;
+}
+
+/**
+ * The authoritative video fields that must be carried on the portal WorkItemDto so the Tenant
+ * view can render a preview.
+ *
+ * #808: The Tenant-view preview is driven by the portal payload's
+ * `uploadedVideoEmbedUrl` / `uploadedVideoUrl` / `uploadedVideoProvider`. Those fields were
+ * previously left to the LLM to copy out of the system prompt during structured extraction,
+ * which is non-deterministic and intermittently dropped them — exactly the "missing
+ * embedUrl/videoFile" symptom #808 reports. We instead derive them deterministically from the
+ * same authoritative upload result that the local backstop uses.
+ */
+export interface PortalVideoFields {
+  uploadedVideoProvider: string | null;
+  uploadedVideoEmbedUrl: string | null;
+  uploadedVideoUrl: string | null;
+}
+
+/**
+ * Derive the portal WorkItemDto video fields from the authoritative upload/download result.
+ *
+ * Returns `null` when the result carries no usable URL, signalling the caller to leave whatever
+ * the model produced untouched (we never want to overwrite a real value with nulls).
+ *
+ * When a URL is present we always return all three fields together so the caller can override
+ * the model-derived values atomically:
+ * - `uploadedVideoUrl` is the canonical watch URL (normalized for YouTube, otherwise as-is).
+ * - `uploadedVideoEmbedUrl` is the `/embed/` form for YouTube, otherwise the same URL.
+ * - `uploadedVideoProvider` is `"youtube"` for recognizable YouTube URLs, otherwise null.
+ */
+export function derivePortalVideoFields(
+  youtubeResult: VideoUploadResult,
+): PortalVideoFields | null {
+  const url = youtubeResult.success ? youtubeResult.data?.url : undefined;
+  if (!url) {
+    return null;
+  }
+
+  const normalized = normalizeYouTubeUrl(url);
+  const youtubeId = extractYouTubeId(normalized);
+
+  if (youtubeId) {
+    return {
+      uploadedVideoProvider: "youtube",
+      uploadedVideoUrl: `https://www.youtube.com/watch?v=${youtubeId}`,
+      uploadedVideoEmbedUrl: `https://www.youtube.com/embed/${youtubeId}`,
+    };
+  }
+
+  // Non-YouTube URL: still carry it deterministically, but we can't synthesize an embed form
+  // or claim a provider, so mirror the raw URL and leave the provider unknown.
+  return {
+    uploadedVideoProvider: null,
+    uploadedVideoUrl: url,
+    uploadedVideoEmbedUrl: url,
+  };
+}
+
+/** Extracts the 11-char video id from a normalized `watch?v=ID` YouTube URL, else null. */
+function extractYouTubeId(normalizedUrl: string | null): string | null {
+  if (!normalizedUrl) return null;
+  try {
+    const parsed = new URL(normalizedUrl);
+    const id = parsed.searchParams.get("v");
+    return id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/backend/services/workflow/video-metadata-persistence.ts
+++ b/src/backend/services/workflow/video-metadata-persistence.ts
@@ -142,9 +142,12 @@ export interface PortalVideoFields {
  *
  * When a URL is present we always return all three fields together so the caller can override
  * the model-derived values atomically:
- * - `uploadedVideoUrl` is the canonical watch URL (normalized for YouTube, otherwise as-is).
- * - `uploadedVideoEmbedUrl` is the `/embed/` form for YouTube, otherwise the same URL.
- * - `uploadedVideoProvider` is `"youtube"` for recognizable YouTube URLs, otherwise null.
+ * - `uploadedVideoUrl` is the canonical watch/page URL (normalized for YouTube, otherwise as-is).
+ * - `uploadedVideoEmbedUrl` is an iframe-embeddable URL for recognized providers (YouTube's
+ *   `/embed/` form, Vimeo's `player.vimeo.com/video/` form), otherwise `null` — because a plain
+ *   provider page URL is NOT iframe-embeddable, and the Tenant view should fall back to a link
+ *   rather than render an `<iframe>` whose `src` fails to load.
+ * - `uploadedVideoProvider` is `"youtube"`/`"vimeo"` for recognizable URLs, otherwise null.
  */
 export function derivePortalVideoFields(
   youtubeResult: VideoUploadResult,
@@ -165,13 +168,71 @@ export function derivePortalVideoFields(
     };
   }
 
-  // Non-YouTube URL: still carry it deterministically, but we can't synthesize an embed form
-  // or claim a provider, so mirror the raw URL and leave the provider unknown.
+  const vimeoEmbedUrl = deriveVimeoEmbedUrl(url);
+  if (vimeoEmbedUrl) {
+    return {
+      uploadedVideoProvider: "vimeo",
+      uploadedVideoUrl: url,
+      uploadedVideoEmbedUrl: vimeoEmbedUrl,
+    };
+  }
+
+  // Unrecognized provider: carry the page URL deterministically, but we can't synthesize an
+  // iframe-embeddable form, so leave the embed URL null (the Tenant view falls back to a link
+  // instead of rendering an <iframe> whose src would fail to load) and the provider unknown.
   return {
     uploadedVideoProvider: null,
     uploadedVideoUrl: url,
-    uploadedVideoEmbedUrl: url,
+    uploadedVideoEmbedUrl: null,
   };
+}
+
+/**
+ * Resolves the iframe-embeddable Vimeo player URL from a Vimeo page URL, else null.
+ *
+ * A plain `vimeo.com/<id>` page URL is NOT iframe-embeddable; Vimeo's embeddable form is
+ * `https://player.vimeo.com/video/<id>`. Unlisted videos carry a privacy hash as the second
+ * path segment (`vimeo.com/<id>/<hash>`) which must be forwarded as the `h` query param so the
+ * player will load them. We only synthesize from a numeric video id we recognize.
+ *
+ * Examples:
+ * - https://vimeo.com/123456            -> https://player.vimeo.com/video/123456
+ * - https://vimeo.com/123456/ab12cd34ef -> https://player.vimeo.com/video/123456?h=ab12cd34ef
+ * - https://player.vimeo.com/video/123456?h=ab12cd34ef (already embeddable) -> unchanged form
+ */
+function deriveVimeoEmbedUrl(rawUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const host = parsed.hostname.replace(/^www\./, "");
+  const segments = parsed.pathname.split("/").filter(Boolean);
+
+  // Already an embeddable player URL: player.vimeo.com/video/<id>[?h=<hash>]
+  if (host === "player.vimeo.com") {
+    if (segments[0] === "video" && /^\d+$/.test(segments[1] ?? "")) {
+      const hash = parsed.searchParams.get("h");
+      const base = `https://player.vimeo.com/video/${segments[1]}`;
+      return hash ? `${base}?h=${hash}` : base;
+    }
+    return null;
+  }
+
+  if (host !== "vimeo.com") {
+    return null;
+  }
+
+  // Page URL: vimeo.com/<id>[/<hash>]
+  const [videoId, privacyHash] = segments;
+  if (!videoId || !/^\d+$/.test(videoId)) {
+    return null;
+  }
+
+  const base = `https://player.vimeo.com/video/${videoId}`;
+  return privacyHash ? `${base}?h=${privacyHash}` : base;
 }
 
 /** Extracts the 11-char video id from a normalized `watch?v=ID` YouTube URL, else null. */


### PR DESCRIPTION
Fixes #808.

## Root cause
#808 reports the symptom in the **Tenant view** (the portal/web app): YakShaves recorded from the Desktop source are missing the `videoFile`/`embedUrl`, so the Tenant view renders no preview.

The Tenant-view preview is driven **exclusively by the portal `WorkItemDto`'s `uploadedVideo*` fields** (`uploadedVideoProvider` / `uploadedVideoEmbedUrl` / `uploadedVideoUrl`). Those fields were previously left to the **LLM** to copy out of the system prompt during structured extraction (`orchestrator.convertToObjectAsync(mcpResult, WorkItemDtoSchema)`) — a non-deterministic step that intermittently dropped them. That is the exact "missing embedUrl/videoFile" symptom #808 reports.

(Separately, the desktop app's own thumbnail list — `VideoThumbnail.tsx` / `ShaveCards.tsx` — reads the **local** `videoEmbedUrl` DB column, which was written only on the renderer side in reaction to a race-prone `uploading_video`/`downloading_video` progress event. That column is desktop-only and is **never** sent to the portal, so it cannot affect the Tenant view — see the backstop note below.)

## Fix — the Tenant-view payload (this is what resolves #808)
Set the portal `WorkItemDto`'s `uploadedVideo*` fields **deterministically** from the authoritative upload result, overriding whatever the model produced, before `SendWorkItemDetailsToPortal` (`src/backend/ipc/process-video-handlers.ts`). A successful recording now ALWAYS carries the embed URL to the portal regardless of model output.

The derivation + override are extracted into pure, unit-testable helpers (`src/backend/services/workflow/video-metadata-persistence.ts`):
- `derivePortalVideoFields(result)` — derives `{ provider, url, embedUrl }`, synthesizing an **iframe-embeddable** form for recognized providers (YouTube `/embed/`, Vimeo `player.vimeo.com/video/<id>[?h=]`), and leaving `embedUrl` null for unrecognized providers so the Tenant view falls back to a link rather than a broken `<iframe>` src. Returns `null` (leave model output untouched) when there's no usable URL.
- `applyPortalVideoFields(dto, result)` — applies that derivation onto the `WorkItemDto` (mirrors the local-DB `applyVideoMetadataPersistence` helper), so the override wiring is unit-testable: it fires before the portal POST, overwrites only the three video fields, and is skipped on a null derivation.

## Secondary fix — local-DB backstop (desktop-thumbnail robustness, not the Tenant view)
A **separate** improvement, independent of #808's Tenant-view symptom: a backend backstop in `processVideoSource` persists the **local** `videoEmbedUrl` column / attaches the video source directly from the authoritative result, so the desktop app's own thumbnail list is robust to the renderer-side progress-event race. This column is desktop-only and is **never** transmitted to the portal, so it does not (and cannot) change the Tenant-view preview — it is included here because it shares the same authoritative result and fixes a real, adjacent desktop-side gap.

- **Upload origin** → set local `videoEmbedUrl`, only when the shave doesn't already have one (never clobbers a UI/metadata-update write).
- **External origin** → attach a video source via the idempotent `attachVideoSourceToShave`.
- No-op when the upload didn't succeed or produced no URL. Best-effort / non-fatal.

## Tests
`src/backend/services/workflow/video-metadata-persistence.test.ts` — DB-free unit tests:
- **Tenant-view payload** (the #808 fix): `derivePortalVideoFields` provider/url/embed derivation (YouTube, `youtu.be`, Vimeo page + unlisted hash, unrecognized provider, failed/no-URL); `applyPortalVideoFields` override wiring (overwrites the three fields, leaves other dto fields untouched, skips on null derivation, clears a model-guessed embed URL to null for unrecognized providers).
- **Local backstop** (desktop-thumbnail robustness): `decideVideoMetadataPersistence` + `applyVideoMetadataPersistence` wiring against an in-memory store (writes when missing, no-clobber, external attach, no-op branches).

## Verification
- `npm run build` (tsc): green
- `npx vitest run --exclude '**/db/**'` : 187 passed (DB-backed suites excluded — better-sqlite3 native ABI mismatch in this env; ffmpeg native binary unsupported on win32-arm64, both pre-existing and unrelated)
- `npx biome check` on changed files: clean

## Pending — live walkthrough (required to close #808)
#808's acceptance criterion is **behavioural and Tenant-side**: a real Desktop recording must land in the portal and render a preview in the Tenant view consistently. That portal → Tenant render path is **not** demonstrated by the unit tests, which prove only the deterministic derivation/override and the local-DB wiring. Per repo house rules this needs a **live repro-then-fix walkthrough** demonstrating the AC: record via Desktop on a remote project, confirm the portal payload carries `uploadedVideoEmbedUrl`, and confirm the Tenant view renders the preview. Tracking that before considering #808 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
