### PR TITLE
L⚠️ ◾ feat(#907): Claude Code (local) orchestration mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,11 @@ YakShaver is a desktop AI agent with the following capabilities:
 - **Windows/macOS YouTube downloads**: `scripts/install-yt-dlp.mjs` installs standalone
   `yt-dlp` binaries into `node_modules/youtube-dl-exec/bin/` during setup so local
   development does not depend on the operating system's Python.
+- **Optional Claude Code CLI runtime**: the `local-claude` orchestration backend spawns a
+  headless `claude` (`@anthropic-ai/claude-code`) subprocess from PATH. It is NOT a bundled
+  dependency — the user installs it separately, and the feature is only active when the user
+  selects it in Settings. (Spawned through the shell on Windows so an npm `claude.cmd`/`.ps1`
+  shim still launches.)
 
 ## Project Structure
 
@@ -391,6 +396,24 @@ APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...;IngestionEndpoint=.
 #### Singleton Pattern (Services)
 
 Most backend services use the singleton pattern. Use `getInstanceAsync()` for async initialization (e.g., `MCPServerManager`, `MCPOrchestrator`), or `getInstance()` with nullish coalescing for sync (e.g., `RecordingService`, all `*Storage` classes). See any storage class for the sync pattern.
+
+#### Backlog Orchestration Backends (Pluggable Seam)
+
+The EXECUTING_TASK stage drives backlog creation through the `IBacklogOrchestrator` seam
+(`src/backend/services/mcp/backlog-orchestrator.ts`). Two interchangeable backends implement it:
+
+- **`openai`** (default): the in-process `MCPOrchestrator` OpenAI tool loop.
+- **`local-claude`**: `LocalClaudeOrchestrator`, which spawns a headless `claude -p` subprocess,
+  serializes the enabled MCP servers to a temp `--mcp-config` (with OAuth bearer headers; the
+  config file is written `0600` because it carries a live token), maps the tool-approval mode to
+  Claude's `--permission-mode`/`--allowedTools`, and reuses the shared `judgeBacklogOutcome`
+  verifier. The verifier still runs on the configured OpenAI/Azure model, so `local-claude` is
+  "no API key for orchestration" but still needs a language model configured to confirm success.
+
+The backend is selected per run by `getBacklogOrchestrator()` from the `orchestrationBackend`
+field on `LLMConfigV2` (`src/shared/types/llm.ts`, default `openai`), surfaced in Settings via
+`OrchestratorBackendSetting`. Both backends return the same `MCPLoopResult`, whose
+`backlogActionSucceeded` gates COMPLETE vs FAIL.
 
 #### IPC Handler Pattern (Class-based)
 

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -13,12 +13,15 @@ import { IdentityServerAuthService } from "../services/auth/identity-server-auth
 import type { VideoUploadResult } from "../services/auth/types";
 import { YouTubeClient } from "../services/auth/youtube-client";
 import { FFmpegService } from "../services/ffmpeg/ffmpeg-service";
+import type { IBacklogOrchestrator } from "../services/mcp/backlog-orchestrator";
 import { LanguageModelProvider } from "../services/mcp/language-model-provider";
+import { LocalClaudeOrchestrator } from "../services/mcp/local-claude-orchestrator";
 import { MCPOrchestrator } from "../services/mcp/mcp-orchestrator";
 import { TranscriptionModelProvider } from "../services/mcp/transcription-model-provider";
 import { SendWorkItemDetailsToPortal, WorkItemDtoSchema } from "../services/portal/actions";
 import type { ProjectDto } from "../services/prompt/prompt-manager";
 import { ShaveService } from "../services/shave/shave-service";
+import { LlmStorage } from "../services/storage/llm-storage";
 import { UserInteractionService } from "../services/user-interaction/user-interaction-service";
 import { VideoMetadataBuilder } from "../services/video/video-metadata-builder";
 import { YouTubeDownloadService } from "../services/video/youtube-service";
@@ -136,7 +139,7 @@ export class ProcessVideoIPCHandlers {
 
           const mcpAdapter = new McpWorkflowAdapter(workflowManager);
 
-          const orchestrator = await MCPOrchestrator.getInstanceAsync();
+          const orchestrator = await this.getBacklogOrchestrator();
           const loopResult = await orchestrator.manualLoopAsync(
             intermediateOutput,
             videoUploadResult,
@@ -564,7 +567,7 @@ export class ProcessVideoIPCHandlers {
           intermediateOutput,
         });
 
-        const orchestrator = await MCPOrchestrator.getInstanceAsync();
+        const orchestrator = await this.getBacklogOrchestrator();
 
         // transcriptText guaranteed by: normal flow sets it in TRANSCRIBING; retry validated at entry
         const loopResult = await orchestrator.manualLoopAsync(
@@ -616,7 +619,11 @@ export class ProcessVideoIPCHandlers {
           (await IdentityServerAuthService.getInstance().isAuthenticated())
         ) {
           try {
-            const objectResult = await orchestrator.convertToObjectAsync(
+            // Portal serialization uses the OpenAI orchestrator's structured-output helper
+            // regardless of which backend drove the loop (the local Claude backend has no
+            // convertToObjectAsync). This is a separate LLM call from the orchestration step.
+            const portalOrchestrator = await MCPOrchestrator.getInstanceAsync();
+            const objectResult = await portalOrchestrator.convertToObjectAsync(
               mcpResult,
               WorkItemDtoSchema,
             );
@@ -721,6 +728,31 @@ export class ProcessVideoIPCHandlers {
     const outputFilePath = tmp.tmpNameSync({ postfix: ".mp3" });
     const result = await this.ffmpegService.ConvertVideoToMp3(inputPath, outputFilePath);
     return result;
+  }
+
+  /**
+   * Selects the orchestrator backend for the backlog-creation step from the persisted LLM config.
+   * `local-claude` drives the step with a headless `claude -p`; anything else (including a config
+   * with no `orchestrationBackend` field) uses the in-process OpenAI loop. Falls back to OpenAI if
+   * the config can't be read so the stage never hard-fails on a config hiccup.
+   */
+  private async getBacklogOrchestrator(): Promise<IBacklogOrchestrator> {
+    let backend: string | undefined;
+    try {
+      backend = (await LlmStorage.getInstance().getLLMConfig())?.orchestrationBackend;
+    } catch (error) {
+      console.warn(
+        "[ProcessVideo] Failed to read orchestration backend, defaulting to OpenAI",
+        error,
+      );
+    }
+
+    if (backend === "local-claude") {
+      console.log("[ProcessVideo] Using local Claude Code orchestrator");
+      return new LocalClaudeOrchestrator();
+    }
+
+    return await MCPOrchestrator.getInstanceAsync();
   }
 
   private async formatFinalResult(mcpResult: string | undefined): Promise<string | undefined> {

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -590,7 +590,9 @@ export class ProcessVideoIPCHandlers {
         // created/updated a backlog item, the run did nothing — fail the stage so the user
         // isn't told an issue exists when none does. Temp files are kept for retry.
         if (!loopResult.backlogActionSucceeded) {
-          const failureMessage = formatNoWorkItemError(loopResult.terminationReason);
+          const failureMessage = formatNoWorkItemError(loopResult.terminationReason, {
+            verificationUnavailable: loopResult.verificationUnavailable,
+          });
           mcpAdapter.fail(mcpResult, finalOutput, failureMessage);
           workflowManager.createCheckpoint(WorkflowProgressStage.EXECUTING_TASK, {
             mcpResult,

--- a/src/backend/services/ffmpeg/ffmpeg-service.ts
+++ b/src/backend/services/ffmpeg/ffmpeg-service.ts
@@ -1,8 +1,8 @@
-import { spawn } from "node:child_process";
 import { dirname } from "node:path";
 import ffmpeg from "@ffmpeg-installer/ffmpeg";
 import { FileService, type IFileService } from "../file/file-service";
-import type { ConversionProgress, IProcessSpawner } from "./types";
+import { defaultProcessSpawner, type IProcessSpawner } from "../process/process-spawner";
+import type { ConversionProgress } from "./types";
 
 function getDefaultFfmpegPath(): string {
   let ffmpegPath = ffmpeg.path;
@@ -11,10 +11,6 @@ function getDefaultFfmpegPath(): string {
   }
   return ffmpegPath;
 }
-
-const defaultProcessSpawner: IProcessSpawner = {
-  spawn: (command, args) => spawn(command, args),
-};
 
 export class FFmpegService {
   private static instance: FFmpegService;

--- a/src/backend/services/ffmpeg/types.ts
+++ b/src/backend/services/ffmpeg/types.ts
@@ -1,11 +1,9 @@
-import type { ChildProcess } from "node:child_process";
+// `IProcessSpawner` lives in the shared `process` module so both ffmpeg and the local-claude
+// orchestrator consume one definition (DRY). Re-exported here for existing importers.
+export type { IProcessSpawner } from "../process/process-spawner";
 
 export interface ConversionProgress {
   percentage: number;
   timeProcessed: string;
   speed: string;
-}
-
-export interface IProcessSpawner {
-  spawn(command: string, args: string[]): ChildProcess;
 }

--- a/src/backend/services/mcp/backlog-orchestrator.ts
+++ b/src/backend/services/mcp/backlog-orchestrator.ts
@@ -163,8 +163,9 @@ export async function judgeBacklogOutcome(
     );
     // Enforce the contract in CODE, not just the prompt: a verdict is only trusted as success
     // if it cites concrete evidence. A model that answers achieved=true but populates no
-    // artifacts is treated as not-achieved (conservative — a false success is the costly error).
-    const achieved = verdict.achieved && verdict.artifacts.length > 0;
+    // artifacts — or only blank `idOrUrl`s (the schema allows empty strings) — is treated as
+    // not-achieved (conservative — a false success is the costly error).
+    const achieved = verdict.achieved && verdict.artifacts.some((a) => a.idOrUrl.trim().length > 0);
     console.log("[judgeBacklogOutcome] outcome judged:", {
       achieved,
       modelClaimedAchieved: verdict.achieved,

--- a/src/backend/services/mcp/backlog-orchestrator.ts
+++ b/src/backend/services/mcp/backlog-orchestrator.ts
@@ -30,6 +30,13 @@ export interface MCPLoopResult {
   artifacts: BacklogArtifact[];
   /** Why the loop ended — distinguishes a clean finish from hitting a safety cap. */
   terminationReason: MCPTerminationReason;
+  /**
+   * True when a tool call succeeded but the outcome could NOT be verified because no judge model
+   * was configured (the local-Claude-without-an-OpenAI/Azure-model case). The run still counts as
+   * not-succeeded (we fail closed), but the caller should tell the user an item MAY have been
+   * created and to check their backlog before re-running — not that their connection is signed out.
+   */
+  verificationUnavailable?: boolean;
 }
 
 /** One executed tool call and (a truncated view of) its result — the ground truth the judge reasons over. */
@@ -51,6 +58,12 @@ export interface ManualLoopOptions {
   serverFilter?: string[]; // if provided, only include tools from these server IDs
   shaveId?: string; // identifies the current shave for per-shave auto-approve
   onStep?: (step: MCPStep) => void;
+  /**
+   * Aborts an in-flight run. The OpenAI backend can already be cancelled via its approval flow;
+   * the headless local-Claude backend has no approval prompts, so this signal is its cancellation
+   * path — when it fires the spawned `claude -p` child is killed and the run rejects.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -106,7 +119,7 @@ export async function judgeBacklogOutcome(
   transcript: string,
   toolActivity: ToolActivity[],
   finalText: string,
-): Promise<{ achieved: boolean; artifacts: BacklogArtifact[] }> {
+): Promise<{ achieved: boolean; artifacts: BacklogArtifact[]; verificationUnavailable?: boolean }> {
   const succeeded = toolActivity.filter((t) => t.ok);
   if (succeeded.length === 0) {
     console.log("[judgeBacklogOutcome] no successful tool calls -> not achieved");
@@ -114,8 +127,15 @@ export async function judgeBacklogOutcome(
   }
 
   if (!provider) {
-    console.warn("[judgeBacklogOutcome] outcome judge unavailable (no LLM) -> not achieved");
-    return { achieved: false, artifacts: [] };
+    // A tool DID succeed, but there's no judge to confirm whether it filed a backlog item. We
+    // still fail CLOSED (achieved=false), but flag verificationUnavailable so the caller can tell
+    // the user "an item may have been created but couldn't be verified" instead of the misleading
+    // generic "your backlog connection is signed out" copy (#833 / local-Claude no-LLM case).
+    console.warn(
+      "[judgeBacklogOutcome] outcome judge unavailable (no LLM) but a tool succeeded -> " +
+        "not achieved, verification unavailable",
+    );
+    return { achieved: false, artifacts: [], verificationUnavailable: true };
   }
 
   const judgeSystemPrompt =

--- a/src/backend/services/mcp/backlog-orchestrator.ts
+++ b/src/backend/services/mcp/backlog-orchestrator.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+import type { MCPStep } from "../../../shared/types/mcp";
+import type { VideoUploadResult } from "../auth/types";
+
+export type MCPTerminationReason =
+  | "stop"
+  | "length"
+  | "content-filter"
+  | "cancelled"
+  | "max-iterations"
+  | "unknown";
+
+export interface BacklogArtifact {
+  /** e.g. "issue", "work_item", "ticket", "comment", "pull_request". */
+  type: string;
+  /** The concrete identifier or URL evidencing the created/updated item. */
+  idOrUrl: string;
+}
+
+export interface MCPLoopResult {
+  /** The model's final text output — the drafted work item, or a message explaining why it stopped. */
+  text: string;
+  /**
+   * True only when a backlog item was actually created/updated, decided from the TOOL RESULTS
+   * (not the model's narration). A graceful `stop` with only internal tools, no tools, or an
+   * errored mutation means nothing was filed.
+   */
+  backlogActionSucceeded: boolean;
+  /** The concrete created/updated artifacts the judge found (issue ids/URLs), if any. */
+  artifacts: BacklogArtifact[];
+  /** Why the loop ended — distinguishes a clean finish from hitting a safety cap. */
+  terminationReason: MCPTerminationReason;
+}
+
+/** One executed tool call and (a truncated view of) its result — the ground truth the judge reasons over. */
+export interface ToolActivity {
+  toolName: string;
+  ok: boolean;
+  resultText: string;
+}
+
+/**
+ * Options the backlog-creation step passes to whichever orchestrator backend drives it.
+ * Identical to what `MCPOrchestrator.manualLoopAsync` accepts so the call site is backend-agnostic.
+ */
+export interface ManualLoopOptions {
+  projectMetaData?: string;
+  desktopAgentProjectPrompt?: string;
+  maxToolIterations?: number; // safety cap to avoid infinite loops
+  videoFilePath?: string; // local video file path for screenshot capture
+  serverFilter?: string[]; // if provided, only include tools from these server IDs
+  shaveId?: string; // identifies the current shave for per-shave auto-approve
+  onStep?: (step: MCPStep) => void;
+}
+
+/**
+ * The seam the EXECUTING_TASK stage talks to. Both the in-process `MCPOrchestrator` (OpenAI loop)
+ * and the `LocalClaudeOrchestrator` (headless `claude -p`) implement this, so the call site can
+ * pick a backend without caring how the work gets done — both return the same `MCPLoopResult`,
+ * whose `backlogActionSucceeded` gates COMPLETE vs FAIL.
+ */
+export interface IBacklogOrchestrator {
+  manualLoopAsync(
+    videoTranscription: string,
+    videoUploadResult?: VideoUploadResult,
+    options?: ManualLoopOptions,
+  ): Promise<MCPLoopResult>;
+}
+
+/**
+ * Structured verdict from the outcome judge. Every field is REQUIRED — no `.optional()` / `.default()`.
+ * OpenAI strict structured outputs reject a schema whose `required` omits any property, so a
+ * `.default()` here makes the field optional and breaks the real `generateObject` call at runtime
+ * ("Invalid schema for response_format … Missing 'artifacts'"). That only surfaces against a live
+ * model, never in tests that stub generateObject — so keep this schema strict-compatible.
+ */
+export const BacklogOutcomeSchema = z.object({
+  achieved: z.boolean(),
+  artifacts: z.array(z.object({ type: z.string(), idOrUrl: z.string() })),
+  reasoning: z.string(),
+});
+
+/** The minimal LLM capability the outcome judge needs — kept narrow so it's trivial to stub in tests. */
+export interface OutcomeJudgeProvider {
+  generateObject(
+    prompt: string,
+    schema: typeof BacklogOutcomeSchema,
+    systemPrompt?: string,
+  ): Promise<{ achieved: boolean; artifacts: BacklogArtifact[]; reasoning?: string }>;
+}
+
+/**
+ * Decides whether the run ACTUALLY created/updated a backlog item, judging from the tool
+ * RESULTS (ground truth) rather than a tool-name heuristic or the model's own claims (#833).
+ *
+ * Shared by both orchestrator backends (OpenAI loop + local Claude Code) so success is judged
+ * identically regardless of who drove the tools.
+ *
+ * Short-circuits to "not achieved" when no tool call succeeded (the common signed-out case),
+ * so the extra LLM call only happens when something plausibly did get filed. Fails CLOSED
+ * (not achieved) if the judge is unavailable or errors — a false success is the costly mistake.
+ */
+export async function judgeBacklogOutcome(
+  provider: OutcomeJudgeProvider | null | undefined,
+  goal: string | undefined,
+  transcript: string,
+  toolActivity: ToolActivity[],
+  finalText: string,
+): Promise<{ achieved: boolean; artifacts: BacklogArtifact[] }> {
+  const succeeded = toolActivity.filter((t) => t.ok);
+  if (succeeded.length === 0) {
+    console.log("[judgeBacklogOutcome] no successful tool calls -> not achieved");
+    return { achieved: false, artifacts: [] };
+  }
+
+  if (!provider) {
+    console.warn("[judgeBacklogOutcome] outcome judge unavailable (no LLM) -> not achieved");
+    return { achieved: false, artifacts: [] };
+  }
+
+  const judgeSystemPrompt =
+    "You are a strict verifier deciding whether an automated agent ACTUALLY created or updated " +
+    "a backlog work item (e.g. a GitHub issue, an Azure DevOps work item, or a Jira ticket) as " +
+    "instructed. Judge ONLY from the tool results below (ground truth) — NEVER trust the agent's " +
+    "own final message, which may claim success it did not achieve. Set achieved=true only when a " +
+    "non-errored tool result contains concrete evidence of a created or updated item: an id, a " +
+    "number, or a URL. Put that evidence in artifacts. If no mutating tool produced such evidence — " +
+    "nothing ran, the call errored, or only read/internal tools ran — set achieved=false. When " +
+    "uncertain, set achieved=false.";
+
+  const judgePrompt = [
+    `TASK INSTRUCTIONS GIVEN TO THE AGENT:\n${goal?.slice(0, 4000) || "(create a backlog work item describing the user's request)"}`,
+    `USER REQUEST (video transcript):\n${transcript.slice(0, 2000)}`,
+    `TOOL CALLS AND THEIR RESULTS (ground truth — decide from these):\n${JSON.stringify(toolActivity)}`,
+    `AGENT FINAL MESSAGE (do NOT trust this for success):\n${finalText.slice(0, 2000)}`,
+  ].join("\n\n---\n\n");
+
+  try {
+    const verdict = await provider.generateObject(
+      judgePrompt,
+      BacklogOutcomeSchema,
+      judgeSystemPrompt,
+    );
+    // Enforce the contract in CODE, not just the prompt: a verdict is only trusted as success
+    // if it cites concrete evidence. A model that answers achieved=true but populates no
+    // artifacts is treated as not-achieved (conservative — a false success is the costly error).
+    const achieved = verdict.achieved && verdict.artifacts.length > 0;
+    console.log("[judgeBacklogOutcome] outcome judged:", {
+      achieved,
+      modelClaimedAchieved: verdict.achieved,
+      artifacts: verdict.artifacts,
+      tools: toolActivity.map((t) => `${t.toolName}${t.ok ? "" : "(errored)"}`),
+    });
+    return { achieved, artifacts: verdict.artifacts };
+  } catch (error) {
+    // Fail CLOSED: if the judge itself errors we cannot confirm a filing, so report
+    // not-achieved rather than risk a false success (the costly direction for #833).
+    console.warn(
+      "[judgeBacklogOutcome] outcome judge failed -> not achieved (failing closed)",
+      error,
+    );
+    return { achieved: false, artifacts: [] };
+  }
+}

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -1,0 +1,401 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The orchestrator pulls electron in transitively via LanguageModelProvider; stub it so the
+// real control flow runs in a plain node test environment.
+vi.mock("electron", () => ({
+  BrowserWindow: { getAllWindows: vi.fn().mockReturnValue([]) },
+}));
+vi.mock("../../utils/error-utils", () => ({
+  formatAndReportError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+import type { MCPStep } from "../../../shared/types/mcp";
+import type { ToolApprovalMode } from "../../../shared/types/user-settings";
+// vi.mock calls above are hoisted, so this static import sees the stubbed modules.
+import { LocalClaudeOrchestrator } from "./local-claude-orchestrator";
+import type { MCPServerConfig } from "./types";
+
+type MockChild = ChildProcess & {
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+};
+
+function createMockChild(): MockChild {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  return proc as unknown as MockChild;
+}
+
+/**
+ * A spawner that returns a `--version` child first (success), then the run child. The run child's
+ * scripted stream is emitted right after the run child is returned (a tick later), guaranteeing the
+ * orchestrator has attached its stdout/close listeners before any event fires — no race.
+ */
+function makeSpawner(versionExitCode: number, runChild: MockChild, runScript?: () => void) {
+  const versionChild = createMockChild();
+  const spawn = vi.fn((_cmd: string, args: string[]) => {
+    if (args.includes("--version")) {
+      setImmediate(() => versionChild.emit("close", versionExitCode));
+      return versionChild;
+    }
+    if (runScript) setImmediate(runScript);
+    return runChild;
+  });
+  return { spawn };
+}
+
+function makeManager(servers: MCPServerConfig[]) {
+  return { listAvailableServers: vi.fn().mockResolvedValue(servers) };
+}
+
+function makeSettings(mode: ToolApprovalMode) {
+  return { getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: mode }) };
+}
+
+function makeTokenStorage(tokenByServer: Record<string, string> = {}) {
+  return {
+    getTokensAsync: vi.fn(async (serverId: string) =>
+      tokenByServer[serverId] ? { access_token: tokenByServer[serverId] } : undefined,
+    ),
+  };
+}
+
+const httpServer: MCPServerConfig = {
+  id: "gh-1",
+  name: "GitHub",
+  transport: "streamableHttp",
+  url: "https://mcp.github.test/",
+  toolWhitelist: ["create_issue"],
+  enabled: true,
+};
+
+const stdioServer: MCPServerConfig = {
+  id: "fs-1",
+  name: "Local FS",
+  transport: "stdio",
+  command: "npx",
+  args: ["-y", "fs-mcp"],
+  env: { FOO: "bar" },
+  toolWhitelist: ["read_file"],
+  enabled: true,
+};
+
+describe("LocalClaudeOrchestrator", () => {
+  let runChild: MockChild;
+
+  beforeEach(() => {
+    runChild = createMockChild();
+  });
+
+  describe("claude availability", () => {
+    it("throws a clear error when `claude` is not found (--version fails)", async () => {
+      const { spawn } = makeSpawner(/* versionExitCode */ 127, runChild);
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("ask"),
+        { generateObject: vi.fn() },
+      );
+
+      await expect(orch.manualLoopAsync("transcript", undefined, {})).rejects.toThrow(
+        /Claude Code CLI not found on PATH/,
+      );
+    });
+
+    it("throws a clear error when spawning `claude --version` errors (ENOENT)", async () => {
+      const versionChild = createMockChild();
+      const spawn = vi.fn((_cmd: string, args: string[]) => {
+        if (args.includes("--version")) {
+          setImmediate(() => versionChild.emit("error", new Error("spawn ENOENT")));
+          return versionChild;
+        }
+        return runChild;
+      });
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("ask"),
+        { generateObject: vi.fn() },
+      );
+
+      await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
+        /Claude Code CLI not found on PATH/,
+      );
+    });
+  });
+
+  describe("MCP config serialization", () => {
+    it("serializes stdio (command/args/env) and http (url + injected bearer token)", async () => {
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn: vi.fn() },
+        makeManager([stdioServer, httpServer]),
+        makeTokenStorage({ "gh-1": "tok-123" }),
+        makeSettings("ask"),
+        { generateObject: vi.fn() },
+      );
+
+      const { mcpConfig, allowedTools } = await orch.serializeMcpServers(
+        makeManager([stdioServer, httpServer]),
+        undefined,
+      );
+
+      expect(mcpConfig.mcpServers).toEqual({
+        Local_FS: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "fs-mcp"],
+          env: { FOO: "bar" },
+        },
+        GitHub: {
+          type: "http",
+          url: "https://mcp.github.test/",
+          headers: { Authorization: "Bearer tok-123" },
+        },
+      });
+      expect(allowedTools).toEqual(["mcp__Local_FS__read_file", "mcp__GitHub__create_issue"]);
+    });
+
+    it("respects the serverFilter and skips disabled + inMemory servers", async () => {
+      const disabled: MCPServerConfig = { ...stdioServer, id: "off", name: "Off", enabled: false };
+      const internal: MCPServerConfig = {
+        id: "in",
+        name: "Internal",
+        transport: "inMemory",
+        enabled: true,
+      };
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn: vi.fn() },
+        null,
+        makeTokenStorage(),
+      );
+      const mgr = makeManager([stdioServer, httpServer, disabled, internal]);
+
+      const { mcpConfig } = await orch.serializeMcpServers(mgr, ["gh-1"]);
+      expect(Object.keys(mcpConfig.mcpServers)).toEqual(["GitHub"]);
+    });
+
+    it("flags servers with no whitelist (under ask/wait) instead of hanging", async () => {
+      const noWhitelist: MCPServerConfig = { ...httpServer, toolWhitelist: [] };
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn: vi.fn() },
+        null,
+        makeTokenStorage(),
+      );
+      const { skippedNonWhitelistedServers, allowedTools } = await orch.serializeMcpServers(
+        makeManager([noWhitelist]),
+        undefined,
+      );
+      expect(skippedNonWhitelistedServers).toEqual(["GitHub"]);
+      expect(allowedTools).toEqual([]);
+    });
+  });
+
+  describe("argv building per approval mode", () => {
+    it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "yolo", ["mcp__GitHub__create_issue"]);
+      expect(argv).toContain("--permission-mode");
+      expect(argv).toContain("bypassPermissions");
+      expect(argv).not.toContain("--allowedTools");
+      expect(argv).toEqual(
+        expect.arrayContaining([
+          "-p",
+          "--mcp-config",
+          "/tmp/cfg.json",
+          "--output-format",
+          "stream-json",
+          "--verbose",
+        ]),
+      );
+    });
+
+    it("ask -> --allowedTools built from the whitelist", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "ask", [
+        "mcp__GitHub__create_issue",
+        "mcp__Local_FS__read_file",
+      ]);
+      const idx = argv.indexOf("--allowedTools");
+      expect(idx).toBeGreaterThan(-1);
+      expect(argv[idx + 1]).toBe("mcp__GitHub__create_issue,mcp__Local_FS__read_file");
+      expect(argv).not.toContain("bypassPermissions");
+    });
+
+    it("wait with empty whitelist -> no --allowedTools and no bypass (constrained run)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "wait", []);
+      expect(argv).not.toContain("--allowedTools");
+      expect(argv).not.toContain("bypassPermissions");
+    });
+  });
+
+  describe("stream-json parsing -> MCPStep sequence + judge", () => {
+    /** Builds a closure that emits the given newline-delimited JSON lines then closes the child. */
+    function streamScript(child: MockChild, lines: string[], exitCode = 0) {
+      return () => {
+        for (const line of lines) {
+          child.stdout?.emit("data", Buffer.from(`${line}\n`));
+        }
+        child.emit("close", exitCode);
+      };
+    }
+
+    it("maps assistant text/tool_use and user tool_result to MCPStep, then judges achieved", async () => {
+      const steps: MCPStep[] = [];
+      const generateObject = vi.fn().mockResolvedValue({
+        achieved: true,
+        artifacts: [{ type: "issue", idOrUrl: "https://github.com/o/r/issues/5" }],
+        reasoning: "created",
+      });
+
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "I'll create an issue." }] },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", name: "mcp__GitHub__create_issue", input: { title: "Bug" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "mcp__GitHub__create_issue",
+                content: "Created issue #5: https://github.com/o/r/issues/5",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          result: "Done! Created issue #5.",
+        }),
+      ];
+
+      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([httpServer]),
+        makeTokenStorage({ "gh-1": "tok" }),
+        makeSettings("yolo"),
+        { generateObject },
+      );
+
+      const result = await orch.manualLoopAsync("a bug report", undefined, {
+        onStep: (s) => steps.push(s),
+      });
+
+      // stdin received the system prompt + transcript
+      expect(runChild.stdin.write).toHaveBeenCalled();
+      const written = (runChild.stdin.write as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(written).toContain("video transcription: a bug report");
+
+      const types = steps.map((s) => s.type);
+      expect(types).toContain("reasoning");
+      expect(types).toContain("tool_call");
+      expect(types).toContain("tool_result");
+      expect(types).toContain("final_result");
+
+      expect(generateObject).toHaveBeenCalledTimes(1);
+      expect(result.backlogActionSucceeded).toBe(true);
+      expect(result.terminationReason).toBe("stop");
+      expect(result.artifacts).toEqual([
+        { type: "issue", idOrUrl: "https://github.com/o/r/issues/5" },
+      ]);
+      expect(result.text).toBe("Done! Created issue #5.");
+    });
+
+    it("an errored tool_result is recorded as not-ok, so the judge is not consulted -> not achieved", async () => {
+      const generateObject = vi.fn();
+      const lines = [
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "mcp__GitHub__create_issue",
+                is_error: true,
+                content: "401 Unauthorized",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({ type: "result", subtype: "success", result: "Could not create." }),
+      ];
+      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([httpServer]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject },
+      );
+
+      const result = await orch.manualLoopAsync("t", undefined, {});
+      expect(generateObject).not.toHaveBeenCalled();
+      expect(result.backlogActionSucceeded).toBe(false);
+    });
+
+    it("error_max_turns subtype -> terminationReason max-iterations", async () => {
+      const lines = [JSON.stringify({ type: "result", subtype: "error_max_turns", result: "" })];
+      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject: vi.fn() },
+      );
+
+      const result = await orch.manualLoopAsync("t", undefined, {});
+      expect(result.terminationReason).toBe("max-iterations");
+    });
+
+    it("rejects when the process exits non-zero before any result event", async () => {
+      const failScript = () => {
+        runChild.stderr?.emit("data", Buffer.from("boom"));
+        runChild.emit("close", 1);
+      };
+      const { spawn } = makeSpawner(0, runChild, failScript);
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject: vi.fn() },
+      );
+
+      await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
+        /Claude Code process exited with code 1/,
+      );
+    });
+  });
+});

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -96,7 +96,7 @@ describe("LocalClaudeOrchestrator", () => {
   });
 
   describe("claude availability", () => {
-    it("throws a clear error when `claude` is not found (--version fails)", async () => {
+    it("throws a clear 'exited with an error' message when `claude --version` exits non-zero", async () => {
       const { spawn } = makeSpawner(/* versionExitCode */ 127, runChild);
       const orch = new LocalClaudeOrchestrator(
         "claude",
@@ -107,12 +107,13 @@ describe("LocalClaudeOrchestrator", () => {
         { generateObject: vi.fn() },
       );
 
+      // The binary launched (close fired) but exited non-zero — distinguished from a PATH miss.
       await expect(orch.manualLoopAsync("transcript", undefined, {})).rejects.toThrow(
-        /Claude Code CLI not found on PATH/,
+        /exited with an error/,
       );
     });
 
-    it("throws a clear error when spawning `claude --version` errors (ENOENT)", async () => {
+    it("throws a 'could not be launched' error when spawning `claude --version` errors (ENOENT)", async () => {
       const versionChild = createMockChild();
       const spawn = vi.fn((_cmd: string, args: string[]) => {
         if (args.includes("--version")) {
@@ -131,7 +132,7 @@ describe("LocalClaudeOrchestrator", () => {
       );
 
       await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
-        /Claude Code CLI not found on PATH/,
+        /could not be launched/,
       );
     });
   });
@@ -188,6 +189,45 @@ describe("LocalClaudeOrchestrator", () => {
       expect(Object.keys(mcpConfig.mcpServers)).toEqual(["GitHub"]);
     });
 
+    it("refreshes an expired OAuth token before injecting it (no stale Bearer header)", async () => {
+      // A refreshable storage whose stored token is expired but has a refresh_token: the helper
+      // must refresh it and inject the NEW access token, matching the in-process client.
+      const refreshableStorage = {
+        getTokensAsync: vi
+          .fn()
+          .mockResolvedValueOnce({
+            access_token: "stale",
+            refresh_token: "r1",
+            expires_in: 3600,
+            storedAt: 1, // long expired
+          })
+          .mockResolvedValue({ access_token: "fresh", refresh_token: "r2", token_type: "Bearer" }),
+        isTokenExpired: vi.fn().mockReturnValue(true),
+        saveTokensAsync: vi.fn().mockResolvedValue(undefined),
+        clearTokensAsync: vi.fn().mockResolvedValue(undefined),
+      };
+      // Stub the backend refresh call the helper invokes.
+      const refreshMod = await import("./mcp-oauth");
+      const refreshSpy = vi
+        .spyOn(refreshMod, "refreshTokenWithBackend")
+        .mockResolvedValue({ access_token: "fresh", refresh_token: "r2", token_type: "Bearer" });
+
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn: vi.fn() },
+        null,
+        refreshableStorage,
+      );
+
+      const { mcpConfig } = await orch.serializeMcpServers(makeManager([httpServer]), undefined);
+      expect(refreshSpy).toHaveBeenCalledWith("https://mcp.github.test/", "r1");
+      expect(refreshableStorage.saveTokensAsync).toHaveBeenCalled();
+      expect((mcpConfig.mcpServers.GitHub as { headers?: Record<string, string> }).headers).toEqual(
+        { Authorization: "Bearer fresh" },
+      );
+      refreshSpy.mockRestore();
+    });
+
     it("flags servers with no whitelist (under ask/wait) instead of hanging", async () => {
       const noWhitelist: MCPServerConfig = { ...httpServer, toolWhitelist: [] };
       const orch = new LocalClaudeOrchestrator(
@@ -225,6 +265,19 @@ describe("LocalClaudeOrchestrator", () => {
           "--verbose",
         ]),
       );
+    });
+
+    it("passes --max-turns as the iteration safety cap (default 20, override honoured)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const def = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", []);
+      const defIdx = def.indexOf("--max-turns");
+      expect(defIdx).toBeGreaterThan(-1);
+      expect(def[defIdx + 1]).toBe("20");
+
+      const custom = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", [], 5);
+      const customIdx = custom.indexOf("--max-turns");
+      expect(customIdx).toBeGreaterThan(-1);
+      expect(custom[customIdx + 1]).toBe("5");
     });
 
     it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -20,6 +20,7 @@ import type { MCPServerConfig } from "./types";
 
 type MockChild = ChildProcess & {
   stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+  kill: ReturnType<typeof vi.fn>;
 };
 
 function createMockChild(): MockChild {
@@ -27,10 +28,12 @@ function createMockChild(): MockChild {
     stdout: EventEmitter;
     stderr: EventEmitter;
     stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+    kill: ReturnType<typeof vi.fn>;
   };
   proc.stdout = new EventEmitter();
   proc.stderr = new EventEmitter();
   proc.stdin = { write: vi.fn(), end: vi.fn() };
+  proc.kill = vi.fn();
   return proc as unknown as MockChild;
 }
 
@@ -478,6 +481,94 @@ describe("LocalClaudeOrchestrator", () => {
 
       const result = await orch.manualLoopAsync("t", undefined, {});
       expect(result.terminationReason).toBe("max-iterations");
+    });
+
+    it("no judge model + a tool succeeded -> verificationUnavailable (not the generic failure)", async () => {
+      // A user picked Claude Code without configuring an OpenAI/Azure model: the judge is null.
+      // The run must NOT silently report a plain failure — it should flag verificationUnavailable
+      // so the handler tells the user an item MAY have been created instead of "signed out".
+      const lines = [
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "mcp__GitHub__create_issue",
+                content: "Created issue #7: https://github.com/o/r/issues/7",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({ type: "result", subtype: "success", result: "Done." }),
+      ];
+      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
+      // No judge provider passed (null) — mirrors "no language model configured".
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([httpServer]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        null,
+      );
+
+      const steps: MCPStep[] = [];
+      const result = await orch.manualLoopAsync("t", undefined, { onStep: (s) => steps.push(s) });
+
+      expect(result.backlogActionSucceeded).toBe(false);
+      expect(result.verificationUnavailable).toBe(true);
+      // The user-facing reasoning notice explains the real cause.
+      const reasoning = steps
+        .filter((s) => s.type === "reasoning")
+        .map((s) => s.reasoning ?? "")
+        .join(" ");
+      expect(reasoning).toMatch(/could NOT be verified/i);
+    });
+
+    it("kills the child and rejects when the caller's AbortSignal fires mid-run", async () => {
+      const controller = new AbortController();
+      // A run child that never closes on its own; aborting must kill it and reject.
+      const abortScript = () => {
+        runChild.stdout?.emit("data", Buffer.from(`${JSON.stringify({ type: "assistant" })}\n`));
+        controller.abort();
+      };
+      const { spawn } = makeSpawner(0, runChild, abortScript);
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject: vi.fn() },
+      );
+
+      await expect(
+        orch.manualLoopAsync("t", undefined, { signal: controller.signal }),
+      ).rejects.toThrow(/cancelled/i);
+      expect(runChild.kill).toHaveBeenCalled();
+    });
+
+    it("kills the child and rejects when the wall-clock run timeout elapses", async () => {
+      // A run child that emits a line but never closes — only the wall-clock timeout can end it.
+      // Real timers (not fake) because the orchestrator does real fs.writeFile before spawning the
+      // run child, which fake timers can't advance past. A tiny 20ms timeout keeps it fast.
+      const stallScript = () => {
+        runChild.stdout?.emit("data", Buffer.from(`${JSON.stringify({ type: "assistant" })}\n`));
+      };
+      const { spawn } = makeSpawner(0, runChild, stallScript);
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject: vi.fn() },
+        20,
+      );
+
+      await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(/timed out/i);
+      expect(runChild.kill).toHaveBeenCalled();
     });
 
     it("rejects when the process exits non-zero before any result event", async () => {

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -206,12 +206,15 @@ describe("LocalClaudeOrchestrator", () => {
   });
 
   describe("argv building per approval mode", () => {
-    it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {
+    it("always passes the serialized config strictly + the system prompt file", () => {
       const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "yolo", ["mcp__GitHub__create_issue"]);
-      expect(argv).toContain("--permission-mode");
-      expect(argv).toContain("bypassPermissions");
-      expect(argv).not.toContain("--allowedTools");
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", []);
+      // --strict-mcp-config keeps the run to YakShaver's servers only (no ambient .mcp.json).
+      expect(argv).toContain("--strict-mcp-config");
+      // The orchestrator role is delivered as the system prompt, not as the user turn.
+      const sysIdx = argv.indexOf("--system-prompt-file");
+      expect(sysIdx).toBeGreaterThan(-1);
+      expect(argv[sysIdx + 1]).toBe("/tmp/sys.txt");
       expect(argv).toEqual(
         expect.arrayContaining([
           "-p",
@@ -224,21 +227,47 @@ describe("LocalClaudeOrchestrator", () => {
       );
     });
 
-    it("ask -> --allowedTools built from the whitelist", () => {
+    it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {
       const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "ask", [
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", [
+        "mcp__GitHub__create_issue",
+      ]);
+      expect(argv).toContain("--permission-mode");
+      expect(argv).toContain("bypassPermissions");
+      expect(argv).not.toContain("--allowedTools");
+    });
+
+    it("wait -> --permission-mode bypassPermissions (matches OpenAI's auto-approve-after-delay)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      // wait auto-approves non-whitelisted tools after a delay on the OpenAI path; the headless
+      // analogue that still RUNS them is bypassPermissions, not a hard deny.
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "wait", []);
+      expect(argv).toContain("--permission-mode");
+      expect(argv).toContain("bypassPermissions");
+      expect(argv).not.toContain("--allowedTools");
+      expect(argv).not.toContain("dontAsk");
+    });
+
+    it("ask -> --permission-mode dontAsk + --allowedTools (denies non-whitelisted, never hangs)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "ask", [
         "mcp__GitHub__create_issue",
         "mcp__Local_FS__read_file",
       ]);
+      // dontAsk converts any approval prompt into a denial so a headless run can't block.
+      const pmIdx = argv.indexOf("--permission-mode");
+      expect(pmIdx).toBeGreaterThan(-1);
+      expect(argv[pmIdx + 1]).toBe("dontAsk");
       const idx = argv.indexOf("--allowedTools");
       expect(idx).toBeGreaterThan(-1);
       expect(argv[idx + 1]).toBe("mcp__GitHub__create_issue,mcp__Local_FS__read_file");
       expect(argv).not.toContain("bypassPermissions");
     });
 
-    it("wait with empty whitelist -> no --allowedTools and no bypass (constrained run)", () => {
+    it("ask with empty whitelist -> dontAsk and no --allowedTools (no MCP tools run, no hang)", () => {
       const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "wait", []);
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "ask", []);
+      expect(argv).toContain("dontAsk");
       expect(argv).not.toContain("--allowedTools");
       expect(argv).not.toContain("bypassPermissions");
     });
@@ -263,6 +292,8 @@ describe("LocalClaudeOrchestrator", () => {
         reasoning: "created",
       });
 
+      // Realistic stream: the tool_use block carries an OPAQUE id; the tool_result references it
+      // only via tool_use_id (NOT the tool name). The orchestrator must correlate id -> name.
       const lines = [
         JSON.stringify({
           type: "assistant",
@@ -272,7 +303,12 @@ describe("LocalClaudeOrchestrator", () => {
           type: "assistant",
           message: {
             content: [
-              { type: "tool_use", name: "mcp__GitHub__create_issue", input: { title: "Bug" } },
+              {
+                type: "tool_use",
+                id: "toolu_01ABCdef",
+                name: "mcp__GitHub__create_issue",
+                input: { title: "Bug" },
+              },
             ],
           },
         }),
@@ -282,7 +318,7 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_result",
-                tool_use_id: "mcp__GitHub__create_issue",
+                tool_use_id: "toolu_01ABCdef",
                 content: "Created issue #5: https://github.com/o/r/issues/5",
               },
             ],
@@ -309,7 +345,7 @@ describe("LocalClaudeOrchestrator", () => {
         onStep: (s) => steps.push(s),
       });
 
-      // stdin received the system prompt + transcript
+      // stdin received only the transcript as the user turn (the system prompt goes via argv).
       expect(runChild.stdin.write).toHaveBeenCalled();
       const written = (runChild.stdin.write as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(written).toContain("video transcription: a bug report");
@@ -319,6 +355,19 @@ describe("LocalClaudeOrchestrator", () => {
       expect(types).toContain("tool_call");
       expect(types).toContain("tool_result");
       expect(types).toContain("final_result");
+
+      // Reasoning is emitted JSON-encoded ({type,text}) so ReasoningStep renders it (not blank).
+      const reasoningStep = steps.find((s) => s.type === "reasoning");
+      expect(JSON.parse(reasoningStep?.reasoning ?? "{}")).toEqual({
+        type: "text",
+        text: "I'll create an issue.",
+      });
+
+      // The judge must receive the REAL tool name, correlated from the opaque tool_use_id — not
+      // the opaque `toolu_...` id itself.
+      const judgePrompt = generateObject.mock.calls[0][0] as string;
+      expect(judgePrompt).toContain("mcp__GitHub__create_issue");
+      expect(judgePrompt).not.toContain("toolu_01ABCdef");
 
       expect(generateObject).toHaveBeenCalledTimes(1);
       expect(result.backlogActionSucceeded).toBe(true);

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -1,0 +1,503 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ToolApprovalMode } from "../../../shared/types/user-settings";
+import { getDurationParts } from "../../utils/duration-utils";
+import type { VideoUploadResult } from "../auth/types";
+import { McpOAuthTokenStorage } from "../storage/mcp-oauth-token-storage";
+import { UserSettingsStorage } from "../storage/user-settings-storage";
+import {
+  type IBacklogOrchestrator,
+  judgeBacklogOutcome,
+  type ManualLoopOptions,
+  type MCPLoopResult,
+  type MCPTerminationReason,
+  type OutcomeJudgeProvider,
+  type ToolActivity,
+} from "./backlog-orchestrator";
+import { LanguageModelProvider } from "./language-model-provider";
+import { MCPServerManager } from "./mcp-server-manager";
+import { orchestratorSystemPrompt } from "./prompts";
+import type { MCPServerConfig } from "./types";
+
+/**
+ * Spawner abstraction mirroring ffmpeg-service's `IProcessSpawner`, kept here so the unit tests
+ * can inject a mock child process and assert on the exact argv without ever running `claude`.
+ */
+export interface IClaudeProcessSpawner {
+  spawn(command: string, args: string[]): ChildProcess;
+}
+
+const defaultClaudeSpawner: IClaudeProcessSpawner = {
+  spawn: (command, args) => spawn(command, args),
+};
+
+/** Claude Code's `--mcp-config` JSON entry for one stdio server. */
+interface ClaudeStdioServer {
+  type?: "stdio";
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/** Claude Code's `--mcp-config` JSON entry for one HTTP server. */
+interface ClaudeHttpServer {
+  type: "http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+type ClaudeMcpServer = ClaudeStdioServer | ClaudeHttpServer;
+
+export interface ClaudeMcpConfigFile {
+  mcpServers: Record<string, ClaudeMcpServer>;
+}
+
+/** Minimal token lookup the orchestrator needs — narrower than the full storage so tests stub it easily. */
+export interface TokenLookup {
+  getTokensAsync(serverId: string): Promise<{ access_token?: string } | undefined>;
+}
+
+/** Claude Code's tool name format is `mcp__<server>__<tool>`. Server names are sanitized to match. */
+function sanitizeServerName(name: string): string {
+  return name.replace(/\s+/g, "_");
+}
+
+/**
+ * Drives the backlog-creation step with a local headless `claude -p` process instead of the
+ * in-process OpenAI loop. Serializes the enabled MCP servers to a temp `--mcp-config`, maps the
+ * tool-approval mode to Claude's permission flags, streams `stream-json` events to `onStep`, and
+ * reuses the shared `judgeBacklogOutcome` on the collected tool results.
+ */
+export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
+  // Storage deps are resolved lazily — only when actually needed — so constructing the orchestrator
+  // (and the argv/serialization unit tests that do) never touches the electron-backed singletons.
+  constructor(
+    private readonly claudeCommand: string = "claude",
+    private readonly spawner: IClaudeProcessSpawner = defaultClaudeSpawner,
+    private readonly serverManager: Pick<MCPServerManager, "listAvailableServers"> | null = null,
+    private readonly tokenStorage: TokenLookup | null = null,
+    private readonly settingsStorage: Pick<UserSettingsStorage, "getSettingsAsync"> | null = null,
+    private readonly judgeProvider: OutcomeJudgeProvider | null = null,
+  ) {}
+
+  private getTokenStorage(): TokenLookup {
+    return this.tokenStorage ?? McpOAuthTokenStorage.getInstance();
+  }
+
+  private getSettingsStorage(): Pick<UserSettingsStorage, "getSettingsAsync"> {
+    return this.settingsStorage ?? UserSettingsStorage.getInstance();
+  }
+
+  /** Verifies the `claude` CLI is reachable; throws a user-actionable error if not. */
+  public async ensureClaudeAvailable(): Promise<void> {
+    const detected = await new Promise<boolean>((resolve) => {
+      let child: ChildProcess;
+      try {
+        child = this.spawner.spawn(this.claudeCommand, ["--version"]);
+      } catch {
+        resolve(false);
+        return;
+      }
+      child.on("error", () => resolve(false));
+      child.on("close", (code) => resolve(code === 0));
+    });
+
+    if (!detected) {
+      throw new Error(
+        "Claude Code CLI not found on PATH — install it, or switch Orchestrator to OpenAI in Settings.",
+      );
+    }
+  }
+
+  public async manualLoopAsync(
+    videoTranscription: string,
+    videoUploadResult?: VideoUploadResult,
+    options: ManualLoopOptions = {},
+  ): Promise<MCPLoopResult> {
+    await this.ensureClaudeAvailable();
+
+    const manager = this.serverManager ?? (await MCPServerManager.getInstanceAsync());
+    const approvalMode = (await this.getSettingsStorage().getSettingsAsync()).toolApprovalMode;
+
+    const systemPrompt = this.buildSystemPrompt(
+      options.projectMetaData,
+      options.desktopAgentProjectPrompt,
+      videoUploadResult,
+      options.videoFilePath,
+    );
+
+    const { mcpConfig, allowedTools, skippedNonWhitelistedServers } =
+      await this.serializeMcpServers(manager, options.serverFilter);
+
+    if (skippedNonWhitelistedServers.length > 0) {
+      console.warn(
+        `[LocalClaudeOrchestrator] No whitelisted tools for server(s): ${skippedNonWhitelistedServers.join(", ")} under "${approvalMode}" approval mode — proceeding with whatever is whitelisted; non-whitelisted tools were skipped.`,
+      );
+    }
+
+    const tmpConfigPath = join(tmpdir(), `yakshaver-mcp-${randomUUID()}.json`);
+    await fs.writeFile(tmpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf8");
+
+    try {
+      const argv = this.buildArgv(tmpConfigPath, approvalMode, allowedTools);
+      return await this.runClaude(argv, systemPrompt, videoTranscription, options);
+    } finally {
+      await fs.unlink(tmpConfigPath).catch(() => {
+        /* best-effort cleanup */
+      });
+    }
+  }
+
+  /**
+   * Builds the system prompt the same way `MCPOrchestrator` does: base orchestrator prompt +
+   * project metadata + project prompt + video info.
+   */
+  private buildSystemPrompt(
+    projectMetaData?: string,
+    desktopAgentProjectPrompt?: string,
+    videoUploadResult?: VideoUploadResult,
+    videoFilePath?: string,
+  ): string {
+    let systemPrompt = orchestratorSystemPrompt;
+
+    systemPrompt += projectMetaData ? `\n---\nProject Metadata:\n${projectMetaData}` : "";
+    systemPrompt += desktopAgentProjectPrompt
+      ? `\n---\nProject Prompt:\n${desktopAgentProjectPrompt}`
+      : "";
+
+    const videoUrl = videoUploadResult?.data?.url;
+    const duration = videoUploadResult?.data?.duration;
+    if (videoUrl) {
+      const isValidDuration = typeof duration === "number" && duration > 0;
+      if (isValidDuration) {
+        const outputDuration = getDurationParts(duration);
+        systemPrompt += `\n\nThis is the uploaded video URL: ${videoUrl}.
+Video duration:
+- totalSeconds: ${outputDuration.totalSeconds}
+- hours: ${outputDuration.hours}
+- minutes: ${outputDuration.minutes}
+- seconds: ${outputDuration.seconds}
+Embed this URL and duration in the task content that you create. Follow user requirements STRICTLY about the link formatting rule.`;
+      } else {
+        systemPrompt += `\n\nThis is the uploaded video URL: ${videoUrl}.
+Embed this URL in the task content that you create. Follow user requirements STRICTLY about the link formatting rule.`;
+      }
+    }
+
+    if (videoFilePath) {
+      systemPrompt += `\n\nVideo file available for screenshot capture: ${videoFilePath}.`;
+    }
+
+    return systemPrompt;
+  }
+
+  /**
+   * Serializes the enabled MCP servers (respecting `serverFilter`) into Claude Code's
+   * `--mcp-config` format. stdio → {command,args,env}; streamableHttp → {url, headers} with the
+   * OAuth bearer token injected from token storage when present. Also returns the `--allowedTools`
+   * derived from each server's whitelist (used under ask/wait approval modes).
+   */
+  public async serializeMcpServers(
+    manager: Pick<MCPServerManager, "listAvailableServers">,
+    serverFilter?: string[],
+  ): Promise<{
+    mcpConfig: ClaudeMcpConfigFile;
+    allowedTools: string[];
+    skippedNonWhitelistedServers: string[];
+  }> {
+    const all = await manager.listAvailableServers();
+    const filterSet = serverFilter && serverFilter.length > 0 ? new Set(serverFilter) : null;
+
+    const selected = all.filter((c) => {
+      if (c.enabled === false) return false;
+      if (!filterSet) return true;
+      return filterSet.has(c.id) || filterSet.has(c.name);
+    });
+
+    const mcpServers: Record<string, ClaudeMcpServer> = {};
+    const allowedTools: string[] = [];
+    const skippedNonWhitelistedServers: string[] = [];
+
+    for (const config of selected) {
+      // inMemory servers are YakShaver-internal; Claude Code can't reach them over its own
+      // transports, so they're skipped for the local backend.
+      if (config.transport === "inMemory") continue;
+
+      const serverKey = sanitizeServerName(config.name);
+      const entry = await this.toClaudeServerEntry(config);
+      if (!entry) continue;
+      mcpServers[serverKey] = entry;
+
+      const whitelist = config.toolWhitelist ?? [];
+      if (whitelist.length === 0) {
+        skippedNonWhitelistedServers.push(config.name);
+      }
+      for (const toolName of whitelist) {
+        allowedTools.push(`mcp__${serverKey}__${toolName}`);
+      }
+    }
+
+    return {
+      mcpConfig: { mcpServers },
+      allowedTools,
+      skippedNonWhitelistedServers,
+    };
+  }
+
+  private async toClaudeServerEntry(config: MCPServerConfig): Promise<ClaudeMcpServer | null> {
+    if (config.transport === "stdio") {
+      const entry: ClaudeStdioServer = {
+        type: "stdio",
+        command: config.command,
+      };
+      if (config.args && config.args.length > 0) entry.args = config.args;
+      if (config.env && Object.keys(config.env).length > 0) entry.env = config.env;
+      return entry;
+    }
+
+    if (config.transport === "streamableHttp") {
+      const headers: Record<string, string> = { ...config.headers };
+      // Inject the OAuth bearer token so Claude Code authenticates the same way the in-process
+      // client does (built-in servers don't use OAuth).
+      if (!config.builtin) {
+        const tokens = await this.getTokenStorage().getTokensAsync(config.id);
+        if (tokens?.access_token) {
+          headers.Authorization = `Bearer ${tokens.access_token}`;
+        }
+      }
+      const entry: ClaudeHttpServer = { type: "http", url: config.url };
+      if (Object.keys(headers).length > 0) entry.headers = headers;
+      return entry;
+    }
+
+    return null;
+  }
+
+  /**
+   * Maps the approval mode to Claude Code's permission flags:
+   * - `yolo` → `--permission-mode bypassPermissions` (run every tool immediately).
+   * - `ask` / `wait` → `--allowedTools <whitelist>` (only the whitelisted tools may run; anything
+   *   else is denied by Claude rather than hanging on an interactive prompt the headless run can't answer).
+   */
+  public buildArgv(
+    mcpConfigPath: string,
+    approvalMode: ToolApprovalMode,
+    allowedTools: string[],
+  ): string[] {
+    const argv = [
+      "-p",
+      "--mcp-config",
+      mcpConfigPath,
+      "--output-format",
+      "stream-json",
+      "--verbose",
+    ];
+
+    if (approvalMode === "yolo") {
+      argv.push("--permission-mode", "bypassPermissions");
+    } else {
+      // ask & wait: a headless process can't service interactive approvals, so we constrain the
+      // run to the user-approved (whitelisted) tools. An empty whitelist yields no extra tools.
+      if (allowedTools.length > 0) {
+        argv.push("--allowedTools", allowedTools.join(","));
+      }
+    }
+
+    return argv;
+  }
+
+  private async runClaude(
+    argv: string[],
+    systemPrompt: string,
+    videoTranscription: string,
+    options: ManualLoopOptions,
+  ): Promise<MCPLoopResult> {
+    const toolActivity: ToolActivity[] = [];
+
+    const child = this.spawner.spawn(this.claudeCommand, argv);
+
+    // The full prompt = system prompt + the transcript as the user input, passed over stdin so
+    // long transcripts don't bump into argv length limits.
+    const fullPrompt = `${systemPrompt}\n\n---\nvideo transcription: ${videoTranscription}`;
+    child.stdin?.write(fullPrompt);
+    child.stdin?.end();
+
+    const { finalText, terminationReason } = await new Promise<{
+      finalText: string;
+      terminationReason: MCPTerminationReason;
+    }>((resolve, reject) => {
+      let stdoutBuffer = "";
+      let stderr = "";
+      let finalText = "";
+      let terminationReason: MCPTerminationReason = "unknown";
+
+      const handleLine = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        let event: ClaudeStreamEvent;
+        try {
+          event = JSON.parse(trimmed) as ClaudeStreamEvent;
+        } catch {
+          // Non-JSON lines (e.g. stray logs) are ignored — the stream is newline-delimited JSON.
+          return;
+        }
+        const result = this.handleStreamEvent(event, toolActivity, options.onStep);
+        if (result.finalText !== undefined) finalText = result.finalText;
+        if (result.terminationReason) terminationReason = result.terminationReason;
+      };
+
+      child.stdout?.on("data", (data: Buffer) => {
+        stdoutBuffer += data.toString();
+        const lines = stdoutBuffer.split("\n");
+        // Keep the last (possibly partial) line in the buffer.
+        stdoutBuffer = lines.pop() ?? "";
+        for (const line of lines) handleLine(line);
+      });
+
+      child.stderr?.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      child.on("error", (error: Error) => {
+        reject(new Error(`Failed to start Claude Code: ${error.message}`));
+      });
+
+      child.on("close", (code: number | null) => {
+        // Flush any trailing buffered line.
+        if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
+
+        if (code !== 0 && terminationReason === "unknown") {
+          reject(
+            new Error(
+              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}`,
+            ),
+          );
+          return;
+        }
+        resolve({ finalText, terminationReason });
+      });
+    });
+
+    options.onStep?.({ type: "final_result", message: terminationReason });
+
+    const provider = this.judgeProvider ?? (await this.getJudgeProvider());
+    const outcome = await judgeBacklogOutcome(
+      provider,
+      options.desktopAgentProjectPrompt,
+      videoTranscription,
+      toolActivity,
+      finalText,
+    );
+
+    return {
+      text: finalText,
+      backlogActionSucceeded: outcome.achieved,
+      artifacts: outcome.artifacts,
+      terminationReason,
+    };
+  }
+
+  /**
+   * Translates one Claude Code stream-json event into the UI's `MCPStep` progress events (the
+   * same shape the OpenAI loop emits) and records tool calls/results for the outcome judge.
+   */
+  private handleStreamEvent(
+    event: ClaudeStreamEvent,
+    toolActivity: ToolActivity[],
+    onStep?: ManualLoopOptions["onStep"],
+  ): { finalText?: string; terminationReason?: MCPTerminationReason } {
+    // Assistant turn: may carry text and/or tool_use blocks.
+    if (event.type === "assistant" && event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === "text" && block.text) {
+          onStep?.({ type: "reasoning", reasoning: block.text });
+        } else if (block.type === "tool_use") {
+          onStep?.({
+            type: "tool_call",
+            toolName: block.name ?? "unknown",
+            args: block.input,
+          });
+        }
+      }
+      return {};
+    }
+
+    // User turn carries tool_result blocks (Claude reports tool outputs as a user message).
+    if (event.type === "user" && event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === "tool_result") {
+          const resultText = extractToolResultText(block.content);
+          const ok = block.is_error !== true;
+          toolActivity.push({
+            toolName: block.tool_use_id ?? "unknown",
+            ok,
+            resultText: resultText.slice(0, 8000),
+          });
+          onStep?.({ type: "tool_result", result: block.content });
+        }
+      }
+      return {};
+    }
+
+    // Terminal result event: carries the final text + how the run ended.
+    if (event.type === "result") {
+      const finalText = event.result ?? "";
+      const terminationReason: MCPTerminationReason =
+        event.subtype === "success"
+          ? "stop"
+          : event.subtype === "error_max_turns"
+            ? "max-iterations"
+            : "unknown";
+      return { finalText, terminationReason };
+    }
+
+    return {};
+  }
+
+  private async getJudgeProvider(): Promise<OutcomeJudgeProvider | null> {
+    try {
+      return await LanguageModelProvider.getInstance();
+    } catch (error) {
+      console.warn("[LocalClaudeOrchestrator] judge provider unavailable", error);
+      return null;
+    }
+  }
+}
+
+/** A loose view of the Claude Code stream-json events we care about. */
+interface ClaudeStreamEvent {
+  type: "assistant" | "user" | "result" | "system" | string;
+  subtype?: string;
+  result?: string;
+  message?: {
+    content?: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      input?: unknown;
+      tool_use_id?: string;
+      is_error?: boolean;
+      content?: unknown;
+    }>;
+  };
+}
+
+/** Tool results in stream-json may be a string or an array of `{type:"text", text}` blocks. */
+function extractToolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((item) =>
+        item && typeof item === "object" && "text" in item
+          ? String((item as { text?: unknown }).text ?? "")
+          : "",
+      )
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  if (content && typeof content === "object") return JSON.stringify(content);
+  return "";
+}

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -129,25 +129,63 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
       options.videoFilePath,
     );
 
-    const { mcpConfig, allowedTools, skippedNonWhitelistedServers } =
+    const { mcpConfig, allowedTools, skippedNonWhitelistedServers, droppedInMemoryServers } =
       await this.serializeMcpServers(manager, options.serverFilter);
 
-    if (skippedNonWhitelistedServers.length > 0) {
-      console.warn(
-        `[LocalClaudeOrchestrator] No whitelisted tools for server(s): ${skippedNonWhitelistedServers.join(", ")} under "${approvalMode}" approval mode — proceeding with whatever is whitelisted; non-whitelisted tools were skipped.`,
-      );
-    }
+    this.surfaceServerNotices(
+      approvalMode,
+      skippedNonWhitelistedServers,
+      droppedInMemoryServers,
+      options.onStep,
+    );
 
     const tmpConfigPath = join(tmpdir(), `yakshaver-mcp-${randomUUID()}.json`);
+    const tmpPromptPath = join(tmpdir(), `yakshaver-sysprompt-${randomUUID()}.txt`);
     await fs.writeFile(tmpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf8");
+    await fs.writeFile(tmpPromptPath, systemPrompt, "utf8");
 
     try {
-      const argv = this.buildArgv(tmpConfigPath, approvalMode, allowedTools);
-      return await this.runClaude(argv, systemPrompt, videoTranscription, options);
+      const argv = this.buildArgv(tmpConfigPath, tmpPromptPath, approvalMode, allowedTools);
+      return await this.runClaude(argv, videoTranscription, options);
     } finally {
-      await fs.unlink(tmpConfigPath).catch(() => {
-        /* best-effort cleanup */
-      });
+      await Promise.all([
+        fs.unlink(tmpConfigPath).catch(() => {
+          /* best-effort cleanup */
+        }),
+        fs.unlink(tmpPromptPath).catch(() => {
+          /* best-effort cleanup */
+        }),
+      ]);
+    }
+  }
+
+  /**
+   * Surfaces server-selection caveats to both the log and the UI (via an onStep notice) so the
+   * user understands why a tool/server may be unavailable under the local backend — rather than
+   * seeing a silent run that quietly does less than the OpenAI path would.
+   */
+  private surfaceServerNotices(
+    approvalMode: ToolApprovalMode,
+    skippedNonWhitelistedServers: string[],
+    droppedInMemoryServers: string[],
+    onStep?: ManualLoopOptions["onStep"],
+  ): void {
+    const notices: string[] = [];
+
+    if (skippedNonWhitelistedServers.length > 0 && approvalMode === "ask") {
+      const msg = `Claude Code (local) only runs whitelisted tools under "ask" approval mode (no runtime approval prompt). These server(s) have no whitelisted tools, so their tools were not made available: ${skippedNonWhitelistedServers.join(", ")}.`;
+      notices.push(msg);
+      console.warn(`[LocalClaudeOrchestrator] ${msg}`);
+    }
+
+    if (droppedInMemoryServers.length > 0) {
+      const msg = `Claude Code (local) cannot reach YakShaver's built-in in-memory tools, so these are unavailable under this backend (e.g. screenshot capture): ${droppedInMemoryServers.join(", ")}.`;
+      notices.push(msg);
+      console.warn(`[LocalClaudeOrchestrator] ${msg}`);
+    }
+
+    for (const text of notices) {
+      onStep?.({ type: "reasoning", reasoning: JSON.stringify({ type: "text", text }) });
     }
   }
 
@@ -207,6 +245,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
     mcpConfig: ClaudeMcpConfigFile;
     allowedTools: string[];
     skippedNonWhitelistedServers: string[];
+    droppedInMemoryServers: string[];
   }> {
     const all = await manager.listAvailableServers();
     const filterSet = serverFilter && serverFilter.length > 0 ? new Set(serverFilter) : null;
@@ -220,11 +259,16 @@ Embed this URL in the task content that you create. Follow user requirements STR
     const mcpServers: Record<string, ClaudeMcpServer> = {};
     const allowedTools: string[] = [];
     const skippedNonWhitelistedServers: string[] = [];
+    const droppedInMemoryServers: string[] = [];
 
     for (const config of selected) {
-      // inMemory servers are YakShaver-internal; Claude Code can't reach them over its own
-      // transports, so they're skipped for the local backend.
-      if (config.transport === "inMemory") continue;
+      // inMemory servers are YakShaver-internal (e.g. Yak_Video_Tools' screenshot capture); Claude
+      // Code can't reach them over its own transports, so they're dropped for the local backend.
+      // Surface them so the caller can warn the user that the local backend lacks those tools.
+      if (config.transport === "inMemory") {
+        droppedInMemoryServers.push(config.name);
+        continue;
+      }
 
       const serverKey = sanitizeServerName(config.name);
       const entry = await this.toClaudeServerEntry(config);
@@ -244,6 +288,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
       mcpConfig: { mcpServers },
       allowedTools,
       skippedNonWhitelistedServers,
+      droppedInMemoryServers,
     };
   }
 
@@ -277,13 +322,27 @@ Embed this URL in the task content that you create. Follow user requirements STR
   }
 
   /**
-   * Maps the approval mode to Claude Code's permission flags:
+   * Maps the approval mode to Claude Code's permission flags.
+   *
    * - `yolo` → `--permission-mode bypassPermissions` (run every tool immediately).
-   * - `ask` / `wait` → `--allowedTools <whitelist>` (only the whitelisted tools may run; anything
-   *   else is denied by Claude rather than hanging on an interactive prompt the headless run can't answer).
+   * - `wait` → ALSO `--permission-mode bypassPermissions`. In the OpenAI backend `wait` shows the
+   *   approval prompt but AUTO-APPROVES after a delay, so a non-whitelisted tool the user doesn't
+   *   dismiss still RUNS. A headless `claude -p` can't render a deferred prompt, so the faithful
+   *   analogue of "auto-approve after a delay" is to bypass permissions — otherwise `wait` would
+   *   silently HARD-DENY non-whitelisted tools, diverging from the OpenAI behaviour for the same
+   *   setting. (See requestToolApproval's `wait` -> auto-approve path.)
+   * - `ask` → `--allowedTools <whitelist>` + `--permission-mode dontAsk`. `--allowedTools` only
+   *   auto-approves the listed tools; on its own (default permission mode) a non-whitelisted tool
+   *   would trigger an interactive prompt the headless run can't answer and the run can hang/abort.
+   *   `dontAsk` converts any such prompt into an outright denial, so the run never blocks.
+   *
+   * `--strict-mcp-config` ensures Claude only uses the servers we serialized into `--mcp-config`,
+   * ignoring any ambient project `.mcp.json` / `~/.claude` MCP config so the embedded run is
+   * deterministic across machines and can't reach servers YakShaver never configured.
    */
   public buildArgv(
     mcpConfigPath: string,
+    systemPromptPath: string,
     approvalMode: ToolApprovalMode,
     allowedTools: string[],
   ): string[] {
@@ -291,16 +350,21 @@ Embed this URL in the task content that you create. Follow user requirements STR
       "-p",
       "--mcp-config",
       mcpConfigPath,
+      "--strict-mcp-config",
+      "--system-prompt-file",
+      systemPromptPath,
       "--output-format",
       "stream-json",
       "--verbose",
     ];
 
-    if (approvalMode === "yolo") {
+    if (approvalMode === "yolo" || approvalMode === "wait") {
       argv.push("--permission-mode", "bypassPermissions");
     } else {
-      // ask & wait: a headless process can't service interactive approvals, so we constrain the
-      // run to the user-approved (whitelisted) tools. An empty whitelist yields no extra tools.
+      // ask: only the user-approved (whitelisted) tools auto-approve; `dontAsk` denies anything
+      // else instead of prompting (which a headless run can't answer). An empty whitelist means
+      // no MCP tools run.
+      argv.push("--permission-mode", "dontAsk");
       if (allowedTools.length > 0) {
         argv.push("--allowedTools", allowedTools.join(","));
       }
@@ -311,18 +375,20 @@ Embed this URL in the task content that you create. Follow user requirements STR
 
   private async runClaude(
     argv: string[],
-    systemPrompt: string,
     videoTranscription: string,
     options: ManualLoopOptions,
   ): Promise<MCPLoopResult> {
     const toolActivity: ToolActivity[] = [];
+    // Correlates a tool_use block's opaque id (e.g. `toolu_01ABC...`) back to its real tool name,
+    // so the tool_result we record later carries the actual name instead of the opaque id.
+    const toolNameById = new Map<string, string>();
 
     const child = this.spawner.spawn(this.claudeCommand, argv);
 
-    // The full prompt = system prompt + the transcript as the user input, passed over stdin so
-    // long transcripts don't bump into argv length limits.
-    const fullPrompt = `${systemPrompt}\n\n---\nvideo transcription: ${videoTranscription}`;
-    child.stdin?.write(fullPrompt);
+    // The orchestrator role is delivered via `--system-prompt` (in argv), so only the transcript
+    // goes on stdin as the user turn. Passing it over stdin avoids argv length limits.
+    const userPrompt = `video transcription: ${videoTranscription}`;
+    child.stdin?.write(userPrompt);
     child.stdin?.end();
 
     const { finalText, terminationReason } = await new Promise<{
@@ -344,7 +410,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
           // Non-JSON lines (e.g. stray logs) are ignored — the stream is newline-delimited JSON.
           return;
         }
-        const result = this.handleStreamEvent(event, toolActivity, options.onStep);
+        const result = this.handleStreamEvent(event, toolActivity, toolNameById, options.onStep);
         if (result.finalText !== undefined) finalText = result.finalText;
         if (result.terminationReason) terminationReason = result.terminationReason;
       };
@@ -384,6 +450,22 @@ Embed this URL in the task content that you create. Follow user requirements STR
     options.onStep?.({ type: "final_result", message: terminationReason });
 
     const provider = this.judgeProvider ?? (await this.getJudgeProvider());
+
+    // The success judge (#833) runs on the configured OpenAI/Azure language model — it is NOT
+    // driven by Claude. If a user selected Claude Code (local) to avoid configuring a language
+    // model, the judge is unavailable and judgeBacklogOutcome fails CLOSED, so a run where Claude
+    // genuinely filed an item would be reported as FAILED. Surface that cause instead of a silent
+    // misleading failure.
+    if (!provider && toolActivity.some((t) => t.ok)) {
+      const text =
+        "Claude Code (local) created or updated something, but success could NOT be verified " +
+        "because no OpenAI/Azure language model is configured — Claude Code orchestration still " +
+        "needs a configured language model to verify the outcome. Configure one in Settings to " +
+        "confirm success.";
+      options.onStep?.({ type: "reasoning", reasoning: JSON.stringify({ type: "text", text }) });
+      console.warn(`[LocalClaudeOrchestrator] ${text}`);
+    }
+
     const outcome = await judgeBacklogOutcome(
       provider,
       options.desktopAgentProjectPrompt,
@@ -407,17 +489,27 @@ Embed this URL in the task content that you create. Follow user requirements STR
   private handleStreamEvent(
     event: ClaudeStreamEvent,
     toolActivity: ToolActivity[],
+    toolNameById: Map<string, string>,
     onStep?: ManualLoopOptions["onStep"],
   ): { finalText?: string; terminationReason?: MCPTerminationReason } {
     // Assistant turn: may carry text and/or tool_use blocks.
     if (event.type === "assistant" && event.message?.content) {
       for (const block of event.message.content) {
         if (block.type === "text" && block.text) {
-          onStep?.({ type: "reasoning", reasoning: block.text });
+          // Match the OpenAI loop's payload shape so ReasoningStep's JSON.parse path renders it
+          // (it reads `parsed.text`). Emitting raw text here would render blank in the UI.
+          onStep?.({
+            type: "reasoning",
+            reasoning: JSON.stringify({ type: "text", text: block.text }),
+          });
         } else if (block.type === "tool_use") {
+          const toolName = block.name ?? "unknown";
+          // Remember which tool this opaque id belongs to so the matching tool_result (which only
+          // carries the id) can be recorded under the real tool name.
+          if (block.id) toolNameById.set(block.id, toolName);
           onStep?.({
             type: "tool_call",
-            toolName: block.name ?? "unknown",
+            toolName,
             args: block.input,
           });
         }
@@ -431,8 +523,14 @@ Embed this URL in the task content that you create. Follow user requirements STR
         if (block.type === "tool_result") {
           const resultText = extractToolResultText(block.content);
           const ok = block.is_error !== true;
+          // `tool_use_id` is the opaque correlation id of the originating tool_use block, NOT the
+          // tool name. Resolve it back to the real name so the judge and logs see meaningful names.
+          const toolName =
+            (block.tool_use_id ? toolNameById.get(block.tool_use_id) : undefined) ??
+            block.tool_use_id ??
+            "unknown";
           toolActivity.push({
-            toolName: block.tool_use_id ?? "unknown",
+            toolName,
             ok,
             resultText: resultText.slice(0, 8000),
           });
@@ -475,6 +573,7 @@ interface ClaudeStreamEvent {
   message?: {
     content?: Array<{
       type: string;
+      id?: string;
       text?: string;
       name?: string;
       input?: unknown;

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -462,6 +462,13 @@ Embed this URL in the task content that you create. Follow user requirements STR
     // The orchestrator role is delivered via `--system-prompt` (in argv), so only the transcript
     // goes on stdin as the user turn. Passing it over stdin avoids argv length limits.
     const userPrompt = `video transcription: ${videoTranscription}`;
+    // If `claude` dies before/while we write, its stdin pipe closes and the write emits EPIPE on the
+    // stdin stream. An unhandled `error` on a stream throws (and would crash the host process), so
+    // swallow it here — the real failure is reported by the child's `error`/non-zero `close` paths.
+    // (Optional `?.on` guards the unit-test mock whose stdin is a plain `{write,end}` object.)
+    child.stdin?.on?.("error", () => {
+      /* EPIPE on a dead child — handled via child error/close below */
+    });
     child.stdin?.write(userPrompt);
     child.stdin?.end();
 

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 import { getDurationParts } from "../../utils/duration-utils";
 import type { VideoUploadResult } from "../auth/types";
+import type { IProcessSpawner } from "../process/process-spawner";
 import { McpOAuthTokenStorage } from "../storage/mcp-oauth-token-storage";
 import { UserSettingsStorage } from "../storage/user-settings-storage";
 import {
@@ -19,19 +20,23 @@ import {
 } from "./backlog-orchestrator";
 import { LanguageModelProvider } from "./language-model-provider";
 import { MCPServerManager } from "./mcp-server-manager";
+import { getFreshAccessTokenAsync, type RefreshableTokenStorage } from "./mcp-token-refresh";
 import { orchestratorSystemPrompt } from "./prompts";
 import type { MCPServerConfig } from "./types";
 
-/**
- * Spawner abstraction mirroring ffmpeg-service's `IProcessSpawner`, kept here so the unit tests
- * can inject a mock child process and assert on the exact argv without ever running `claude`.
- */
-export interface IClaudeProcessSpawner {
-  spawn(command: string, args: string[]): ChildProcess;
-}
+/** Default safety cap on tool iterations when the caller doesn't supply one (mirrors the OpenAI loop). */
+const DEFAULT_MAX_TOOL_ITERATIONS = 20;
 
-const defaultClaudeSpawner: IClaudeProcessSpawner = {
-  spawn: (command, args) => spawn(command, args),
+/**
+ * Default spawner for the `claude` CLI. On Windows, an npm-global install of `@anthropic-ai/claude-code`
+ * places a `claude.cmd`/`claude.ps1` shim on PATH (no `.exe`), and Node's `child_process.spawn` cannot
+ * launch a `.cmd`/`.ps1` shim without `shell: true` — it throws ENOENT, which would make a user who
+ * genuinely has Claude Code installed see a false "not found". So spawn through the shell on win32.
+ * (ffmpeg-service can use the plain spawner because it launches an absolute bundled binary, never a
+ * bare PATH name.)
+ */
+const defaultClaudeSpawner: IProcessSpawner = {
+  spawn: (command, args) => spawn(command, args, { shell: process.platform === "win32" }),
 };
 
 /** Claude Code's `--mcp-config` JSON entry for one stdio server. */
@@ -55,10 +60,13 @@ export interface ClaudeMcpConfigFile {
   mcpServers: Record<string, ClaudeMcpServer>;
 }
 
-/** Minimal token lookup the orchestrator needs — narrower than the full storage so tests stub it easily. */
-export interface TokenLookup {
-  getTokensAsync(serverId: string): Promise<{ access_token?: string } | undefined>;
-}
+/**
+ * Token lookup the orchestrator needs. A bare `getTokensAsync` is enough for tests; the real
+ * `McpOAuthTokenStorage` also provides the optional refresh hooks (`isTokenExpired` /
+ * `saveTokensAsync` / `clearTokensAsync`) so expired tokens are refreshed before use — see
+ * `getFreshAccessTokenAsync`.
+ */
+export type TokenLookup = RefreshableTokenStorage;
 
 /** Claude Code's tool name format is `mcp__<server>__<tool>`. Server names are sanitized to match. */
 function sanitizeServerName(name: string): string {
@@ -76,7 +84,7 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
   // (and the argv/serialization unit tests that do) never touches the electron-backed singletons.
   constructor(
     private readonly claudeCommand: string = "claude",
-    private readonly spawner: IClaudeProcessSpawner = defaultClaudeSpawner,
+    private readonly spawner: IProcessSpawner = defaultClaudeSpawner,
     private readonly serverManager: Pick<MCPServerManager, "listAvailableServers"> | null = null,
     private readonly tokenStorage: TokenLookup | null = null,
     private readonly settingsStorage: Pick<UserSettingsStorage, "getSettingsAsync"> | null = null,
@@ -93,23 +101,37 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
 
   /** Verifies the `claude` CLI is reachable; throws a user-actionable error if not. */
   public async ensureClaudeAvailable(): Promise<void> {
-    const detected = await new Promise<boolean>((resolve) => {
+    const { ok, spawnError } = await new Promise<{ ok: boolean; spawnError?: Error }>((resolve) => {
       let child: ChildProcess;
       try {
         child = this.spawner.spawn(this.claudeCommand, ["--version"]);
-      } catch {
-        resolve(false);
+      } catch (error) {
+        resolve({
+          ok: false,
+          spawnError: error instanceof Error ? error : new Error(String(error)),
+        });
         return;
       }
-      child.on("error", () => resolve(false));
-      child.on("close", (code) => resolve(code === 0));
+      // An `error` event (e.g. ENOENT) means we could not launch the binary at all.
+      child.on("error", (error: Error) => resolve({ ok: false, spawnError: error }));
+      // A non-zero exit means the binary launched but reported a problem (not a PATH miss).
+      child.on("close", (code) => resolve({ ok: code === 0, spawnError: undefined }));
     });
 
-    if (!detected) {
+    if (ok) return;
+
+    // Distinguish "couldn't launch the process at all" (PATH miss / unlaunchable shim) from
+    // "launched but exited non-zero" so the message points at the real cause.
+    if (spawnError) {
       throw new Error(
-        "Claude Code CLI not found on PATH — install it, or switch Orchestrator to OpenAI in Settings.",
+        `Claude Code CLI could not be launched (${spawnError.message}). Make sure the \`claude\` ` +
+          "CLI is installed and on PATH, or switch Orchestrator to OpenAI in Settings.",
       );
     }
+    throw new Error(
+      "Claude Code CLI was found but `claude --version` exited with an error. Reinstall the " +
+        "CLI, or switch Orchestrator to OpenAI in Settings.",
+    );
   }
 
   public async manualLoopAsync(
@@ -141,11 +163,23 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
 
     const tmpConfigPath = join(tmpdir(), `yakshaver-mcp-${randomUUID()}.json`);
     const tmpPromptPath = join(tmpdir(), `yakshaver-sysprompt-${randomUUID()}.txt`);
-    await fs.writeFile(tmpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf8");
-    await fs.writeFile(tmpPromptPath, systemPrompt, "utf8");
+    // The MCP config carries the live OAuth bearer token, so write it owner-read/write only
+    // (0600). Without this, Node defaults to 0644 and `tmpdir()` is a world-readable shared dir
+    // on POSIX, so any local user could read the token for the lifetime of the run.
+    await fs.writeFile(tmpConfigPath, JSON.stringify(mcpConfig, null, 2), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await fs.writeFile(tmpPromptPath, systemPrompt, { encoding: "utf8", mode: 0o600 });
 
     try {
-      const argv = this.buildArgv(tmpConfigPath, tmpPromptPath, approvalMode, allowedTools);
+      const argv = this.buildArgv(
+        tmpConfigPath,
+        tmpPromptPath,
+        approvalMode,
+        allowedTools,
+        options.maxToolIterations ?? DEFAULT_MAX_TOOL_ITERATIONS,
+      );
       return await this.runClaude(argv, videoTranscription, options);
     } finally {
       await Promise.all([
@@ -174,6 +208,19 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
 
     if (skippedNonWhitelistedServers.length > 0 && approvalMode === "ask") {
       const msg = `Claude Code (local) only runs whitelisted tools under "ask" approval mode (no runtime approval prompt). These server(s) have no whitelisted tools, so their tools were not made available: ${skippedNonWhitelistedServers.join(", ")}.`;
+      notices.push(msg);
+      console.warn(`[LocalClaudeOrchestrator] ${msg}`);
+    }
+
+    // Under "wait", the OpenAI path shows a 15s approval dialog the user can still deny within. A
+    // headless `claude -p` can't render that deferred prompt, so "wait" runs EVERY tool immediately
+    // (effectively YOLO) under the local backend. Tell the user so the safe-looking "wait" setting
+    // doesn't silently widen tool execution without any signal.
+    if (approvalMode === "wait") {
+      const msg =
+        'Claude Code (local) cannot show the "wait" approval dialog because it runs headlessly, ' +
+        "so under this backend every tool runs immediately without a chance to deny (the same as " +
+        '"YOLO"). Switch to "ask" to restrict the run to whitelisted tools only.';
       notices.push(msg);
       console.warn(`[LocalClaudeOrchestrator] ${msg}`);
     }
@@ -306,11 +353,17 @@ Embed this URL in the task content that you create. Follow user requirements STR
     if (config.transport === "streamableHttp") {
       const headers: Record<string, string> = { ...config.headers };
       // Inject the OAuth bearer token so Claude Code authenticates the same way the in-process
-      // client does (built-in servers don't use OAuth).
+      // client does (built-in servers don't use OAuth). Refresh an expired token first — the same
+      // freshness guarantee MCPServerClient applies — so the local backend doesn't hand Claude a
+      // stale token that an HTTP MCP server would 401.
       if (!config.builtin) {
-        const tokens = await this.getTokenStorage().getTokensAsync(config.id);
-        if (tokens?.access_token) {
-          headers.Authorization = `Bearer ${tokens.access_token}`;
+        const accessToken = await getFreshAccessTokenAsync(
+          this.getTokenStorage(),
+          config.id,
+          config.url,
+        );
+        if (accessToken) {
+          headers.Authorization = `Bearer ${accessToken}`;
         }
       }
       const entry: ClaudeHttpServer = { type: "http", url: config.url };
@@ -345,6 +398,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
     systemPromptPath: string,
     approvalMode: ToolApprovalMode,
     allowedTools: string[],
+    maxToolIterations: number = DEFAULT_MAX_TOOL_ITERATIONS,
   ): string[] {
     const argv = [
       "-p",
@@ -356,6 +410,11 @@ Embed this URL in the task content that you create. Follow user requirements STR
       "--output-format",
       "stream-json",
       "--verbose",
+      // Mirror the OpenAI loop's iteration safety cap (`maxToolIterations`) so a runaway local
+      // run is bounded by the SAME limit; `handleStreamEvent` maps Claude's `error_max_turns` to
+      // our `max-iterations` termination reason.
+      "--max-turns",
+      String(maxToolIterations),
     ];
 
     if (approvalMode === "yolo" || approvalMode === "wait") {

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -28,6 +28,15 @@ import type { MCPServerConfig } from "./types";
 const DEFAULT_MAX_TOOL_ITERATIONS = 20;
 
 /**
+ * Wall-clock cap on a single headless `claude -p` run. `--max-turns` bounds the number of agent
+ * TURNS, but a tool stalled on I/O (a hung MCP server, a network stall) never advances a turn, so
+ * that cap never trips and the awaited Promise would hang EXECUTING_TASK forever. This timeout
+ * kills the child and rejects with a clear message so a stuck run surfaces instead of hanging.
+ * Overridable via `LOCAL_CLAUDE_RUN_TIMEOUT_MS` for slow environments / long-running tools.
+ */
+const DEFAULT_RUN_TIMEOUT_MS = Number(process.env.LOCAL_CLAUDE_RUN_TIMEOUT_MS ?? 10 * 60 * 1000);
+
+/**
  * Default spawner for the `claude` CLI. On Windows, an npm-global install of `@anthropic-ai/claude-code`
  * places a `claude.cmd`/`claude.ps1` shim on PATH (no `.exe`), and Node's `child_process.spawn` cannot
  * launch a `.cmd`/`.ps1` shim without `shell: true` — it throws ENOENT, which would make a user who
@@ -89,6 +98,7 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
     private readonly tokenStorage: TokenLookup | null = null,
     private readonly settingsStorage: Pick<UserSettingsStorage, "getSettingsAsync"> | null = null,
     private readonly judgeProvider: OutcomeJudgeProvider | null = null,
+    private readonly runTimeoutMs: number = DEFAULT_RUN_TIMEOUT_MS,
   ) {}
 
   private getTokenStorage(): TokenLookup {
@@ -442,6 +452,11 @@ Embed this URL in the task content that you create. Follow user requirements STR
     // so the tool_result we record later carries the actual name instead of the opaque id.
     const toolNameById = new Map<string, string>();
 
+    // Reject early if the caller already aborted before we spawned anything.
+    if (options.signal?.aborted) {
+      throw new Error("Claude Code run was cancelled.");
+    }
+
     const child = this.spawner.spawn(this.claudeCommand, argv);
 
     // The orchestrator role is delivered via `--system-prompt` (in argv), so only the transcript
@@ -458,6 +473,50 @@ Embed this URL in the task content that you create. Follow user requirements STR
       let stderr = "";
       let finalText = "";
       let terminationReason: MCPTerminationReason = "unknown";
+      let settled = false;
+
+      // Kill the spawned child on any terminal path (timeout, abort, error, non-zero exit) so a
+      // stalled `claude -p` never lingers as an orphan after we stop awaiting it.
+      const killChild = () => {
+        try {
+          child.kill();
+        } catch {
+          /* the child may already be gone — best effort */
+        }
+      };
+
+      // A wall-clock guard: `--max-turns` bounds turns, not time, so a tool hung on I/O would hang
+      // forever. On timeout, kill the child and reject with an actionable message.
+      const timeoutMs = this.runTimeoutMs;
+      const timeoutId = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        killChild();
+        reject(
+          new Error(
+            `Claude Code run timed out after ${Math.round(timeoutMs / 1000)}s with no result. ` +
+              "The Claude CLI or an MCP tool may be stalled — try again, or switch Orchestrator " +
+              "to OpenAI in Settings.",
+          ),
+        );
+      }, timeoutMs);
+
+      // Cancellation: when the caller's signal fires, kill the child and reject so an in-flight
+      // local run can be aborted the way the OpenAI backend can.
+      const onAbort = () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        killChild();
+        reject(new Error("Claude Code run was cancelled."));
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        options.signal?.removeEventListener("abort", onAbort);
+      };
+      options.signal?.addEventListener("abort", onAbort);
 
       const handleLine = (line: string) => {
         const trimmed = line.trim();
@@ -487,10 +546,17 @@ Embed this URL in the task content that you create. Follow user requirements STR
       });
 
       child.on("error", (error: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        killChild();
         reject(new Error(`Failed to start Claude Code: ${error.message}`));
       });
 
       child.on("close", (code: number | null) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
         // Flush any trailing buffered line.
         if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
 
@@ -510,21 +576,6 @@ Embed this URL in the task content that you create. Follow user requirements STR
 
     const provider = this.judgeProvider ?? (await this.getJudgeProvider());
 
-    // The success judge (#833) runs on the configured OpenAI/Azure language model — it is NOT
-    // driven by Claude. If a user selected Claude Code (local) to avoid configuring a language
-    // model, the judge is unavailable and judgeBacklogOutcome fails CLOSED, so a run where Claude
-    // genuinely filed an item would be reported as FAILED. Surface that cause instead of a silent
-    // misleading failure.
-    if (!provider && toolActivity.some((t) => t.ok)) {
-      const text =
-        "Claude Code (local) created or updated something, but success could NOT be verified " +
-        "because no OpenAI/Azure language model is configured — Claude Code orchestration still " +
-        "needs a configured language model to verify the outcome. Configure one in Settings to " +
-        "confirm success.";
-      options.onStep?.({ type: "reasoning", reasoning: JSON.stringify({ type: "text", text }) });
-      console.warn(`[LocalClaudeOrchestrator] ${text}`);
-    }
-
     const outcome = await judgeBacklogOutcome(
       provider,
       options.desktopAgentProjectPrompt,
@@ -533,11 +584,27 @@ Embed this URL in the task content that you create. Follow user requirements STR
       finalText,
     );
 
+    // The success judge (#833) runs on the configured OpenAI/Azure language model — it is NOT
+    // driven by Claude. If a user selected Claude Code to avoid configuring a language model, the
+    // judge is unavailable: judgeBacklogOutcome fails CLOSED but flags verificationUnavailable so
+    // a run where Claude genuinely filed an item isn't reported with the misleading generic
+    // "backlog signed out" copy. Surface the real cause in the step stream too.
+    if (outcome.verificationUnavailable) {
+      const text =
+        "Claude Code created or updated something, but success could NOT be verified because no " +
+        "OpenAI/Azure language model is configured — Claude Code orchestration still needs a " +
+        "configured language model to verify the outcome. Check your backlog before re-running " +
+        "(to avoid duplicates), and configure a language model in Settings to confirm success.";
+      options.onStep?.({ type: "reasoning", reasoning: JSON.stringify({ type: "text", text }) });
+      console.warn(`[LocalClaudeOrchestrator] ${text}`);
+    }
+
     return {
       text: finalText,
       backlogActionSucceeded: outcome.achieved,
       artifacts: outcome.artifacts,
       terminationReason,
+      verificationUnavailable: outcome.verificationUnavailable,
     };
   }
 

--- a/src/backend/services/mcp/mcp-orchestrator.false-success.test.ts
+++ b/src/backend/services/mcp/mcp-orchestrator.false-success.test.ts
@@ -274,6 +274,20 @@ describe("#833 — outcome is judged from tool RESULTS, not tool-name heuristics
     const r = await orch.manualLoopAsync("a bug report transcript", undefined, {});
     expect(r.backlogActionSucceeded).toBe(false);
   });
+
+  it("judge says achieved:true but every cited artifact has a BLANK idOrUrl → treated as failure", async () => {
+    // `idOrUrl` is `z.string()`, so "" parses. A non-empty `artifacts` array with only blank ids is
+    // no evidence at all — it must not phantom-succeed.
+    const createIssue = tool("the model emitted an artifact entry but left idOrUrl empty");
+    const { orch } = makeOrchestrator(
+      [toolTurn("github__create_issue"), stop("Done!")],
+      { github__create_issue: createIssue },
+      ["github__create_issue"],
+      { achieved: true, artifacts: [{ type: "issue", idOrUrl: "   " }] }, // blank/whitespace id
+    );
+    const r = await orch.manualLoopAsync("a bug report transcript", undefined, {});
+    expect(r.backlogActionSucceeded).toBe(false);
+  });
 });
 
 describe("BacklogOutcomeSchema stays OpenAI strict-structured-output compatible", () => {

--- a/src/backend/services/mcp/mcp-orchestrator.ts
+++ b/src/backend/services/mcp/mcp-orchestrator.ts
@@ -1,65 +1,33 @@
 import { randomUUID } from "node:crypto";
 import type { ModelMessage, ToolExecutionOptions, ToolModelMessage, UserModelMessage } from "ai";
-import { type ZodType, z } from "zod";
-import type { MCPStep } from "../../../shared/types/mcp";
+import type { ZodType } from "zod";
 import { getDurationParts } from "../../utils/duration-utils";
 import { formatAndReportError } from "../../utils/error-utils";
 import type { VideoUploadResult } from "../auth/types";
 import { TelemetryService } from "../telemetry/telemetry-service";
 import { UserInteractionService } from "../user-interaction/user-interaction-service";
+import {
+  type BacklogArtifact,
+  type IBacklogOrchestrator,
+  judgeBacklogOutcome,
+  type ManualLoopOptions,
+  type MCPLoopResult,
+  type MCPTerminationReason,
+  type ToolActivity,
+} from "./backlog-orchestrator";
 import { LanguageModelProvider } from "./language-model-provider";
 import { MCPServerManager } from "./mcp-server-manager";
 import { orchestratorSystemPrompt } from "./prompts";
 
-export type MCPTerminationReason =
-  | "stop"
-  | "length"
-  | "content-filter"
-  | "cancelled"
-  | "max-iterations"
-  | "unknown";
-
-export interface BacklogArtifact {
-  /** e.g. "issue", "work_item", "ticket", "comment", "pull_request". */
-  type: string;
-  /** The concrete identifier or URL evidencing the created/updated item. */
-  idOrUrl: string;
-}
-
-export interface MCPLoopResult {
-  /** The model's final text output — the drafted work item, or a message explaining why it stopped. */
-  text: string;
-  /**
-   * True only when a backlog item was actually created/updated, decided from the TOOL RESULTS
-   * (not the model's narration). A graceful `stop` with only internal tools, no tools, or an
-   * errored mutation means nothing was filed.
-   */
-  backlogActionSucceeded: boolean;
-  /** The concrete created/updated artifacts the judge found (issue ids/URLs), if any. */
-  artifacts: BacklogArtifact[];
-  /** Why the loop ended — distinguishes a clean finish from hitting a safety cap. */
-  terminationReason: MCPTerminationReason;
-}
-
-/** One executed tool call and (a truncated view of) its result — the ground truth the judge reasons over. */
-interface ToolActivity {
-  toolName: string;
-  ok: boolean;
-  resultText: string;
-}
-
-/**
- * Structured verdict from the outcome judge. Every field is REQUIRED — no `.optional()` / `.default()`.
- * OpenAI strict structured outputs reject a schema whose `required` omits any property, so a
- * `.default()` here makes the field optional and breaks the real `generateObject` call at runtime
- * ("Invalid schema for response_format … Missing 'artifacts'"). That only surfaces against a live
- * model, never in tests that stub generateObject — so keep this schema strict-compatible.
- */
-export const BacklogOutcomeSchema = z.object({
-  achieved: z.boolean(),
-  artifacts: z.array(z.object({ type: z.string(), idOrUrl: z.string() })),
-  reasoning: z.string(),
-});
+// Re-export the shared backlog-orchestrator contract from here so existing importers
+// (and tests) that reference these symbols on the orchestrator module keep working.
+export {
+  type BacklogArtifact,
+  BacklogOutcomeSchema,
+  type IBacklogOrchestrator,
+  type MCPLoopResult,
+  type MCPTerminationReason,
+} from "./backlog-orchestrator";
 
 /**
  * Tool Output Buffer for host-level tool chaining.
@@ -129,7 +97,7 @@ export class ToolOutputBuffer {
   }
 }
 
-export class MCPOrchestrator {
+export class MCPOrchestrator implements IBacklogOrchestrator {
   private static instance: MCPOrchestrator;
 
   private static languageModelProvider: LanguageModelProvider | null = null;
@@ -177,15 +145,7 @@ export class MCPOrchestrator {
   public async manualLoopAsync(
     videoTranscription: string,
     videoUploadResult?: VideoUploadResult,
-    options: {
-      projectMetaData?: string;
-      desktopAgentProjectPrompt?: string;
-      maxToolIterations?: number; // safety cap to avoid infinite loops
-      videoFilePath?: string; // local video file path for screenshot capture
-      serverFilter?: string[]; // if provided, only include tools from these server IDs
-      shaveId?: string; // identifies the current shave for per-shave auto-approve
-      onStep?: (step: MCPStep) => void;
-    } = {},
+    options: ManualLoopOptions = {},
   ): Promise<MCPLoopResult> {
     // Ensure LLM has been initialized
     if (!MCPOrchestrator.languageModelProvider) {
@@ -574,12 +534,9 @@ export class MCPOrchestrator {
   }
 
   /**
-   * Decides whether the run ACTUALLY created/updated a backlog item, judging from the tool
-   * RESULTS (ground truth) rather than a tool-name heuristic or the model's own claims (#833).
-   *
-   * Short-circuits to "not achieved" when no tool call succeeded (the common signed-out case),
-   * so the extra LLM call only happens when something plausibly did get filed. Fails CLOSED
-   * (not achieved) if the judge is unavailable or errors — a false success is the costly mistake.
+   * Decides whether the run ACTUALLY created/updated a backlog item (#833). Delegates to the
+   * shared `judgeBacklogOutcome`, which is also used by the local Claude Code backend so success
+   * is judged identically regardless of who drove the tools.
    */
   private async judgeBacklogOutcome(
     goal: string | undefined,
@@ -587,61 +544,13 @@ export class MCPOrchestrator {
     toolActivity: ToolActivity[],
     finalText: string,
   ): Promise<{ achieved: boolean; artifacts: BacklogArtifact[] }> {
-    const succeeded = toolActivity.filter((t) => t.ok);
-    if (succeeded.length === 0) {
-      console.log("[MCPOrchestrator] outcome: no successful tool calls -> not achieved");
-      return { achieved: false, artifacts: [] };
-    }
-
-    const provider = MCPOrchestrator.languageModelProvider;
-    if (!provider) {
-      console.warn("[MCPOrchestrator] outcome judge unavailable (no LLM) -> not achieved");
-      return { achieved: false, artifacts: [] };
-    }
-
-    const judgeSystemPrompt =
-      "You are a strict verifier deciding whether an automated agent ACTUALLY created or updated " +
-      "a backlog work item (e.g. a GitHub issue, an Azure DevOps work item, or a Jira ticket) as " +
-      "instructed. Judge ONLY from the tool results below (ground truth) — NEVER trust the agent's " +
-      "own final message, which may claim success it did not achieve. Set achieved=true only when a " +
-      "non-errored tool result contains concrete evidence of a created or updated item: an id, a " +
-      "number, or a URL. Put that evidence in artifacts. If no mutating tool produced such evidence — " +
-      "nothing ran, the call errored, or only read/internal tools ran — set achieved=false. When " +
-      "uncertain, set achieved=false.";
-
-    const judgePrompt = [
-      `TASK INSTRUCTIONS GIVEN TO THE AGENT:\n${goal?.slice(0, 4000) || "(create a backlog work item describing the user's request)"}`,
-      `USER REQUEST (video transcript):\n${transcript.slice(0, 2000)}`,
-      `TOOL CALLS AND THEIR RESULTS (ground truth — decide from these):\n${JSON.stringify(toolActivity)}`,
-      `AGENT FINAL MESSAGE (do NOT trust this for success):\n${finalText.slice(0, 2000)}`,
-    ].join("\n\n---\n\n");
-
-    try {
-      const verdict = await provider.generateObject(
-        judgePrompt,
-        BacklogOutcomeSchema,
-        judgeSystemPrompt,
-      );
-      // Enforce the contract in CODE, not just the prompt: a verdict is only trusted as success
-      // if it cites concrete evidence. A model that answers achieved=true but populates no
-      // artifacts is treated as not-achieved (conservative — a false success is the costly error).
-      const achieved = verdict.achieved && verdict.artifacts.length > 0;
-      console.log("[MCPOrchestrator] outcome judged:", {
-        achieved,
-        modelClaimedAchieved: verdict.achieved,
-        artifacts: verdict.artifacts,
-        tools: toolActivity.map((t) => `${t.toolName}${t.ok ? "" : "(errored)"}`),
-      });
-      return { achieved, artifacts: verdict.artifacts };
-    } catch (error) {
-      // Fail CLOSED: if the judge itself errors we cannot confirm a filing, so report
-      // not-achieved rather than risk a false success (the costly direction for #833).
-      console.warn(
-        "[MCPOrchestrator] outcome judge failed -> not achieved (failing closed)",
-        error,
-      );
-      return { achieved: false, artifacts: [] };
-    }
+    return judgeBacklogOutcome(
+      MCPOrchestrator.languageModelProvider,
+      goal,
+      transcript,
+      toolActivity,
+      finalText,
+    );
   }
 
   public async convertToObjectAsync(prompt: string, schema: ZodType): Promise<unknown> {

--- a/src/backend/services/mcp/mcp-server-client.ts
+++ b/src/backend/services/mcp/mcp-server-client.ts
@@ -2,7 +2,8 @@ import { experimental_createMCPClient, type experimental_MCPClient } from "@ai-s
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { formatAndReportError } from "../../utils/error-utils";
-import { authorizeWithBackend, refreshTokenWithBackend } from "./mcp-oauth";
+import { authorizeWithBackend } from "./mcp-oauth";
+import { getFreshAccessTokenAsync } from "./mcp-token-refresh";
 import { expandHomePath, sanitizeSegment } from "./mcp-utils";
 import type { MCPServerConfig } from "./types";
 import "dotenv/config";
@@ -52,30 +53,14 @@ export class MCPServerClient {
       const serverId = mcpConfig.id;
       const tokenStorage = McpOAuthTokenStorage.getInstance();
 
-      // Check if we already have tokens
+      // Refresh the access token if it has expired (shared with the local-Claude orchestrator so
+      // both backends inject the same freshness guarantee), then re-read what's in storage.
+      await getFreshAccessTokenAsync(tokenStorage, serverId, serverUrl);
       let tokens = await tokenStorage.getTokensAsync(serverId);
       console.log(
         `[MCPServerClient] Tokens for ${mcpConfig.name}:`,
         tokens ? "Present" : "Missing",
       );
-
-      // Handle refresh token logic if the token is stale
-      if (tokens?.refresh_token && tokenStorage.isTokenExpired(tokens)) {
-        try {
-          console.log(`[MCPServerClient] Token expired for ${mcpConfig.name}, refreshing...`);
-          const newTokens = await refreshTokenWithBackend(serverUrl, tokens.refresh_token);
-          await tokenStorage.saveTokensAsync(serverId, newTokens);
-          tokens = await tokenStorage.getTokensAsync(serverId);
-        } catch (refreshError) {
-          console.error(
-            `[MCPServerClient] Failed to refresh token for ${mcpConfig.name}:`,
-            refreshError,
-          );
-          // If refresh fails, we clear the tokens to trigger re-auth.
-          await tokenStorage.clearTokensAsync(serverId);
-          tokens = undefined;
-        }
-      }
 
       // If no valid tokens, trigger backend OAuth flow
       if (!tokens?.access_token) {

--- a/src/backend/services/mcp/mcp-token-refresh.ts
+++ b/src/backend/services/mcp/mcp-token-refresh.ts
@@ -1,0 +1,62 @@
+import type { OAuthTokens } from "@ai-sdk/mcp";
+import { refreshTokenWithBackend } from "./mcp-oauth";
+import { expandHomePath } from "./mcp-utils";
+
+/** The minimal token shape the refresh helper reads — a subset of `StoredOAuthTokens`. */
+export interface RefreshableTokens {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  storedAt?: number;
+}
+
+/**
+ * The token-storage surface the refresh helper needs. `McpOAuthTokenStorage` satisfies it; tests
+ * can stub a subset (the refresh hooks are optional, so a bare `getTokensAsync` mock is enough for
+ * the no-refresh path). Kept narrow so callers don't have to depend on the full singleton.
+ */
+export interface RefreshableTokenStorage {
+  getTokensAsync(serverId: string): Promise<RefreshableTokens | undefined>;
+  saveTokensAsync?(serverId: string, tokens: OAuthTokens): Promise<void>;
+  clearTokensAsync?(serverId: string): Promise<void>;
+  isTokenExpired?(tokens: RefreshableTokens): boolean;
+}
+
+/**
+ * Returns a VALID OAuth access token for an MCP server, refreshing it first if it has expired and
+ * a refresh token is available (clearing the stored tokens if the refresh fails, so the next run
+ * re-authenticates). Shared by `MCPServerClient` (in-process OpenAI path) and
+ * `LocalClaudeOrchestrator` (headless Claude path) so both inject the SAME freshness guarantee
+ * when building `Authorization: Bearer …` headers — neither hands an MCP server a stale token.
+ *
+ * Returns `undefined` when there is no usable access token (the caller should fall back to
+ * unauthenticated headers, matching prior behaviour).
+ */
+export async function getFreshAccessTokenAsync(
+  storage: RefreshableTokenStorage,
+  serverId: string,
+  serverUrl: string,
+): Promise<string | undefined> {
+  let tokens = await storage.getTokensAsync(serverId);
+
+  const canRefresh =
+    typeof storage.isTokenExpired === "function" &&
+    typeof storage.saveTokensAsync === "function" &&
+    typeof storage.clearTokensAsync === "function";
+
+  if (canRefresh && tokens?.refresh_token && storage.isTokenExpired?.(tokens)) {
+    try {
+      const refreshUrl = expandHomePath(serverUrl);
+      const newTokens = await refreshTokenWithBackend(refreshUrl, tokens.refresh_token);
+      await storage.saveTokensAsync?.(serverId, newTokens);
+      tokens = await storage.getTokensAsync(serverId);
+    } catch (refreshError) {
+      console.error(`[mcp-token-refresh] Failed to refresh token for ${serverId}:`, refreshError);
+      // Clear so the next attempt re-auths instead of reusing a known-bad token.
+      await storage.clearTokensAsync?.(serverId);
+      tokens = undefined;
+    }
+  }
+
+  return tokens?.access_token;
+}

--- a/src/backend/services/process/process-spawner.ts
+++ b/src/backend/services/process/process-spawner.ts
@@ -1,0 +1,15 @@
+import { type ChildProcess, spawn } from "node:child_process";
+
+/**
+ * Minimal child-process spawner seam. Services depend on this interface (not `child_process`
+ * directly) so unit tests can inject a mock child and assert on the exact command/argv without
+ * ever launching a real process. Shared by `FFmpegService` and `LocalClaudeOrchestrator`.
+ */
+export interface IProcessSpawner {
+  spawn(command: string, args: string[]): ChildProcess;
+}
+
+/** Spawns the command directly. Suitable for absolute, executable binary paths. */
+export const defaultProcessSpawner: IProcessSpawner = {
+  spawn: (command, args) => spawn(command, args),
+};

--- a/src/backend/services/workflow/no-work-item-error.test.ts
+++ b/src/backend/services/workflow/no-work-item-error.test.ts
@@ -18,4 +18,16 @@ describe("formatNoWorkItemError — #833 failure copy per termination reason", (
     // Every branch must say nothing was created — that's the whole point of the gate.
     expect(msg.toLowerCase()).toContain("created");
   });
+
+  it("verificationUnavailable overrides the generic copy with a 'may have created / verify' message", () => {
+    // A tool succeeded but no judge model is configured: the item MAY exist. The message must NOT
+    // claim the connection is signed out (that's false and provokes a duplicate re-run) and must
+    // tell the user to check before retrying. Holds even for the 'stop' reason that otherwise maps
+    // to the misleading generic copy.
+    const msg = formatNoWorkItemError("stop", { verificationUnavailable: true });
+    expect(msg).toMatch(/may have created/i);
+    expect(msg).toMatch(/check your backlog/i);
+    expect(msg).toMatch(/language model/i);
+    expect(msg).not.toMatch(/signed out/i);
+  });
 });

--- a/src/backend/services/workflow/no-work-item-error.ts
+++ b/src/backend/services/workflow/no-work-item-error.ts
@@ -5,7 +5,17 @@ import type { MCPTerminationReason } from "../mcp/mcp-orchestrator";
  * created a backlog item (#833), tailored to why the loop ended. Extracted as a pure function so
  * the message table is unit-testable without standing up the IPC handler.
  */
-export function formatNoWorkItemError(reason: MCPTerminationReason): string {
+export function formatNoWorkItemError(
+  reason: MCPTerminationReason,
+  options: { verificationUnavailable?: boolean } = {},
+): string {
+  // A tool succeeded but there was no judge model to confirm it. The item MAY exist, so we must
+  // NOT claim "nothing was created / your connection is signed out" — that's actively false and
+  // tends to make the user re-run and file a duplicate. Tell them to verify before retrying.
+  if (options.verificationUnavailable) {
+    return "Claude Code may have created a work item, but it could not be verified because no OpenAI/Azure language model is configured. Configure a language model in Settings to confirm success — and check your backlog before re-running to avoid creating a duplicate.";
+  }
+
   switch (reason) {
     case "length":
     case "max-iterations":

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -23,6 +23,15 @@ export type ModelConfig = OpenAIConfig | AzureOpenAIConfig | DeepSeekConfig;
 
 export type ProviderApiKeys = Readonly<Partial<Record<ProviderName, string>>>;
 
+/**
+ * Which backend drives the backlog-creation (EXECUTING_TASK) step.
+ * - `openai`: the in-process MCPOrchestrator loop (default, original behaviour).
+ * - `local-claude`: drive the step with a local `claude -p` (headless) process.
+ */
+export type OrchestrationBackend = "openai" | "local-claude";
+
+export const DEFAULT_ORCHESTRATION_BACKEND: OrchestrationBackend = "openai";
+
 export type LLMConfigV1 = ModelConfig & {
   version?: 1;
 };
@@ -33,6 +42,11 @@ export interface LLMConfigV2 {
   transcriptionModel: ModelConfig | null;
   /** Persisted API keys per provider, enabling restoration when switching providers */
   providerApiKeys?: ProviderApiKeys;
+  /**
+   * Opt-in orchestration backend for the backlog-creation step.
+   * Absent/undefined behaves exactly as `openai` — existing configs are unaffected.
+   */
+  orchestrationBackend?: OrchestrationBackend;
 }
 
 export type LLMConfig = LLMConfigV1 | LLMConfigV2;

--- a/src/ui/src/components/recording/VideoPreviewModal.tsx
+++ b/src/ui/src/components/recording/VideoPreviewModal.tsx
@@ -1,7 +1,6 @@
 import type { ToolApprovalMode } from "@shared/types/user-settings";
 import { ArrowRight, RotateCcw } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useWorkflowNavigation } from "@/hooks/useWorkflowNavigation";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,6 +21,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { useWorkflowNavigation } from "@/hooks/useWorkflowNavigation";
 import { VideoPlayer } from "./VideoPlayer";
 
 interface VideoPreviewModalProps {

--- a/src/ui/src/components/settings/llm/LLMSettingsPanel.tsx
+++ b/src/ui/src/components/settings/llm/LLMSettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { LanguageModelSetting } from "./LanguageModelSetting";
+import { OrchestratorBackendSetting } from "./OrchestratorBackendSetting";
 import { TranscriptionModelSetting } from "./TranscriptionModelSetting";
 
 interface LLMSettingsPanelProps {
@@ -17,6 +18,7 @@ export function LLMSettingsPanel({ isActive }: LLMSettingsPanelProps) {
 
       <LanguageModelSetting isActive={isActive} />
       <TranscriptionModelSetting isActive={isActive} />
+      <OrchestratorBackendSetting isActive={isActive} />
     </div>
   );
 }

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -27,7 +27,7 @@ const BACKEND_OPTIONS: readonly BackendOption[] = [
     id: "local-claude",
     title: "Claude Code (local)",
     description:
-      "Drive backlog creation with a local headless `claude` process. Requires the `claude` CLI installed and on PATH.",
+      'Drive backlog creation with a local headless `claude` process. Requires the `claude` CLI installed and on PATH, and still needs a configured OpenAI/Azure language model to verify success. Under "ask" approval mode only whitelisted tools run (no runtime approval prompt), and YakShaver\'s built-in screenshot tools are unavailable.',
   },
 ];
 

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -1,0 +1,150 @@
+import type { LLMConfigV2, OrchestrationBackend } from "@shared/types/llm";
+import { DEFAULT_ORCHESTRATION_BACKEND } from "@shared/types/llm";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { ipcClient } from "@/services/ipc-client";
+import { formatErrorMessage } from "@/utils";
+
+interface OrchestratorBackendSettingProps {
+  isActive: boolean;
+}
+
+interface BackendOption {
+  id: OrchestrationBackend;
+  title: string;
+  description: string;
+}
+
+const BACKEND_OPTIONS: readonly BackendOption[] = [
+  {
+    id: "openai",
+    title: "OpenAI",
+    description: "Drive backlog creation with the built-in language model loop. (Default)",
+  },
+  {
+    id: "local-claude",
+    title: "Claude Code (local)",
+    description:
+      "Drive backlog creation with a local headless `claude` process. Requires the `claude` CLI installed and on PATH.",
+  },
+];
+
+const BACKEND_LABELS: Record<OrchestrationBackend, string> = {
+  openai: "OpenAI",
+  "local-claude": "Claude Code (local)",
+};
+
+export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSettingProps) {
+  const [currentBackend, setCurrentBackend] = useState<OrchestrationBackend>(
+    DEFAULT_ORCHESTRATION_BACKEND,
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [pendingBackend, setPendingBackend] = useState<OrchestrationBackend | null>(null);
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const cfg = await ipcClient.llm.getConfig();
+        if (!cancelled) {
+          setCurrentBackend(cfg?.orchestrationBackend ?? DEFAULT_ORCHESTRATION_BACKEND);
+        }
+      } catch (error) {
+        console.error("Failed to load orchestrator backend setting", error);
+        toast.error(`Failed to load orchestrator setting: ${formatErrorMessage(error)}`);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isActive]);
+
+  const handleSelect = useCallback(
+    async (backend: OrchestrationBackend) => {
+      if (backend === currentBackend) {
+        return;
+      }
+
+      setPendingBackend(backend);
+      try {
+        // Preserve every other field on the V2 config; only flip the backend.
+        const existing = await ipcClient.llm.getConfig();
+        const next: LLMConfigV2 = {
+          version: 2,
+          languageModel: existing?.languageModel ?? null,
+          transcriptionModel: existing?.transcriptionModel ?? null,
+          providerApiKeys: existing?.providerApiKeys,
+          orchestrationBackend: backend,
+        };
+        const result = await ipcClient.llm.setConfig(next);
+        if (!result.success) {
+          throw new Error("Failed to update orchestrator backend");
+        }
+        setCurrentBackend(backend);
+        toast.success(`Orchestrator set to ${BACKEND_LABELS[backend]}`);
+      } catch (error) {
+        console.error("Failed to update orchestrator backend", error);
+        toast.error(`Failed to update orchestrator: ${formatErrorMessage(error)}`);
+      } finally {
+        setPendingBackend(null);
+      }
+    },
+    [currentBackend],
+  );
+
+  return (
+    <Card className="w-full gap-4 border-white/10 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>Orchestrator</CardTitle>
+        <CardDescription>
+          Choose which backend drives backlog creation. Claude Code (local) requires the{" "}
+          <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="px-4">
+        <div className="grid gap-2 md:grid-cols-2">
+          {BACKEND_OPTIONS.map((option) => {
+            const isSelected = option.id === currentBackend;
+            const isDisabled = isLoading || (!!pendingBackend && pendingBackend !== option.id);
+
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => void handleSelect(option.id)}
+                disabled={isDisabled}
+                aria-pressed={isSelected}
+                className={cn(
+                  "flex h-full flex-col gap-1.5 rounded-md border px-3 py-2 text-left transition-colors",
+                  "disabled:cursor-not-allowed disabled:opacity-60",
+                  isSelected
+                    ? "border-white/50 bg-white/10"
+                    : "border-white/10 hover:border-white/30 hover:bg-white/5",
+                )}
+              >
+                <span className="text-sm font-medium">{option.title}</span>
+                <span className="text-xs leading-relaxed text-muted-foreground">
+                  {option.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/ui/src/components/settings/llm/llm-config-utils.test.ts
+++ b/src/ui/src/components/settings/llm/llm-config-utils.test.ts
@@ -72,6 +72,30 @@ describe("LLM settings config utilities", () => {
     });
   });
 
+  describe("orchestrationBackend preservation", () => {
+    const configWithBackend: LLMConfigV2 = {
+      ...baseConfig,
+      orchestrationBackend: "local-claude",
+    };
+
+    it("preserves orchestrationBackend when saving a model", () => {
+      const result = buildConfigWithSavedModel(configWithBackend, "languageModel", {
+        provider: "azure",
+        model: "gpt-4o",
+        apiKey: "new-azure-key",
+        resourceName: "yakshaver-openai",
+      });
+
+      expect(result.orchestrationBackend).toBe("local-claude");
+    });
+
+    it("preserves orchestrationBackend when clearing a model", () => {
+      const result = buildConfigWithClearedModel(configWithBackend, "languageModel");
+
+      expect(result.orchestrationBackend).toBe("local-claude");
+    });
+  });
+
   describe("buildConfigWithSavedModel", () => {
     it("saves language model without overwriting the fresh transcription model", () => {
       const updatedLanguageModel: ModelConfig = {

--- a/src/ui/src/components/settings/llm/llm-config-utils.ts
+++ b/src/ui/src/components/settings/llm/llm-config-utils.ts
@@ -7,6 +7,7 @@ const EMPTY_LLM_CONFIG: LLMConfigV2 = {
   languageModel: null,
   transcriptionModel: null,
   providerApiKeys: {},
+  orchestrationBackend: undefined,
 };
 
 function getBaseConfig(config: LLMConfigV2 | null): LLMConfigV2 {
@@ -28,6 +29,7 @@ export function buildConfigWithSavedModel(
       ...baseConfig.providerApiKeys,
       [values.provider]: values.apiKey,
     },
+    orchestrationBackend: baseConfig.orchestrationBackend,
     [modelType]: values,
   };
 }
@@ -54,6 +56,7 @@ export function buildConfigWithClearedModel(
     languageModel: baseConfig.languageModel,
     transcriptionModel: baseConfig.transcriptionModel,
     providerApiKeys,
+    orchestrationBackend: baseConfig.orchestrationBackend,
     [modelType]: null,
   };
 }

--- a/src/ui/src/components/workflow/ReasoningStep.tsx
+++ b/src/ui/src/components/workflow/ReasoningStep.tsx
@@ -6,12 +6,14 @@ interface ReasoningStepProps {
 }
 
 export function ReasoningStep({ reasoning }: ReasoningStepProps) {
+  // Reasoning is normally a JSON-encoded `{ type, text }` payload, but fall back to rendering the
+  // raw string when it isn't valid JSON so plain-text reasoning never renders blank.
   let parsed: ParsedResult = {};
 
   try {
     parsed = JSON.parse(reasoning);
-  } catch (error) {
-    console.error("Failed to parse reasoning:", error);
+  } catch {
+    parsed = { text: reasoning };
   }
 
   return (


### PR DESCRIPTION
Closes #907

## What this adds (Phase 1 — orchestration mode only)

An **opt-in** orchestration backend that drives the backlog-creation (`EXECUTING_TASK`) step with a local headless `claude -p` process instead of the in-process OpenAI loop. Default behaviour is unchanged; existing configs keep using OpenAI.

## Architecture

- **`IBacklogOrchestrator`** (`src/backend/services/mcp/backlog-orchestrator.ts`) — the seam the `EXECUTING_TASK` stage talks to. Both backends return the same `MCPLoopResult` (`{ text, backlogActionSucceeded, artifacts, terminationReason }`), whose `backlogActionSucceeded` gates COMPLETE vs FAIL. `MCPOrchestrator` now `implements` this interface (adapter-only; no behaviour change).
- **Shared judge** — `judgeBacklogOutcome` was extracted from `MCPOrchestrator` into the shared module and made provider-injectable. `MCPOrchestrator` delegates to it; the local backend reuses it verbatim, so success is judged identically (from tool RESULTS, #833) regardless of who drove the tools.
- **`LocalClaudeOrchestrator`** (`src/backend/services/mcp/local-claude-orchestrator.ts`):
  - Builds the **same system prompt** as the OpenAI loop (orchestrator prompt + projectMetaData + desktopAgentProjectPrompt + video info); transcript is the user input (passed over stdin).
  - Serializes the enabled MCP servers (respecting `serverFilter`, skipping disabled + inMemory) to a temp `--mcp-config` JSON in Claude Code's format: stdio -> `{command,args,env}`; streamableHttp -> `{type:"http", url, headers}` with the OAuth **bearer token injected** from `mcp-oauth-token-storage` (built-in servers don't use OAuth). Temp file is always cleaned up (`finally`).
  - Spawns `claude` via an **injectable spawner** (mirrors `ffmpeg-service`'s `IProcessSpawner`) for testability.
  - Parses the `stream-json` events (`assistant` text/`tool_use`, `user` `tool_result`, terminal `result`) into `MCPStep`s and calls **the same `onStep`** — so UI progress streams exactly as today. Tool results are collected for the judge.
  - **Detects `claude` first** (`claude --version`); if absent, throws *"Claude Code CLI not found on PATH — install it, or switch Orchestrator to OpenAI in Settings"* so the stage fails cleanly with a helpful message (no crash). Handles process error/non-zero exit/cleanup.

### The claude argv built

```
claude -p --mcp-config <tmp.json> --output-format stream-json --verbose [permission flags]
```
The full prompt (system prompt + `video transcription: <transcript>`) is written to **stdin** (avoids argv length limits).

### Approval-mode -> Claude permission mapping

| `toolApprovalMode` | Claude flags |
|---|---|
| `yolo` / `wait` | `--permission-mode bypassPermissions` |
| `ask` | `--permission-mode dontAsk` + `--allowedTools mcp__<server>__<tool>,...` built from each selected server's `toolWhitelist` |

A headless `claude -p` run can't service interactive approvals, so the mapping is:

- **`yolo`** and **`wait`** -> `bypassPermissions`: **every tool runs immediately**. On the OpenAI path `wait` shows a 15s approval dialog that AUTO-APPROVES after the delay, so a non-dismissed tool still runs; the faithful headless analogue (there is no dialog to render) is to bypass permissions rather than hard-deny. ⚠️ This means **under this backend `wait` runs all tools with permissions bypassed — effectively the same as YOLO** (the run surfaces a console + onStep warning saying exactly this). Use `ask` if you want the run constrained to whitelisted tools.
- **`ask`** -> `dontAsk` + `--allowedTools <whitelist>`: only the user-approved (whitelisted) tools auto-approve; `dontAsk` turns any other approval prompt into an outright denial so the headless run never blocks. If a needed server has **no** whitelist we proceed with whatever is whitelisted and surface a clear console note that non-whitelisted tools were skipped — **we never hang**.

## What's reused
- `judgeBacklogOutcome` (the #833 outcome judge — now shared)
- `onStep` / `MCPStep` UI progress streaming
- `orchestratorSystemPrompt` + the exact prompt-assembly shape

## Config + selection
- `orchestrationBackend?: 'openai' | 'local-claude'` added to `LLMConfigV2` (default `openai`, **migration-safe** — absent field behaves as openai; V2->V2 migration is a no-op).
- Selected at the `process-video-handlers` seam via `getBacklogOrchestrator()`. Portal serialization still uses the OpenAI orchestrator's `convertToObjectAsync` (separate LLM call) regardless of backend.

## Settings UI
- An **Orchestrator: OpenAI | Claude Code (local)** selector in the Model Settings panel (`OrchestratorBackendSetting.tsx`), wired through the existing `llm` get/set IPC, noting *"Claude Code (local) requires the `claude` CLI installed"*.

## Tests
Unit tests with a **mock spawner** (`local-claude-orchestrator.test.ts`, 12 tests) assert:
- argv per approval mode (`bypassPermissions` vs `--allowedTools` list vs empty-whitelist constrained run);
- MCP config serialization (stdio command/args/env + http url + injected token; serverFilter; disabled/inMemory skipped; no-whitelist flagged not hung);
- stream-json parsing -> `MCPStep` sequence (reasoning/tool_call/tool_result/final_result) + stdin contents;
- judge applied to tool results -> correct `backlogActionSucceeded`/`artifacts`; errored tool_result -> judge not consulted -> not achieved;
- missing-`claude` -> clean error (both `--version` non-zero and spawn ENOENT).

**Verification:** root `npm run build` (tsc) green; `cd src/ui && npm run build` green; `npx vitest run` on the new + related orchestrator/llm tests = 29 passed. Biome (2.3.11) clean on changed files. (4 unrelated DB/ffmpeg suites fail only because `better-sqlite3` / `@ffmpeg-installer/ffmpeg` have no win32-arm64 native binary in this sandbox — not touched by this PR.)

## ⚠️ PENDING live verification

This PR ships code + unit tests (subprocess mocked). The **LIVE end-to-end run is deferred** — it needs the real `claude` CLI on PATH, configured MCP servers, and a real shave. To verify:
1. Install the `claude` CLI and ensure it's on PATH (`claude --version`).
2. In Settings -> Model Settings, set **Orchestrator = Claude Code (local)**.
3. Configure/enable at least one MCP server (e.g. GitHub) with an appropriate `toolWhitelist`, or set Tool Approval to YOLO.
4. Run a real shave and confirm: a PBI / work item is actually created, progress streams in the UI (reasoning/tool calls/results), and the stage reports success only when an item was filed.
5. Also confirm the clean error path: rename/remove `claude` from PATH and verify the stage fails with the *"Claude Code CLI not found on PATH…"* message rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
