### PR TITLE
XS✔ ◾ ✨ Clear action when processing fails (#733)

### DIFF
--- a/src/ui/src/components/workflow/FinalResultPanel.test.tsx
+++ b/src/ui/src/components/workflow/FinalResultPanel.test.tsx
@@ -1,0 +1,92 @@
+import { ProgressStage, type WorkflowState, type WorkflowStatus } from "@shared/types/workflow";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKFLOW_CLEAR_EVENT_CHANNEL } from "../../types/index";
+import { FinalResultPanel } from "./FinalResultPanel";
+
+type ProgressCallback = (payload: unknown) => void;
+
+// Captures the renderer's progress listener so the test can push workflow state
+// the same way the main process would over IPC.
+let progressCallback: ProgressCallback | undefined;
+
+// FinalResultPanel reaches the IPC layer via the `ipcClient` singleton (bound to
+// window.electronAPI at module load), so mock the module rather than the window.
+vi.mock("../../services/ipc-client", () => ({
+  ipcClient: {
+    workflow: {
+      onProgressNeo: (cb: ProgressCallback) => {
+        progressCallback = cb;
+        return () => {
+          progressCallback = undefined;
+        };
+      },
+    },
+    mcp: {
+      onStepUpdate: () => () => {},
+    },
+  },
+}));
+
+function makeStep(status: WorkflowStatus, stage: ProgressStage, payload?: string) {
+  return { stage, status, payload };
+}
+
+// A run that produced a final output AND then had its metadata stage fail — the
+// reachable state where the progress panel shows the failure banner/Clear while
+// the Final Result card is also on screen (#733, #904 orphan finding).
+function makeFinalOutputWithMetadataFailureState(): WorkflowState {
+  return {
+    uploading_video: makeStep("completed", ProgressStage.UPLOADING_VIDEO),
+    downloading_video: makeStep("not_started", ProgressStage.DOWNLOADING_VIDEO),
+    converting_audio: makeStep("completed", ProgressStage.CONVERTING_AUDIO),
+    transcribing: makeStep("completed", ProgressStage.TRANSCRIBING),
+    analyzing_transcript: makeStep("completed", ProgressStage.ANALYZING_TRANSCRIPT),
+    selecting_prompt: makeStep("completed", ProgressStage.SELECTING_PROMPT),
+    executing_task: makeStep(
+      "completed",
+      ProgressStage.EXECUTING_TASK,
+      JSON.stringify({ finalOutput: "All done — backlog item created." }),
+    ),
+    updating_metadata: makeStep("failed", ProgressStage.UPDATING_METADATA),
+  };
+}
+
+beforeEach(() => {
+  progressCallback = undefined;
+});
+
+afterEach(() => {
+  progressCallback = undefined;
+});
+
+describe("FinalResultPanel — clear coexistence (#733/#904)", () => {
+  it("renders the Final Result card once a final output is produced", () => {
+    render(<FinalResultPanel />);
+
+    expect(screen.queryByText("Final Result")).not.toBeInTheDocument();
+
+    act(() => {
+      progressCallback?.({ shaveId: "shave-1", state: makeFinalOutputWithMetadataFailureState() });
+    });
+
+    expect(screen.getByText("Final Result")).toBeInTheDocument();
+  });
+
+  it("clears the orphaned Final Result card when the workflow-clear event fires", () => {
+    render(<FinalResultPanel />);
+
+    act(() => {
+      progressCallback?.({ shaveId: "shave-1", state: makeFinalOutputWithMetadataFailureState() });
+    });
+    expect(screen.getByText("Final Result")).toBeInTheDocument();
+
+    // The progress panel's Clear button broadcasts this event; the Final Result
+    // card must reset too instead of lingering orphaned on the page.
+    act(() => {
+      window.dispatchEvent(new CustomEvent(WORKFLOW_CLEAR_EVENT_CHANNEL));
+    });
+
+    expect(screen.queryByText("Final Result")).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/src/components/workflow/FinalResultPanel.tsx
+++ b/src/ui/src/components/workflow/FinalResultPanel.tsx
@@ -12,7 +12,11 @@ import {
 import { useClipboard } from "../../hooks/useClipboard";
 import { ipcClient } from "../../services/ipc-client";
 import { type MCPStep, MCPStepType, ShaveStatus, type VideoUploadResult } from "../../types";
-import { UNDO_EVENT_CHANNEL, type UndoEventDetail } from "../../types/index";
+import {
+  UNDO_EVENT_CHANNEL,
+  type UndoEventDetail,
+  WORKFLOW_CLEAR_EVENT_CHANNEL,
+} from "../../types/index";
 import { LoadingState } from "../common/LoadingState";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -620,6 +624,23 @@ export function FinalResultPanel() {
     setLastUndoPrompt(null);
     emitUndoEvent("reset");
   }, []);
+
+  // The user cleared the run from the processing screen (#733). Fully reset the
+  // panel — including the run-scoped upload/intermediate/shave state that a normal
+  // new-recording transition would otherwise repopulate — so the Final Result card
+  // does not linger orphaned after the progress panel is dismissed.
+  const handleWorkflowCleared = useCallback(() => {
+    resetForNewRun();
+    setIntermediateOutput(undefined);
+    setUploadResult(undefined);
+    setShaveId(undefined);
+    stageRef.current = null;
+  }, [resetForNewRun]);
+
+  useEffect(() => {
+    window.addEventListener(WORKFLOW_CLEAR_EVENT_CHANNEL, handleWorkflowCleared);
+    return () => window.removeEventListener(WORKFLOW_CLEAR_EVENT_CHANNEL, handleWorkflowCleared);
+  }, [handleWorkflowCleared]);
 
   useEffect(() => {
     return ipcClient.workflow.onProgressNeo((data: unknown) => {

--- a/src/ui/src/components/workflow/StageWithContent.tsx
+++ b/src/ui/src/components/workflow/StageWithContent.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, Check, ChevronRight, Play, Wrench, X } from "lucide-react";
 import type React from "react";
 import { type MCPStep, MCPStepType, type MetadataPreview, type VideoChapter } from "../../types";
-import { deepParseJson, formatToolName } from "../../utils";
+import { deepParseJson, formatToolName, isErrorStep } from "../../utils";
 import { ReasoningStep } from "./ReasoningStep";
 
 interface StageWithContentProps {
@@ -88,13 +88,6 @@ function ToolResultSuccess({ result }: { result: unknown }) {
         </details>
       )}
     </div>
-  );
-}
-
-export function isErrorStep(step: MCPStep): boolean {
-  return (
-    (step.type === MCPStepType.TOOL_RESULT && Boolean(step.error)) ||
-    step.type === MCPStepType.TOOL_DENIED
   );
 }
 

--- a/src/ui/src/components/workflow/WorkflowProgressPanel.test.tsx
+++ b/src/ui/src/components/workflow/WorkflowProgressPanel.test.tsx
@@ -2,6 +2,8 @@ import { ProgressStage, type WorkflowState, type WorkflowStatus } from "@shared/
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MCPStepType } from "@/types";
+import { WORKFLOW_CLEAR_EVENT_CHANNEL } from "../../types/index";
 import { WorkflowProgressPanel } from "./WorkflowProgressPanel";
 
 type ProgressCallback = (payload: unknown) => void;
@@ -25,22 +27,43 @@ function stubElectronApi() {
   });
 }
 
-function makeStep(status: WorkflowStatus) {
-  return { stage: ProgressStage.UPLOADING_VIDEO, status };
+function makeStep(status: WorkflowStatus, stage: ProgressStage = ProgressStage.UPLOADING_VIDEO) {
+  return { stage, status };
+}
+
+function makeIdleState(): WorkflowState {
+  return {
+    uploading_video: makeStep("not_started", ProgressStage.UPLOADING_VIDEO),
+    downloading_video: makeStep("not_started", ProgressStage.DOWNLOADING_VIDEO),
+    converting_audio: makeStep("not_started", ProgressStage.CONVERTING_AUDIO),
+    transcribing: makeStep("not_started", ProgressStage.TRANSCRIBING),
+    analyzing_transcript: makeStep("not_started", ProgressStage.ANALYZING_TRANSCRIPT),
+    selecting_prompt: makeStep("not_started", ProgressStage.SELECTING_PROMPT),
+    executing_task: makeStep("not_started", ProgressStage.EXECUTING_TASK),
+    updating_metadata: makeStep("not_started", ProgressStage.UPDATING_METADATA),
+  };
 }
 
 // A workflow state where the upload stage has failed and everything else is idle.
 function makeFailedState(): WorkflowState {
-  return {
-    uploading_video: makeStep("failed"),
-    downloading_video: makeStep("not_started"),
-    converting_audio: makeStep("not_started"),
-    transcribing: makeStep("not_started"),
-    analyzing_transcript: makeStep("not_started"),
-    selecting_prompt: makeStep("not_started"),
-    executing_task: makeStep("not_started"),
-    updating_metadata: makeStep("not_started"),
+  const state = makeIdleState();
+  state.uploading_video = makeStep("failed", ProgressStage.UPLOADING_VIDEO);
+  return state;
+}
+
+// A run that the backend marked "completed" because the backlog item was created,
+// yet whose executing_task payload still carries a tool-error step — the case the
+// per-step card renders red but the raw-status failure check used to miss (#733).
+function makeCompletedWithErrorsState(): WorkflowState {
+  const state = makeIdleState();
+  state.executing_task = {
+    stage: ProgressStage.EXECUTING_TASK,
+    status: "completed",
+    payload: JSON.stringify({
+      steps: [{ type: MCPStepType.TOOL_RESULT, error: "tool blew up" }],
+    }),
   };
+  return state;
 }
 
 afterEach(() => {
@@ -92,5 +115,63 @@ describe("WorkflowProgressPanel — clear on processing failure (#733)", () => {
     expect(
       screen.queryByRole("button", { name: /clear failed workflow/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a Clear action when executing_task completed with error steps in its payload", () => {
+    stubElectronApi();
+
+    render(<WorkflowProgressPanel />);
+
+    act(() => {
+      progressCallback?.({ shaveId: "shave-err", state: makeCompletedWithErrorsState() });
+    });
+
+    expect(screen.getByText("AI Workflow Progress")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /clear failed workflow/i })).toBeInTheDocument();
+    expect(screen.getByText(/processing failed/i)).toBeInTheDocument();
+  });
+
+  it("re-populates the panel after Clear when a fresh run arrives (Clear is a soft dismiss)", async () => {
+    stubElectronApi();
+    const user = userEvent.setup();
+
+    render(<WorkflowProgressPanel />);
+
+    act(() => {
+      progressCallback?.({ shaveId: "shave-1", state: makeFailedState() });
+    });
+
+    await user.click(screen.getByRole("button", { name: /clear failed workflow/i }));
+    expect(screen.queryByText("AI Workflow Progress")).not.toBeInTheDocument();
+
+    // The listener stays subscribed, so a brand-new run still drives the panel.
+    const fresh = makeFailedState();
+    fresh.uploading_video = makeStep("in_progress");
+    act(() => {
+      progressCallback?.({ shaveId: "shave-2", state: fresh });
+    });
+
+    expect(screen.getByText("AI Workflow Progress")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /clear failed workflow/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("broadcasts a workflow-clear event so sibling panels reset together", async () => {
+    stubElectronApi();
+    const user = userEvent.setup();
+    const onClear = vi.fn();
+    window.addEventListener(WORKFLOW_CLEAR_EVENT_CHANNEL, onClear);
+
+    render(<WorkflowProgressPanel />);
+
+    act(() => {
+      progressCallback?.({ shaveId: "shave-1", state: makeFailedState() });
+    });
+
+    await user.click(screen.getByRole("button", { name: /clear failed workflow/i }));
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+    window.removeEventListener(WORKFLOW_CLEAR_EVENT_CHANNEL, onClear);
   });
 });

--- a/src/ui/src/components/workflow/WorkflowProgressPanel.test.tsx
+++ b/src/ui/src/components/workflow/WorkflowProgressPanel.test.tsx
@@ -1,0 +1,96 @@
+import { ProgressStage, type WorkflowState, type WorkflowStatus } from "@shared/types/workflow";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorkflowProgressPanel } from "./WorkflowProgressPanel";
+
+type ProgressCallback = (payload: unknown) => void;
+
+// Captures the renderer's progress listener so the test can push workflow state
+// updates the same way the main process would over IPC.
+let progressCallback: ProgressCallback | undefined;
+
+function stubElectronApi() {
+  const onProgressNeo = vi.fn((cb: ProgressCallback) => {
+    progressCallback = cb;
+    return () => {
+      progressCallback = undefined;
+    };
+  });
+
+  Object.defineProperty(window, "electronAPI", {
+    configurable: true,
+    writable: true,
+    value: { workflow: { onProgressNeo } },
+  });
+}
+
+function makeStep(status: WorkflowStatus) {
+  return { stage: ProgressStage.UPLOADING_VIDEO, status };
+}
+
+// A workflow state where the upload stage has failed and everything else is idle.
+function makeFailedState(): WorkflowState {
+  return {
+    uploading_video: makeStep("failed"),
+    downloading_video: makeStep("not_started"),
+    converting_audio: makeStep("not_started"),
+    transcribing: makeStep("not_started"),
+    analyzing_transcript: makeStep("not_started"),
+    selecting_prompt: makeStep("not_started"),
+    executing_task: makeStep("not_started"),
+    updating_metadata: makeStep("not_started"),
+  };
+}
+
+afterEach(() => {
+  progressCallback = undefined;
+});
+
+describe("WorkflowProgressPanel — clear on processing failure (#733)", () => {
+  it("shows a Clear action when a run has failed and resets the panel when clicked", async () => {
+    stubElectronApi();
+    const user = userEvent.setup();
+
+    render(<WorkflowProgressPanel />);
+
+    // Nothing renders until a progress update arrives.
+    expect(screen.queryByText("AI Workflow Progress")).not.toBeInTheDocument();
+
+    // Push a failed workflow state, as the main process would.
+    act(() => {
+      progressCallback?.({ shaveId: "shave-1", state: makeFailedState() });
+    });
+
+    expect(screen.getByText("AI Workflow Progress")).toBeInTheDocument();
+    const clearButton = screen.getByRole("button", { name: /clear failed workflow/i });
+    expect(clearButton).toBeInTheDocument();
+    expect(screen.getByText(/processing failed/i)).toBeInTheDocument();
+
+    // Clearing dismisses the failed run and returns the panel to its empty state.
+    await user.click(clearButton);
+
+    expect(screen.queryByText("AI Workflow Progress")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /clear failed workflow/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show a Clear action while a run is still in progress", () => {
+    stubElectronApi();
+
+    render(<WorkflowProgressPanel />);
+
+    const inProgressState = makeFailedState();
+    inProgressState.uploading_video = makeStep("in_progress");
+
+    act(() => {
+      progressCallback?.({ shaveId: "shave-2", state: inProgressState });
+    });
+
+    expect(screen.getByText("AI Workflow Progress")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /clear failed workflow/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/src/components/workflow/WorkflowProgressPanel.tsx
+++ b/src/ui/src/components/workflow/WorkflowProgressPanel.tsx
@@ -1,6 +1,8 @@
 import { WORKFLOW_STAGE_ORDER, type WorkflowState } from "@shared/types/workflow";
+import { AlertTriangle, X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { parseWorkflowProgressNeoPayload } from "@/utils";
+import { isWorkflowFailed, parseWorkflowProgressNeoPayload } from "@/utils";
+import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { WorkflowStepCard } from "./WorkflowStepCard";
 
@@ -32,7 +34,16 @@ export function WorkflowProgressPanel() {
     return cleanup;
   }, []);
 
+  // Dismiss a finished/failed run and return the processing screen to its ready
+  // state so the user can start fresh without restarting the app (#733).
+  const handleClear = () => {
+    setState(null);
+    setShaveId(undefined);
+  };
+
   if (state) {
+    const hasFailed = isWorkflowFailed(state);
+
     return (
       <div className="w-[500px] mx-auto my-4">
         <Card className="bg-black/20 backdrop-blur-md border-white/10">
@@ -48,6 +59,27 @@ export function WorkflowProgressPanel() {
                 shaveId={shaveId}
               />
             ))}
+
+            {hasFailed && (
+              <div className="mt-4 flex flex-col gap-3 rounded-lg border border-red-500/30 bg-red-500/5 p-3">
+                <div className="flex items-start gap-2 text-sm text-red-400/90">
+                  <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+                  <span>
+                    Processing failed. Retry a step above, or clear this run to start fresh.
+                  </span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClear}
+                  className="self-start"
+                  aria-label="Clear failed workflow"
+                >
+                  <X className="size-4" />
+                  Clear
+                </Button>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/src/ui/src/components/workflow/WorkflowProgressPanel.tsx
+++ b/src/ui/src/components/workflow/WorkflowProgressPanel.tsx
@@ -2,6 +2,7 @@ import { WORKFLOW_STAGE_ORDER, type WorkflowState } from "@shared/types/workflow
 import { AlertTriangle, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { isWorkflowFailed, parseWorkflowProgressNeoPayload } from "@/utils";
+import { WORKFLOW_CLEAR_EVENT_CHANNEL } from "../../types/index";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { WorkflowStepCard } from "./WorkflowStepCard";
@@ -35,10 +36,13 @@ export function WorkflowProgressPanel() {
   }, []);
 
   // Dismiss a finished/failed run and return the processing screen to its ready
-  // state so the user can start fresh without restarting the app (#733).
+  // state so the user can start fresh without restarting the app (#733). The
+  // sibling FinalResultPanel holds its own state, so broadcast a clear event to
+  // reset both panels together rather than orphaning the Final Result card.
   const handleClear = () => {
     setState(null);
     setShaveId(undefined);
+    window.dispatchEvent(new CustomEvent(WORKFLOW_CLEAR_EVENT_CHANNEL));
   };
 
   if (state) {

--- a/src/ui/src/components/workflow/WorkflowStepCard.tsx
+++ b/src/ui/src/components/workflow/WorkflowStepCard.tsx
@@ -3,12 +3,12 @@ import { CheckCircle2, ChevronDown, ChevronRight, Loader2, RefreshCw, XCircle } 
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { formatErrorMessage } from "@/utils";
+import { formatErrorMessage, isErrorStep } from "@/utils";
 import { ipcClient } from "../../services/ipc-client";
 import type { MCPStep } from "../../types";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
-import { isErrorStep, StageWithContent } from "./StageWithContent";
+import { StageWithContent } from "./StageWithContent";
 
 const STATUS_CONFIG = {
   in_progress: {

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -133,6 +133,14 @@ export type UndoEventDetail = {
   type: "start" | "complete" | "error" | "reset";
 };
 
+/**
+ * Dispatched when the user clears a failed/finished run from the processing screen
+ * (#733). The progress panel and the final-result panel hold independent state, so
+ * the panel that owns the Clear button broadcasts this event to let the sibling
+ * panels reset together rather than leaving an orphaned Final Result card behind.
+ */
+export const WORKFLOW_CLEAR_EVENT_CHANNEL = "yakshaver:workflow-clear";
+
 export enum MCPStepType {
   START = "start",
   REASONING = "reasoning",

--- a/src/ui/src/utils/index.test.ts
+++ b/src/ui/src/utils/index.test.ts
@@ -1,5 +1,27 @@
+import { ProgressStage, type WorkflowState, type WorkflowStatus } from "@shared/types/workflow";
 import { describe, expect, it } from "vitest";
-import { formatKeyAsTitle } from "./";
+import { formatKeyAsTitle, isWorkflowFailed } from "./";
+
+function makeStep(status: WorkflowStatus) {
+  return { stage: ProgressStage.UPLOADING_VIDEO, status };
+}
+
+function makeState(overrides: Partial<Record<keyof WorkflowState, WorkflowStatus>>): WorkflowState {
+  const base: WorkflowState = {
+    uploading_video: makeStep("not_started"),
+    downloading_video: makeStep("not_started"),
+    converting_audio: makeStep("not_started"),
+    transcribing: makeStep("not_started"),
+    analyzing_transcript: makeStep("not_started"),
+    selecting_prompt: makeStep("not_started"),
+    executing_task: makeStep("not_started"),
+    updating_metadata: makeStep("not_started"),
+  };
+  for (const [key, status] of Object.entries(overrides)) {
+    base[key as keyof WorkflowState] = makeStep(status as WorkflowStatus);
+  }
+  return base;
+}
 
 describe("formatKeyAsTitle", () => {
   it("converts camelCase to spaced title case", () => {
@@ -32,5 +54,27 @@ describe("formatKeyAsTitle", () => {
 
   it("handles consecutive uppercase acronyms separated by words", () => {
     expect(formatKeyAsTitle("parseHTMLContent")).toBe("Parse HTML Content");
+  });
+});
+
+describe("isWorkflowFailed", () => {
+  it("returns true when any stage has failed", () => {
+    expect(isWorkflowFailed(makeState({ executing_task: "failed" }))).toBe(true);
+  });
+
+  it("returns true when the first stage fails early", () => {
+    expect(isWorkflowFailed(makeState({ uploading_video: "failed" }))).toBe(true);
+  });
+
+  it("returns false while a run is still in progress", () => {
+    expect(isWorkflowFailed(makeState({ uploading_video: "in_progress" }))).toBe(false);
+  });
+
+  it("returns false for a fully completed run", () => {
+    const completed = makeState({});
+    for (const key of Object.keys(completed) as (keyof WorkflowState)[]) {
+      completed[key] = makeStep("completed");
+    }
+    expect(isWorkflowFailed(completed)).toBe(false);
   });
 });

--- a/src/ui/src/utils/index.test.ts
+++ b/src/ui/src/utils/index.test.ts
@@ -1,5 +1,6 @@
 import { ProgressStage, type WorkflowState, type WorkflowStatus } from "@shared/types/workflow";
 import { describe, expect, it } from "vitest";
+import { MCPStepType } from "@/types";
 import { formatKeyAsTitle, isWorkflowFailed } from "./";
 
 function makeStep(status: WorkflowStatus) {
@@ -76,5 +77,29 @@ describe("isWorkflowFailed", () => {
       completed[key] = makeStep("completed");
     }
     expect(isWorkflowFailed(completed)).toBe(false);
+  });
+
+  it("returns true when executing_task completed but its payload has a tool-error step", () => {
+    const state = makeState({ executing_task: "completed" });
+    state.executing_task.payload = JSON.stringify({
+      steps: [{ type: MCPStepType.TOOL_RESULT, error: "boom" }],
+    });
+    expect(isWorkflowFailed(state)).toBe(true);
+  });
+
+  it("returns true when executing_task completed but its payload has a tool-denied step", () => {
+    const state = makeState({ executing_task: "completed" });
+    state.executing_task.payload = JSON.stringify({
+      steps: [{ type: MCPStepType.TOOL_DENIED, message: "denied" }],
+    });
+    expect(isWorkflowFailed(state)).toBe(true);
+  });
+
+  it("returns false when executing_task completed with only successful steps", () => {
+    const state = makeState({ executing_task: "completed" });
+    state.executing_task.payload = JSON.stringify({
+      steps: [{ type: MCPStepType.TOOL_RESULT, result: "ok" }],
+    });
+    expect(isWorkflowFailed(state)).toBe(false);
   });
 });

--- a/src/ui/src/utils/index.ts
+++ b/src/ui/src/utils/index.ts
@@ -3,6 +3,7 @@ import {
   type WorkflowState,
   type WorkflowStep,
 } from "@shared/types/workflow";
+import { type MCPStep, MCPStepType } from "@/types";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -48,12 +49,48 @@ export function isWorkflowReadyForFinalOutput(state: WorkflowState): boolean {
 }
 
 /**
- * A workflow run has failed when any of its stages reports a "failed" status.
+ * A single MCP step represents a failure when a tool result carried an error or a
+ * tool call was denied. This is the canonical "did this step error" signal shared
+ * by the per-step rendering and the panel-level failure predicate.
+ */
+export function isErrorStep(step: MCPStep): boolean {
+  return (
+    (step.type === MCPStepType.TOOL_RESULT && Boolean(step.error)) ||
+    step.type === MCPStepType.TOOL_DENIED
+  );
+}
+
+/**
+ * The executing_task stage can report a raw status of "completed" while its payload
+ * still contains error/denied steps (the backend completes the run whenever the
+ * backlog item was created, regardless of mid-run tool errors). In that case the
+ * run is effectively failed — WorkflowStepCard already renders it red. This helper
+ * reads the parsed executing_task payload and reports whether it holds any error
+ * steps so every consumer agrees on the same "effective failure" contract.
+ */
+export function hasExecutingTaskErrors(state: WorkflowState): boolean {
+  const parsed = parseWorkflowStepPayload(state.executing_task);
+  if (!isRecord(parsed) || !Array.isArray(parsed.steps)) {
+    return false;
+  }
+  return (parsed.steps as MCPStep[]).some(isErrorStep);
+}
+
+/**
+ * A workflow run has failed when any of its stages reports a raw "failed" status,
+ * OR when the executing_task stage completed but its payload contains error/denied
+ * steps (the effective-failure case WorkflowStepCard already surfaces as red).
+ *
  * Used to surface a clear/recover action on the processing screen so a stuck or
  * errored run can be dismissed instead of leaving the panel hung indefinitely.
+ * Keeping this in lock-step with the per-step effective-failure logic ensures the
+ * Clear action appears for every failure mode the user can actually see (#733).
  */
 export function isWorkflowFailed(state: WorkflowState): boolean {
-  return WORKFLOW_STAGE_ORDER.some((stage) => state[stage].status === "failed");
+  return (
+    WORKFLOW_STAGE_ORDER.some((stage) => state[stage].status === "failed") ||
+    (state.executing_task.status === "completed" && hasExecutingTaskErrors(state))
+  );
 }
 
 /**

--- a/src/ui/src/utils/index.ts
+++ b/src/ui/src/utils/index.ts
@@ -48,6 +48,15 @@ export function isWorkflowReadyForFinalOutput(state: WorkflowState): boolean {
 }
 
 /**
+ * A workflow run has failed when any of its stages reports a "failed" status.
+ * Used to surface a clear/recover action on the processing screen so a stuck or
+ * errored run can be dismissed instead of leaving the panel hung indefinitely.
+ */
+export function isWorkflowFailed(state: WorkflowState): boolean {
+  return WORKFLOW_STAGE_ORDER.some((stage) => state[stage].status === "failed");
+}
+
+/**
  * Recursively parses JSON strings within nested objects and arrays.
  * If a string is valid JSON, it will be parsed and the function will continue parsing its contents.
  * Useful for deeply parsing objects that may contain JSON-encoded strings at any level.


### PR DESCRIPTION
Closes #733

## Pain
When a processing run fails, the workflow progress panel stayed on the failed/stuck steps indefinitely with no clear action to recover — users had to restart the app.

## What this adds
A panel-level **Clear** action on the processing screen (`WorkflowProgressPanel`):

- When any workflow stage reports a `failed` status, a short error banner appears: _"Processing failed. Retry a step above, or clear this run to start fresh."_
- A **Clear** button (reuses the existing `Button` primitive, `outline`/`sm`, with an `X` icon to match nearby styling) resets the panel back to its ready/empty state so the user can start a new recording without restarting the app.
- Per-step **Retry** (already present in `WorkflowStepCard`) is unchanged — Clear is the new dismiss/reset path the issue asked for.

Implementation:
- New `isWorkflowFailed(state)` helper in `src/ui/src/utils/index.ts` (true when any stage status is `failed`).
- `WorkflowProgressPanel` shows the failure banner + Clear button and clears `state`/`shaveId` on click.

## Tests
- `src/ui/src/utils/index.test.ts` — unit tests for `isWorkflowFailed` (failed / in-progress / completed cases).
- `src/ui/src/components/workflow/WorkflowProgressPanel.test.tsx` — component tests (jsdom + RTL): clicking Clear resets the panel (failure banner + button gone), and Clear is hidden while a run is still in progress.

## Verification
- `npm run build` (src/ui): green
- `vitest run` for the changed area: 14 passed
- Biome: clean on changed files

## Live QA pending
This was implemented code-only in an isolated worktree (no running app). Still needs live QA in the running Electron app:
- Trigger a real processing failure and confirm the banner + Clear button appear and Clear returns the screen to ready.
- Confirm Clear interplay with the per-step Retry and the `FinalResultPanel` reprocess/undo flows looks right in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)