### PR TITLE
XS⚠️ ◾ Improve permission prompt copy (#783)

### DIFF
--- a/src/ui/src/components/workflow/ApprovalDialog.tsx
+++ b/src/ui/src/components/workflow/ApprovalDialog.tsx
@@ -40,6 +40,38 @@ function getServiceIcon(serverName: string | null): ReactElement {
   return <Terminal className="w-5 h-5 text-white/70" />;
 }
 
+/**
+ * Extracts the raw, unformatted tool id from a prefixed MCP tool name, i.e. the
+ * segment after the server prefix. Handles both the "__" (MCP system) and "."
+ * (AI output) separators, e.g. "Yak_Video_Tools__capture_video_frame" and
+ * "Yak_Video_Tools.capture_video_frame" both yield "capture_video_frame".
+ */
+function rawToolId(rawToolName: string): string {
+  const dunderIndex = rawToolName.indexOf("__");
+  if (dunderIndex !== -1) {
+    return rawToolName.slice(dunderIndex + 2);
+  }
+  const dotIndex = rawToolName.indexOf(".");
+  if (dotIndex !== -1) {
+    return rawToolName.slice(dotIndex + 1);
+  }
+  return rawToolName;
+}
+
+/**
+ * Plain-language explanations of why specific tools are needed, so non-technical
+ * users can make an informed choice (issue #783 AC2). Returns null for tools
+ * without a bespoke explanation, in which case the generic description is used.
+ */
+function getToolPurpose(rawToolName: string): string | null {
+  switch (rawToolId(rawToolName)) {
+    case "capture_video_frame":
+      return "YakShaver wants to capture a still frame from your screen recording so it can see what you're pointing at and keep working on your task accurately. It only runs when you say it's OK.";
+    default:
+      return null;
+  }
+}
+
 export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDialogProps) {
   const payload = request.payload as ToolApprovalPayload;
   const { toolName } = payload;
@@ -141,9 +173,16 @@ export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDia
   const dialogTitle = readableToolInfo
     ? `Can YakShaver use "${readableToolInfo.tool}"?`
     : "Can YakShaver perform this action?";
-  const dialogDescription = readableToolInfo?.server
-    ? `To keep working on your task, YakShaver needs to use the "${readableToolInfo.tool}" tool (from ${readableToolInfo.server}). It only runs when you say it's OK.`
-    : `To keep working on your task, YakShaver needs to perform an action. It only runs when you say it's OK.`;
+
+  // Some tools have a clear, user-facing purpose that non-technical users benefit
+  // from understanding (issue #783 AC2). Keyed on the raw, unformatted tool id so it
+  // survives both MCP separators ("__" and ".") and any display-label changes.
+  const toolPurpose = toolName ? getToolPurpose(toolName) : null;
+  const dialogDescription =
+    toolPurpose ??
+    (readableToolInfo?.server
+      ? `To keep working on your task, YakShaver needs to use the "${readableToolInfo.tool}" tool (from ${readableToolInfo.server}). It only runs when you say it's OK.`
+      : `To keep working on your task, YakShaver needs to perform an action. It only runs when you say it's OK.`);
 
   return (
     <AlertDialog open={isOpen}>
@@ -168,8 +207,9 @@ export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDia
               use {`"${toolLabel}"`} now and skip this prompt next time.
             </li>
             <li>
-              <span className="font-medium text-white/90">Don't Allow</span> &mdash; skip this step.
-              YakShaver won't use {`"${toolLabel}"`}, and you can tell it what to do instead.
+              <span className="font-medium text-white/90">Review / Correct&hellip;</span> &mdash;
+              don't run {`"${toolLabel}"`} as-is. You can leave a note telling YakShaver what to
+              change and try again, or stop the step entirely.
             </li>
           </ul>
         )}
@@ -264,7 +304,7 @@ export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDia
                   setShowCorrectionForm(true);
                 }}
               >
-                Don't Allow
+                Review / Correct&hellip;
               </AlertDialogCancel>
               <Button
                 type="button"

--- a/src/ui/src/components/workflow/ApprovalDialog.tsx
+++ b/src/ui/src/components/workflow/ApprovalDialog.tsx
@@ -2,7 +2,7 @@ import type { InteractionRequest, ToolApprovalPayload } from "@shared/types/user
 import { Terminal } from "lucide-react";
 import { type ReactElement, useCallback, useEffect, useState } from "react";
 import { ipcClient } from "../../services/ipc-client";
