### PR TITLE
XS✔ ◾ Fix #754: clear Processing tab output when a new run starts

### DIFF
--- a/src/ui/src/components/workflow/FinalResultPanel.test.tsx
+++ b/src/ui/src/components/workflow/FinalResultPanel.test.tsx
@@ -1,0 +1,157 @@
+import { ProgressStage, type WorkflowState, type WorkflowStatus } from "@shared/types/workflow";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FinalResultPanel } from "./FinalResultPanel";
+
+// Capture the renderer-side workflow progress callback so the test can drive
+// the panel through a full run and then a second run, exactly as the IPC bridge
+// would at runtime.
+const { onProgressNeo, onStepUpdate, progressCallbacks } = vi.hoisted(() => {
+  const callbacks: ((data: unknown) => void)[] = [];
+  return {
+    progressCallbacks: callbacks,
+    onProgressNeo: vi.fn((cb: (data: unknown) => void) => {
+      callbacks.push(cb);
+      return () => {};
+    }),
+    onStepUpdate: vi.fn(() => () => {}),
+  };
+});
+
+vi.mock("@/services/ipc-client", () => ({
+  ipcClient: {
+    workflow: { onProgressNeo },
+    mcp: { onStepUpdate },
+  },
+}));
+
+const STAGES = [
+  ProgressStage.UPLOADING_VIDEO,
+  ProgressStage.DOWNLOADING_VIDEO,
+  ProgressStage.CONVERTING_AUDIO,
+  ProgressStage.TRANSCRIBING,
+  ProgressStage.ANALYZING_TRANSCRIPT,
+  ProgressStage.SELECTING_PROMPT,
+  ProgressStage.EXECUTING_TASK,
+  ProgressStage.UPDATING_METADATA,
+] as const;
+
+/** Build a WorkflowState with every stage set to `not_started`, then override. */
+function buildState(overrides: Partial<Record<ProgressStage, WorkflowStatus>>): WorkflowState {
+  const state = {} as WorkflowState;
+  for (const stage of STAGES) {
+    state[stage] = { stage, status: overrides[stage] ?? "not_started" };
+  }
+  return state;
+}
+
+function withExecutingPayload(state: WorkflowState, finalOutput: string): WorkflowState {
+  state.executing_task = {
+    stage: ProgressStage.EXECUTING_TASK,
+    status: "completed",
+    payload: JSON.stringify({ finalOutput }),
+  };
+  return state;
+}
+
+function emit(state: WorkflowState) {
+  act(() => {
+    for (const cb of progressCallbacks) {
+      cb({ shaveId: "shave-1", state });
+    }
+  });
+}
+
+// A YouTube/external run: UPLOADING is skipped, DOWNLOADING runs first.
+function completedYouTubeRun(finalOutput: string): WorkflowState {
+  const state = buildState({
+    [ProgressStage.UPLOADING_VIDEO]: "skipped",
+    [ProgressStage.DOWNLOADING_VIDEO]: "completed",
+    [ProgressStage.CONVERTING_AUDIO]: "completed",
+    [ProgressStage.TRANSCRIBING]: "completed",
+    [ProgressStage.ANALYZING_TRANSCRIPT]: "completed",
+    [ProgressStage.SELECTING_PROMPT]: "completed",
+    [ProgressStage.EXECUTING_TASK]: "completed",
+    [ProgressStage.UPDATING_METADATA]: "completed",
+  });
+  return withExecutingPayload(state, finalOutput);
+}
+
+describe("FinalResultPanel — clears previous output on a new run (#754)", () => {
+  beforeEach(() => {
+    progressCallbacks.length = 0;
+    onProgressNeo.mockClear();
+    onStepUpdate.mockClear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("clears the previous run's output the moment a new YouTube download starts, before new output arrives", () => {
+    render(<FinalResultPanel />);
+
+    // First run finishes and renders its final output.
+    emit(completedYouTubeRun(JSON.stringify({ Status: "success", Title: "First run result" })));
+    expect(screen.getByText(/First run result/)).toBeInTheDocument();
+
+    // A new YouTube link is processed: DOWNLOADING_VIDEO becomes in_progress
+    // while the video downloads — no new final output exists yet.
+    emit(
+      buildState({
+        [ProgressStage.UPLOADING_VIDEO]: "skipped",
+        [ProgressStage.DOWNLOADING_VIDEO]: "in_progress",
+      }),
+    );
+
+    // The stale output from the previous run must be gone immediately, even
+    // though the new run has produced no output yet (panel renders nothing).
+    expect(screen.queryByText(/First run result/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Final Result/)).not.toBeInTheDocument();
+  });
+
+  it("still clears for the recording (upload) path", () => {
+    render(<FinalResultPanel />);
+
+    // First run finishes (recording path: UPLOADING ran, DOWNLOADING skipped).
+    const firstRun = buildState({
+      [ProgressStage.DOWNLOADING_VIDEO]: "skipped",
+      [ProgressStage.UPLOADING_VIDEO]: "completed",
+      [ProgressStage.CONVERTING_AUDIO]: "completed",
+      [ProgressStage.TRANSCRIBING]: "completed",
+      [ProgressStage.ANALYZING_TRANSCRIPT]: "completed",
+      [ProgressStage.SELECTING_PROMPT]: "completed",
+      [ProgressStage.EXECUTING_TASK]: "completed",
+      [ProgressStage.UPDATING_METADATA]: "completed",
+    });
+    emit(
+      withExecutingPayload(firstRun, JSON.stringify({ Status: "success", Title: "Recording A" })),
+    );
+    expect(screen.getByText(/Recording A/)).toBeInTheDocument();
+
+    // New recording starts uploading — stale output clears immediately.
+    emit(
+      buildState({
+        [ProgressStage.DOWNLOADING_VIDEO]: "skipped",
+        [ProgressStage.UPLOADING_VIDEO]: "in_progress",
+      }),
+    );
+    expect(screen.queryByText(/Recording A/)).not.toBeInTheDocument();
+  });
+
+  it("shows the new run's output once it completes", () => {
+    render(<FinalResultPanel />);
+
+    emit(completedYouTubeRun(JSON.stringify({ Status: "success", Title: "First run result" })));
+    expect(screen.getByText(/First run result/)).toBeInTheDocument();
+
+    // New download starts (clears), then the second run completes with new output.
+    emit(
+      buildState({
+        [ProgressStage.UPLOADING_VIDEO]: "skipped",
+        [ProgressStage.DOWNLOADING_VIDEO]: "in_progress",
+      }),
+    );
+    expect(screen.queryByText(/First run result/)).not.toBeInTheDocument();
+
+    emit(completedYouTubeRun(JSON.stringify({ Status: "success", Title: "Second run result" })));
+    expect(screen.getByText(/Second run result/)).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/components/workflow/FinalResultPanel.tsx
+++ b/src/ui/src/components/workflow/FinalResultPanel.tsx
@@ -636,15 +636,28 @@ export function FinalResultPanel() {
       const currentStage = getActiveStage(state);
       const previousStage = stageRef.current;
 
+      // A fresh run begins by ingesting the video: recordings start at
+      // UPLOADING_VIDEO and YouTube/external links start at DOWNLOADING_VIDEO
+      // (issue #754 — the download path never cleared the previous run's
+      // output, so it lingered until CONVERTING_AUDIO began after the download
+      // finished). Clearing on the ingest stage wipes stale output the moment a
+      // new run starts, before any new output arrives.
+      const isNewIngestStage =
+        (currentStage === WorkflowProgressStage.UPLOADING_VIDEO ||
+          currentStage === WorkflowProgressStage.DOWNLOADING_VIDEO) &&
+        previousStage !== WorkflowProgressStage.UPLOADING_VIDEO &&
+        previousStage !== WorkflowProgressStage.DOWNLOADING_VIDEO;
+
       const isNewRecordingStage =
         currentStage === WorkflowProgressStage.CONVERTING_AUDIO &&
         previousStage !== WorkflowProgressStage.CONVERTING_AUDIO;
 
+      // Retry reruns start mid-pipeline at EXECUTING_TASK and skip ingest.
       const isRetryStage =
         currentStage === WorkflowProgressStage.EXECUTING_TASK &&
         previousStage !== WorkflowProgressStage.EXECUTING_TASK;
 
-      if (isNewRecordingStage || isRetryStage) {
+      if (isNewIngestStage || isNewRecordingStage || isRetryStage) {
         resetForNewRun();
       }
 


### PR DESCRIPTION
Fixes #754

## Root cause
The **Processing tab** (`WorkflowPage`) renders the `FinalResultPanel`, which keeps the previous run's `finalOutput` in state until a new run explicitly resets it. `resetForNewRun()` was only triggered when the active stage entered `CONVERTING_AUDIO` (a new recording) or `EXECUTING_TASK` (a retry).

A YouTube / external-link run **skips** `UPLOADING_VIDEO` and begins at `DOWNLOADING_VIDEO`. That stage never matched a reset trigger, so the previous run's **Final Result** stayed on screen for the entire download, only clearing once the download finished and `CONVERTING_AUDIO` started — exactly the behaviour reported in the issue.

## Fix
`FinalResultPanel` now also resets when the active stage first transitions into an **ingest** stage (`UPLOADING_VIDEO` or `DOWNLOADING_VIDEO`). This clears the stale output the moment a new run starts — before any new output arrives — covering both the recording (upload) and YouTube/external (download) paths. The existing `CONVERTING_AUDIO` / `EXECUTING_TASK` triggers are kept so retry reruns (which start mid-pipeline and skip ingest) still reset.

Files:
- `src/ui/src/components/workflow/FinalResultPanel.tsx` — add ingest-stage reset trigger
- `src/ui/src/components/workflow/FinalResultPanel.test.tsx` — new component test

## Test
New deterministic component test (mocks the workflow progress IPC callback and drives the panel):
1. YouTube download path — stale output clears the instant `DOWNLOADING_VIDEO` goes `in_progress`, before new output exists (the bug).
2. Recording upload path — same clearing on `UPLOADING_VIDEO`.
3. The new run's output still renders once it completes.

Verified the test **fails without the fix** (3/3 fail) and **passes with it** (3/3 pass).

## Build / lint
- `npm run build` (src/ui) — green
- `@biomejs/biome@2.3.11 check` on both changed files — clean
- Full src/ui vitest suite — 46/46 pass

## Acceptance criteria
- [x] Output panel cleared immediately when a new run starts
- [x] No previous-run output visible during a new video download
- [x] Processing tab reflects only the current run
- [x] Download / processing workflow unchanged (state-only render fix)

## Live QA pending
Code-only environment (no running app / CDP). Needs live verification in the Desktop app: process a YouTube link to completion, add a second link, click **Process**, and confirm the previous Final Result disappears immediately while the new video downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)