-import { formatErrorMessage, parseToolName } from "../../utils";
+import { formatErrorMessage, parseToolName, splitToolName } from "../../utils";
 import { LoadingState } from "../common/LoadingState";
 import { AzureDevOpsIcon } from "../settings/mcp/devops/devops-icon";
 import { GitHubIcon } from "../settings/mcp/github/github-icon";
@@ -41,30 +41,15 @@ function getServiceIcon(serverName: string | null): ReactElement {
 }
 
 /**
- * Extracts the raw, unformatted tool id from a prefixed MCP tool name, i.e. the
- * segment after the server prefix. Handles both the "__" (MCP system) and "."
- * (AI output) separators, e.g. "Yak_Video_Tools__capture_video_frame" and
- * "Yak_Video_Tools.capture_video_frame" both yield "capture_video_frame".
- */
-function rawToolId(rawToolName: string): string {
-  const dunderIndex = rawToolName.indexOf("__");
-  if (dunderIndex !== -1) {
-    return rawToolName.slice(dunderIndex + 2);
-  }
-  const dotIndex = rawToolName.indexOf(".");
-  if (dotIndex !== -1) {
-    return rawToolName.slice(dotIndex + 1);
-  }
-  return rawToolName;
-}
-
-/**
  * Plain-language explanations of why specific tools are needed, so non-technical
  * users can make an informed choice (issue #783 AC2). Returns null for tools
  * without a bespoke explanation, in which case the generic description is used.
+ *
+ * Keyed on the raw, unformatted tool id (the segment after any server prefix) via
+ * the shared {@link splitToolName} so it survives both MCP separators ("__" and ".").
  */
 function getToolPurpose(rawToolName: string): string | null {
-  switch (rawToolId(rawToolName)) {
+  switch (splitToolName(rawToolName).tool) {
     case "capture_video_frame":
       return "YakShaver wants to capture a still frame from your screen recording so it can see what you're pointing at and keep working on your task accurately. It only runs when you say it's OK.";
     default:

--- a/src/ui/src/components/workflow/ApprovalDialog.tsx
+++ b/src/ui/src/components/workflow/ApprovalDialog.tsx
@@ -137,12 +137,13 @@ export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDia
   const isOpen = true;
 
   const readableToolInfo = toolName ? parseToolName(toolName) : null;
+  const toolLabel = readableToolInfo?.tool ?? "an action";
   const dialogTitle = readableToolInfo
-    ? `Allow "${readableToolInfo.tool}" to run?`
-    : "Allow tool to run?";
+    ? `Can YakShaver use "${readableToolInfo.tool}"?`
+    : "Can YakShaver perform this action?";
   const dialogDescription = readableToolInfo?.server
-    ? `The AI wants to run the "${readableToolInfo.tool}" tool from the ${readableToolInfo.server} server. Do you want to allow this?`
-    : `The AI wants to run a tool. Do you want to allow this?`;
+    ? `To keep working on your task, YakShaver needs to use the "${readableToolInfo.tool}" tool (from ${readableToolInfo.server}). It only runs when you say it's OK.`
+    : `To keep working on your task, YakShaver needs to perform an action. It only runs when you say it's OK.`;
 
   return (
     <AlertDialog open={isOpen}>
@@ -156,6 +157,22 @@ export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDia
           </div>
           <AlertDialogDescription>{dialogDescription}</AlertDialogDescription>
         </AlertDialogHeader>
+        {!showCorrectionForm && (
+          <ul className="space-y-1.5 text-sm text-white/70">
+            <li>
+              <span className="font-medium text-white/90">Allow</span> &mdash; let YakShaver use{" "}
+              {`"${toolLabel}"`} this one time.
+            </li>
+            <li>
+              <span className="font-medium text-white/90">Allow Always</span> &mdash; let YakShaver
+              use {`"${toolLabel}"`} now and skip this prompt next time.
+            </li>
+            <li>
+              <span className="font-medium text-white/90">Don't Allow</span> &mdash; skip this step.
+              YakShaver won't use {`"${toolLabel}"`}, and you can tell it what to do instead.
+            </li>
+          </ul>
+        )}
         {autoApprovalCountdown !== null && (
           <p className="text-xs text-yellow-300">
             Auto-approving in {autoApprovalCountdown}s if no action is taken.

--- a/src/ui/src/utils/index.test.ts
+++ b/src/ui/src/utils/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatKeyAsTitle } from "./";
+import { formatKeyAsTitle, parseToolName, splitToolName } from "./";
 
 describe("formatKeyAsTitle", () => {
   it("converts camelCase to spaced title case", () => {
@@ -32,5 +32,52 @@ describe("formatKeyAsTitle", () => {
 
   it("handles consecutive uppercase acronyms separated by words", () => {
     expect(formatKeyAsTitle("parseHTMLContent")).toBe("Parse HTML Content");
+  });
+});
+
+describe("splitToolName", () => {
+  it("splits on the '__' MCP system separator", () => {
+    expect(splitToolName("Jira__getAccessibleAtlassianResources")).toEqual({
+      server: "Jira",
+      tool: "getAccessibleAtlassianResources",
+    });
+  });
+
+  it("splits on the '.' AI-output separator", () => {
+    expect(splitToolName("Yak_Video_Tools.capture_video_frame")).toEqual({
+      server: "Yak_Video_Tools",
+      tool: "capture_video_frame",
+    });
+  });
+
+  it("prefers the '__' separator over '.' when both are present", () => {
+    expect(splitToolName("Yak_Video_Tools__capture_video_frame")).toEqual({
+      server: "Yak_Video_Tools",
+      tool: "capture_video_frame",
+    });
+  });
+
+  it("returns a null server when there is no prefix", () => {
+    expect(splitToolName("issue_write")).toEqual({ server: null, tool: "issue_write" });
+  });
+});
+
+describe("parseToolName", () => {
+  it("formats a '__'-separated tool name", () => {
+    expect(parseToolName("Jira__getAccessibleAtlassianResources")).toEqual({
+      server: "Jira",
+      tool: "Get Accessible Atlassian Resources",
+    });
+  });
+
+  it("formats a '.'-separated tool name and de-underscores the server", () => {
+    expect(parseToolName("Yak_Video_Tools.capture_video_frame")).toEqual({
+      server: "Yak Video Tools",
+      tool: "Capture Video Frame",
+    });
+  });
+
+  it("returns a null server for an unprefixed tool name", () => {
+    expect(parseToolName("issue_write")).toEqual({ server: null, tool: "Issue Write" });
   });
 });

--- a/src/ui/src/utils/index.ts
+++ b/src/ui/src/utils/index.ts
@@ -123,6 +123,48 @@ export function formatKeyAsTitle(key: string): string {
 }
 
 /**
+ * Splits a raw MCP tool name into its raw (unformatted) server-prefix and tool-id
+ * segments. Handles both the "__" (MCP system) and "." (AI output) separators and
+ * is the single source of truth for the separator precedence and slice offsets that
+ * {@link parseToolName} formats and consumers such as the approval dialog key off.
+ *
+ * @param rawToolName - The raw prefixed tool name from the MCP layer.
+ * @returns An object with the raw `server` prefix (null if no prefix) and the raw
+ *          `tool` id, both left exactly as they appear in the source string.
+ *
+ * @example
+ * splitToolName("Jira__getAccessibleAtlassianResources")
+ * // { server: "Jira", tool: "getAccessibleAtlassianResources" }
+ *
+ * splitToolName("Yak_Video_Tools.capture_video_frame")
+ * // { server: "Yak_Video_Tools", tool: "capture_video_frame" }
+ *
+ * splitToolName("issue_write")
+ * // { server: null, tool: "issue_write" }
+ */
+export function splitToolName(rawToolName: string): { server: string | null; tool: string } {
+  // Handle "__" separator (MCP system format: "Jira__getAccessibleAtlassianResources")
+  const dunderIndex = rawToolName.indexOf("__");
+  if (dunderIndex !== -1) {
+    return {
+      server: rawToolName.slice(0, dunderIndex),
+      tool: rawToolName.slice(dunderIndex + 2),
+    };
+  }
+
+  // Handle "." separator (AI output format: "Yak_Video_Tools.capture_video_frame")
+  const dotIndex = rawToolName.indexOf(".");
+  if (dotIndex !== -1) {
+    return {
+      server: rawToolName.slice(0, dotIndex),
+      tool: rawToolName.slice(dotIndex + 1),
+    };
+  }
+
+  return { server: null, tool: rawToolName };
+}
+
+/**
  * Parses a raw MCP tool name (e.g. "Jira__getAccessibleAtlassianResources") into its
  * human-readable server and tool components.
  *
@@ -140,25 +182,11 @@ export function parseToolName(rawToolName: string): { server: string | null; too
   const formatTool = (s: string) => s.split("_").map(formatKeyAsTitle).join(" ");
   const formatServer = (s: string) => s.replace(/_/g, " ");
 
-  // Handle "__" separator (MCP system format: "Jira__getAccessibleAtlassianResources")
-  const dunderIndex = rawToolName.indexOf("__");
-  if (dunderIndex !== -1) {
-    return {
-      server: formatServer(rawToolName.slice(0, dunderIndex)),
-      tool: formatTool(rawToolName.slice(dunderIndex + 2)),
-    };
-  }
-
-  // Handle "." separator (AI output format: "Yak_Video_Tools.capture_video_frame")
-  const dotIndex = rawToolName.indexOf(".");
-  if (dotIndex !== -1) {
-    return {
-      server: formatServer(rawToolName.slice(0, dotIndex)),
-      tool: formatTool(rawToolName.slice(dotIndex + 1)),
-    };
-  }
-
-  return { server: null, tool: formatTool(rawToolName) };
+  const { server, tool } = splitToolName(rawToolName);
+  return {
+    server: server === null ? null : formatServer(server),
+    tool: formatTool(tool),
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #783

## Problem
Users were shown the tool-approval prompt with the title `Allow "capture video frame" to run?` and the description "The AI wants to run the ... tool ... Do you want to allow this?", plus three options (Allow / Allow Always / Don't Allow) with no explanation. Non-technical users did not understand what the permission meant, why it was needed, or which option to pick.

## Change
Copy/wording only in the tool-approval dialog (`src/ui/src/components/workflow/ApprovalDialog.tsx`). No behavioral change.

### Before -> After

**Title (tool known)**
- Before: `Allow "<tool>" to run?`
- After: `Can YakShaver use "<tool>"?`

**Title (tool unknown)**
- Before: `Allow tool to run?`
- After: `Can YakShaver perform this action?`

**Description (server known)**
- Before: `The AI wants to run the "<tool>" tool from the <server> server. Do you want to allow this?`
- After: `To keep working on your task, YakShaver needs to use the "<tool>" tool (from <server>). It only runs when you say it's OK.`

**Description (no server)**
- Before: `The AI wants to run a tool. Do you want to allow this?`
- After: `To keep working on your task, YakShaver needs to perform an action. It only runs when you say it's OK.`

**Third footer button (the dismiss / non-approve action)**
- Before: `Don't Allow`
- After: `Review / Correct…`

### Why the third option was renamed
Issue #783's AC3 lists the three original options as "Allow, Allow Always, Not Allow". In this app the third button does **not** silently abort — clicking it opens an inline correction form where the user can either leave a note telling YakShaver what to change and retry the tool (`request_changes`), or stop the step entirely (`deny_stop`). Labelling it "Don't Allow" misrepresented that flow as a one-click hard stop. It is renamed to **Review / Correct…** so the label matches what the button actually does, and the literal "Don't Allow" wording now appears inside that sub-form as the explicit "stop the step" (deny) action. AC3's intent — that each option is clearly explained — is satisfied by the per-option list below.

**New: per-option explanation** (shown above the buttons)
- **Allow** — let YakShaver use "<tool>" this one time.
- **Allow Always** — let YakShaver use "<tool>" now and skip this prompt next time.
- **Review / Correct…** — don't run "<tool>" as-is. You can leave a note telling YakShaver what to change and try again, or stop the step entirely.

This addresses all 5 acceptance criteria: plain language, explains why/benefit, explains each option, matches app tone, and is understandable without external docs.

## Files
- `src/ui/src/components/workflow/ApprovalDialog.tsx`
- `src/ui/src/utils/index.ts` — new shared `splitToolName()` (raw server/tool split); `parseToolName()` now formats its output
- `src/ui/src/utils/index.test.ts` — unit coverage for `splitToolName` + `parseToolName`

## Verification
- `cd src/ui && npm run build` — green
- `cd src/ui && npx vitest run` — 50 passing (incl. new split/parse cases)
- `biome check` on the changed files — clean
- Renderer copy is a visual/string change; the new util split is unit-tested.

## Live QA pending
Built in an isolated worktree with no running app. Needs a human to launch the desktop app, trigger a tool-approval prompt (e.g. the "capture video frame" tool), and confirm the new copy and option list render correctly and stay readable in the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
