### PR TITLE
L⚠️ ◾ feat(cli): yakshaver CLI + localhost config bridge (#909)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ YakShaver is a desktop AI agent with the following capabilities:
 
 - **AI/LLM**: `@ai-sdk/openai`, `@ai-sdk/azure`, `@ai-sdk/deepseek`, `@ai-sdk/mcp`, `ai`, `openai`
 - **MCP**: `@modelcontextprotocol/sdk`
+- **Schema validation**: `zod` (root dependency — used for the CLI bridge wire-format/protocol schemas and elsewhere)
 - **Database**: `drizzle-orm`, `better-sqlite3`
 - **APIs**: `googleapis`, `@microsoft/microsoft-graph-client`, `google-auth-library`, `@azure/msal-node`
 - **Video/Media**: `@ffmpeg-installer/ffmpeg`, `youtube-dl-exec`
@@ -72,6 +73,8 @@ Frontend (React/Vite)  <-->  IPC Bridge  <-->  Backend (Electron/Node.js)
 
 The frontend communicates **exclusively through IPC** channels. All backend functionality is exposed through 40+ typed IPC channels organized by feature.
 
+There is one additional, deliberately narrow backend access path: the **CLI bridge** (`src/backend/services/cli-bridge/`). It is a localhost-only HTTP server, started in `app.whenReady` and torn down on cleanup, that lets the standalone `yakshaver` CLI (`src/cli/`) read and mutate MCP/LLM/settings config by calling the SAME service singletons (`MCPServerManager`, `LlmStorage`, `UserSettingsStorage`) the IPC handlers use. Its security model: binds to `127.0.0.1` only (never `0.0.0.0`), requires a per-startup 256-bit `Authorization: Bearer` token, redacts all secrets in responses, and can be disabled via `YAKSHAVER_DISABLE_CLI_BRIDGE`. See "Security & Privacy" for the token-file exception to the encrypt-all-credentials rule. Built-in MCP servers are NOT mutable through the bridge (mirrors the desktop UI).
+
 ### Directory Tree
 
 ```
@@ -91,6 +94,7 @@ SSW.YakShaver.Desktop/
 │   │   │   └── channels.ts           # All IPC channel name constants
 │   │   ├── services/                  # Business logic services
 │   │   │   ├── auth/                  # YouTube & Microsoft OAuth
+│   │   │   ├── cli-bridge/            # Localhost HTTP bridge for the yakshaver CLI
 │   │   │   ├── ffmpeg/                # Video codec conversion
 │   │   │   ├── mcp/                   # MCP orchestration (central AI hub)
 │   │   │   ├── recording/             # Screen capture (singleton + EventEmitter)
@@ -105,7 +109,10 @@ SSW.YakShaver.Desktop/
 │   ├── shared/                        # Shared types between frontend & backend
 │   │   ├── types/                     # LLM, workflow, MCP, user-settings, telemetry types
 │   │   ├── llm/                       # Provider factory configuration
+│   │   ├── cli-bridge/                # CLI bridge protocol/schemas + secret redaction
 │   │   └── constants/                 # Shared error messages
+│   │
+│   ├── cli/                           # `yakshaver` CLI (emits dist/cli/index.js, bin: yakshaver)
 │   │
 │   └── ui/                            # React frontend (Vite)
 │       ├── vite.config.mts            # Vite build config (multi-entry)
@@ -580,6 +587,7 @@ APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...;IngestionEndpoint=.
 - **Linux**: `~/.config/SSW.YakShaver/`
 
 Encrypted tokens: `yakshaver-tokens/*.enc`
+CLI bridge handshake (PLAINTEXT, deliberate exception): `yakshaver-tokens/cli-bridge.json` — see "Security & Privacy"
 Database: `database.sqlite` (dev: `./data/database.sqlite`)
 Auth browser templates: `src/backend/assets/auth/*.html` (packaged via `extraResources`)
 
@@ -635,6 +643,7 @@ npm run db:generate    # Generate Drizzle ORM migrations
 - **Never hardcode secrets** - even placeholder values like `"sk-..."`
 - **Use Electron's `safeStorage` API** - for all token/credential encryption
 - **Encrypt all stored credentials** - via `BaseSecureStorage` subclasses
+  - **Documented exception — CLI bridge handshake file** (`yakshaver-tokens/cli-bridge.json`): written as PLAINTEXT JSON, not `*.enc`, even though it sits in the encrypted-credentials directory. The standalone `yakshaver` CLI is a non-Electron process and cannot decrypt `safeStorage`, so the bridge port + bearer token must be plaintext-readable by the same OS user. This is mitigated by: the bridge binding to `127.0.0.1` only, a fresh random 256-bit token per app start (deleted on shutdown), owner-only file permissions (`mode 0o600`, a no-op on Windows), and secret redaction on every bridge response. This is the only credential intentionally not encrypted at rest.
 - **Use HTTPS for all non-local/external API calls** (HTTP is only acceptable for `localhost` in local development)
 - **Validate and sanitize user input** before processing
 - **No telemetry without consent**

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.6.0",
   "description": "YakShaver, an AI agent to help you trim the fluff and get straight to the point",
   "main": "dist/backend/index.js",
+  "bin": {
+    "yakshaver": "./dist/cli/index.js"
+  },
   "build": {},
   "scripts": {
     "setup": "concurrently \"npm run setup:root\" \"cd src/ui && npm install\"",
@@ -60,7 +63,8 @@
     "openai": "^6.16.0",
     "openid-client": "^6.8.2",
     "tmp": "^0.2.5",
-    "youtube-dl-exec": "^3.0.29"
+    "youtube-dl-exec": "^3.0.29",
+    "zod": "^4.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -27,6 +27,7 @@ import { UserSettingsIPCHandlers } from "./ipc/user-settings-handlers";
 import { handleProtocolUrl } from "./protocol/protocol-router";
 import { IdentityServerAuthService } from "./services/auth/identity-server-auth";
 import { MicrosoftAuthService } from "./services/auth/microsoft-auth";
+import { CliBridgeServer } from "./services/cli-bridge/cli-bridge-server";
 import { registerAllInternalMcpServers } from "./services/mcp/internal/register-internal-servers";
 import { MCPOrchestrator } from "./services/mcp/mcp-orchestrator";
 import { MCPServerManager } from "./services/mcp/mcp-server-manager";
@@ -447,6 +448,13 @@ app.whenReady().then(async () => {
 
   const mcpServerManager = await MCPServerManager.getInstanceAsync();
   _mcpHandlers = new McpIPCHandlers(mcpServerManager);
+
+  // Start the localhost-only CLI config bridge (best-effort; never blocks startup).
+  try {
+    await CliBridgeServer.getInstance().start();
+  } catch (err) {
+    console.error("Failed to start CLI bridge:", err);
+  }
   _customPromptSettingsHandlers = new CustomPromptSettingsIPCHandlers();
   _appControlHandlers = new AppControlIPCHandlers();
   _releaseChannelHandlers = new ReleaseChannelIPCHandlers();
@@ -504,6 +512,11 @@ const cleanup = async () => {
   trayManager.destroy();
 
   unregisterEventForwarders?.();
+  try {
+    await CliBridgeServer.getInstance().stop();
+  } catch (err) {
+    console.error("CLI bridge shutdown error:", err);
+  }
   try {
     await RecordingService.getInstance().cleanupAllTempFiles();
   } catch (err) {

--- a/src/backend/ipc/user-settings-handlers.ts
+++ b/src/backend/ipc/user-settings-handlers.ts
@@ -1,10 +1,11 @@
-import { app, BrowserWindow, type IpcMainInvokeEvent, ipcMain } from "electron";
+import { BrowserWindow, type IpcMainInvokeEvent, ipcMain } from "electron";
 import {
   type Hotkeys,
   type PartialUserSettings,
   PartialUserSettingsSchema,
 } from "../../shared/types/user-settings";
 import { HotkeyManager } from "../services/settings/hotkey-manager";
+import { applyOpenAtLoginSetting } from "../services/settings/login-item";
 import { UserSettingsStorage } from "../services/storage/user-settings-storage";
 import type { TrayManager } from "../services/tray/tray-manager";
 import { IPC_CHANNELS } from "./channels";
@@ -29,10 +30,7 @@ export class UserSettingsIPCHandlers {
   private async syncLoginItemSettings(): Promise<void> {
     try {
       const settings = await this.storage.getSettingsAsync();
-      app.setLoginItemSettings({
-        openAtLogin: settings.openAtLogin,
-        openAsHidden: false,
-      });
+      applyOpenAtLoginSetting(settings.openAtLogin);
     } catch (error) {
       console.error("Failed to sync login item settings on startup", error);
     }
@@ -95,10 +93,7 @@ export class UserSettingsIPCHandlers {
   }
 
   private async handleOpenAtLoginUpdate(openAtLogin: boolean): Promise<void> {
-    app.setLoginItemSettings({
-      openAtLogin,
-      openAsHidden: false,
-    });
+    applyOpenAtLoginSetting(openAtLogin);
   }
 
   private registerHandlers(): void {

--- a/src/backend/services/cli-bridge/bridge-router.integration.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.integration.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { REDACTED } from "../../../shared/cli-bridge/protocol";
+import type { MCPServerConfig } from "../mcp/types";
+import { type BridgeServices, routeRequest } from "./bridge-router";
+
+/**
+ * Integration coverage for the CLI bridge against the REAL MCPServerManager
+ * (not the hand-written mocks the other suites use). The PR's unit tests prove
+ * the router and HTTP layer in isolation, but the one path no test exercised was
+ * the actual wiring in createDefaultServices() -> MCPServerManager singleton:
+ * the merge-with-built-ins logic, real persistence, real redaction shapes, and
+ * the built-in immutability invariant.
+ *
+ * We back the manager with an in-memory McpStorage (so there is no Electron
+ * safeStorage / DB dependency) but otherwise let the genuine manager methods run,
+ * then drive them through routeRequest exactly as the live bridge does.
+ */
+
+// In-memory stand-in for the secure McpStorage. The real manager only needs
+// getMcpServerConfigsAsync + storeMcpServers from it.
+const memStore: { configs: MCPServerConfig[] } = { configs: [] };
+
+vi.mock("../storage/mcp-storage", () => ({
+  McpStorage: {
+    getInstance: () => ({
+      getMcpServerConfigsAsync: async () => structuredClone(memStore.configs),
+      storeMcpServers: async (servers: MCPServerConfig[]) => {
+        memStore.configs = structuredClone(servers);
+      },
+      hasMcpServersAsync: async () => memStore.configs.length > 0,
+    }),
+  },
+}));
+
+// The manager's client layer is never needed for config CRUD; stub the transport
+// pieces so importing it doesn't drag in real MCP clients.
+vi.mock("./mcp-server-client", () => ({
+  MCPServerClient: class {},
+}));
+
+import { MCPServerManager } from "../mcp/mcp-server-manager";
+
+/**
+ * Builds the SAME service surface createDefaultServices() builds, but inlined so
+ * the test does not need Electron. Every method calls the real manager.
+ */
+async function realMcpServices(): Promise<BridgeServices["mcp"]> {
+  const manager = await MCPServerManager.getInstanceAsync();
+  return {
+    listAvailableServers: () => manager.listAvailableServers(),
+    addServerAsync: (config) => manager.addServerAsync(config),
+    updateServerAsync: (serverId, config) => manager.updateServerAsync(serverId, config),
+    removeServerAsync: (serverId) => manager.removeServerAsync(serverId),
+    getServerByIdAsync: (serverId) => MCPServerManager.getServerConfigByIdAsync(serverId),
+  };
+}
+
+async function makeServices(): Promise<BridgeServices> {
+  return {
+    mcp: await realMcpServices(),
+    llm: {
+      getLLMConfig: async () => null,
+      storeLLMConfig: async () => {},
+    },
+    settings: {
+      getSettingsAsync: async () => ({ toolApprovalMode: "ask" }) as never,
+      updateSettingsAsync: async () => {},
+    },
+  };
+}
+
+/** Seed a built-in server into the manager's internal (non-stored) config list. */
+function seedBuiltin(): void {
+  // biome-ignore lint/suspicious/noExplicitAny: writing a private static for test isolation
+  (MCPServerManager as any).internalServerConfigs = [
+    {
+      id: "builtin-1",
+      name: "Built In",
+      transport: "inMemory",
+      enabled: true,
+      builtin: true,
+      inMemoryServerId: "builtin-1",
+    },
+  ];
+}
+
+describe("CLI bridge ↔ real MCPServerManager wiring", () => {
+  beforeEach(() => {
+    memStore.configs = [];
+    // biome-ignore lint/suspicious/noExplicitAny: reset private statics for isolation
+    (MCPServerManager as any).instance = undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: reset private statics for isolation
+    (MCPServerManager as any).internalServerConfigs = [];
+  });
+
+  afterEach(() => {
+    memStore.configs = [];
+  });
+
+  it("add -> list -> get -> update -> remove round-trips through the real manager", async () => {
+    const services = await makeServices();
+
+    // POST /mcp/servers (real addServerAsync persists into the in-memory store)
+    const addRes = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers",
+      body: {
+        name: "Round Trip",
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+        headers: { Authorization: "Bearer top-secret" },
+      },
+    });
+    expect(addRes.status).toBe(201);
+    if (!addRes.body.ok) throw new Error("expected ok");
+    const created = addRes.body.data as MCPServerConfig & {
+      headers?: Record<string, string>;
+    };
+    const id = created.id;
+    expect(id).toBeTruthy();
+    // Secret redacted even though the real manager stored the real value.
+    expect(created.headers?.Authorization).toBe(REDACTED);
+    const storedHeaders = (memStore.configs[0] as { headers?: Record<string, string> }).headers;
+    expect(storedHeaders?.Authorization).toBe("Bearer top-secret");
+
+    // GET /mcp/servers lists it (merged set) with the secret still redacted.
+    const listRes = await routeRequest(services, { method: "GET", path: "/mcp/servers" });
+    if (!listRes.body.ok) throw new Error("expected ok");
+    const list = listRes.body.data as MCPServerConfig[];
+    expect(list.some((s) => s.id === id)).toBe(true);
+    expect(JSON.stringify(list)).not.toContain("top-secret");
+
+    // PUT /mcp/servers/:id renames via the real merge.
+    const putRes = await routeRequest(services, {
+      method: "PUT",
+      path: `/mcp/servers/${id}`,
+      body: { name: "Renamed", transport: "streamableHttp", url: "https://new.example.com/mcp" },
+    });
+    expect(putRes.status).toBe(200);
+    expect(memStore.configs.find((s) => s.id === id)?.name).toBe("Renamed");
+
+    // DELETE /mcp/servers/:id removes it for real.
+    const delRes = await routeRequest(services, { method: "DELETE", path: `/mcp/servers/${id}` });
+    expect(delRes.status).toBe(200);
+    if (!delRes.body.ok) throw new Error("expected ok");
+    expect(delRes.body.data).toEqual({ id, removed: true });
+    expect(memStore.configs.find((s) => s.id === id)).toBeUndefined();
+  });
+
+  it("enable toggle persists and the real list reflects it", async () => {
+    const services = await makeServices();
+    const addRes = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers",
+      body: { name: "Toggle Me", transport: "stdio", command: "node" },
+    });
+    if (!addRes.body.ok) throw new Error("expected ok");
+    const id = (addRes.body.data as MCPServerConfig).id;
+
+    const offRes = await routeRequest(services, {
+      method: "POST",
+      path: `/mcp/servers/${id}/enabled`,
+      body: { enabled: false },
+    });
+    expect(offRes.status).toBe(200);
+    expect(memStore.configs.find((s) => s.id === id)?.enabled).toBe(false);
+
+    const listRes = await routeRequest(services, { method: "GET", path: "/mcp/servers" });
+    if (!listRes.body.ok) throw new Error("expected ok");
+    const server = (listRes.body.data as MCPServerConfig[]).find((s) => s.id === id);
+    expect(server?.enabled).toBe(false);
+  });
+
+  it("refuses to enable/disable a built-in server (409) and never persists a phantom row", async () => {
+    seedBuiltin();
+    const services = await makeServices();
+
+    // The built-in IS visible in the merged list...
+    const listRes = await routeRequest(services, { method: "GET", path: "/mcp/servers" });
+    if (!listRes.body.ok) throw new Error("expected ok");
+    expect((listRes.body.data as MCPServerConfig[]).some((s) => s.id === "builtin-1")).toBe(true);
+
+    // ...but enabling/disabling it is rejected instead of silently no-op'ing.
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers/builtin-1/enabled",
+      body: { enabled: false },
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.ok).toBe(false);
+    // No phantom stored row was written for the built-in.
+    expect(memStore.configs.find((s) => s.id === "builtin-1")).toBeUndefined();
+  });
+
+  it("refuses to PUT or DELETE a built-in server (409)", async () => {
+    seedBuiltin();
+    const services = await makeServices();
+
+    const putRes = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/builtin-1",
+      body: { name: "Hijacked", transport: "streamableHttp", url: "https://evil.example.com/mcp" },
+    });
+    expect(putRes.status).toBe(409);
+    expect(memStore.configs.find((s) => s.id === "builtin-1")).toBeUndefined();
+
+    const delRes = await routeRequest(services, {
+      method: "DELETE",
+      path: "/mcp/servers/builtin-1",
+    });
+    expect(delRes.status).toBe(409);
+  });
+});

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -168,6 +168,58 @@ describe("routeRequest - MCP", () => {
     const res = await routeRequest(services, { method: "PATCH", path: "/mcp/servers" });
     expect(res.status).toBe(405);
   });
+
+  describe("built-in server immutability", () => {
+    const builtin: MCPServerConfig = {
+      id: "builtin-1",
+      name: "Built In",
+      transport: "inMemory",
+      enabled: true,
+      builtin: true,
+    } as MCPServerConfig;
+
+    function builtinServices() {
+      return makeServices({
+        mcp: {
+          ...makeServices().mcp,
+          getServerByIdAsync: vi.fn().mockResolvedValue(builtin),
+        },
+      });
+    }
+
+    it("rejects enabling/disabling a built-in server with 409 and does not persist", async () => {
+      const svc = builtinServices();
+      const res = await routeRequest(svc, {
+        method: "POST",
+        path: "/mcp/servers/builtin-1/enabled",
+        body: { enabled: false },
+      });
+      expect(res.status).toBe(409);
+      expect(res.body.ok).toBe(false);
+      expect(svc.mcp.updateServerAsync).not.toHaveBeenCalled();
+    });
+
+    it("rejects PUT on a built-in server with 409 and does not persist", async () => {
+      const svc = builtinServices();
+      const res = await routeRequest(svc, {
+        method: "PUT",
+        path: "/mcp/servers/builtin-1",
+        body: { name: "Hijack", transport: "streamableHttp", url: "https://evil.example.com/mcp" },
+      });
+      expect(res.status).toBe(409);
+      expect(svc.mcp.updateServerAsync).not.toHaveBeenCalled();
+    });
+
+    it("rejects DELETE on a built-in server with 409 and does not remove", async () => {
+      const svc = builtinServices();
+      const res = await routeRequest(svc, {
+        method: "DELETE",
+        path: "/mcp/servers/builtin-1",
+      });
+      expect(res.status).toBe(409);
+      expect(svc.mcp.removeServerAsync).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("routeRequest - LLM", () => {

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { REDACTED } from "../../../shared/cli-bridge/protocol";
+import type { MCPServerConfig } from "../mcp/types";
+import { type BridgeServices, routeRequest } from "./bridge-router";
+
+function makeServices(overrides: Partial<BridgeServices> = {}): BridgeServices {
+  const httpServer: MCPServerConfig = {
+    id: "srv-1",
+    name: "Test HTTP",
+    transport: "streamableHttp",
+    url: "https://example.com/mcp",
+    headers: { Authorization: "Bearer super-secret" },
+    enabled: true,
+  };
+
+  return {
+    mcp: {
+      listAvailableServers: vi.fn().mockResolvedValue([httpServer]),
+      addServerAsync: vi.fn().mockImplementation(async (c: MCPServerConfig) => ({
+        ...c,
+        id: "new-id",
+      })),
+      updateServerAsync: vi.fn().mockResolvedValue(undefined),
+      removeServerAsync: vi.fn().mockResolvedValue(undefined),
+      getServerByIdAsync: vi.fn().mockResolvedValue(httpServer),
+      ...overrides.mcp,
+    },
+    llm: {
+      getLLMConfig: vi.fn().mockResolvedValue({
+        version: 2,
+        languageModel: { provider: "openai", model: "gpt-4", apiKey: "sk-secret-123" },
+        transcriptionModel: null,
+        providerApiKeys: { openai: "sk-secret-123" },
+      }),
+      storeLLMConfig: vi.fn().mockResolvedValue(undefined),
+      ...overrides.llm,
+    },
+    settings: {
+      getSettingsAsync: vi.fn().mockResolvedValue({
+        toolApprovalMode: "ask",
+        openAtLogin: false,
+        hotkeys: { startRecording: "PrintScreen" },
+      }),
+      updateSettingsAsync: vi.fn().mockResolvedValue(undefined),
+      ...overrides.settings,
+    },
+  };
+}
+
+describe("routeRequest - MCP", () => {
+  let services: BridgeServices;
+  beforeEach(() => {
+    services = makeServices();
+  });
+
+  it("GET /mcp/servers lists servers with secrets redacted", async () => {
+    const res = await routeRequest(services, { method: "GET", path: "/mcp/servers" });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    if (!res.body.ok) throw new Error("expected ok");
+    const servers = res.body.data as MCPServerConfig[];
+    expect(servers).toHaveLength(1);
+    // header secret must be redacted, never echoed in full
+    const headers = (servers[0] as { headers?: Record<string, string> }).headers;
+    expect(headers?.Authorization).toBe(REDACTED);
+    expect(JSON.stringify(servers)).not.toContain("super-secret");
+  });
+
+  it("POST /mcp/servers adds a valid stdio server", async () => {
+    const body = {
+      name: "My Server",
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+    };
+    const res = await routeRequest(services, { method: "POST", path: "/mcp/servers", body });
+    expect(res.status).toBe(201);
+    expect(services.mcp.addServerAsync).toHaveBeenCalledOnce();
+    if (!res.body.ok) throw new Error("expected ok");
+    expect((res.body.data as MCPServerConfig).name).toBe("My Server");
+  });
+
+  it("POST /mcp/servers rejects invalid config via zod", async () => {
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers",
+      body: { name: "X", transport: "stdio" }, // missing command
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(services.mcp.addServerAsync).not.toHaveBeenCalled();
+  });
+
+  it("POST /mcp/servers rejects http server with a bad url", async () => {
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers",
+      body: { name: "X", transport: "streamableHttp", url: "not-a-url" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("PUT /mcp/servers/:id updates and merges with existing", async () => {
+    const body = {
+      name: "Renamed",
+      transport: "streamableHttp",
+      url: "https://new.example.com/mcp",
+    };
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body,
+    });
+    expect(res.status).toBe(200);
+    expect(services.mcp.updateServerAsync).toHaveBeenCalledWith(
+      "srv-1",
+      expect.objectContaining({ id: "srv-1", name: "Renamed" }),
+    );
+  });
+
+  it("DELETE /mcp/servers/:id removes the server", async () => {
+    const res = await routeRequest(services, { method: "DELETE", path: "/mcp/servers/srv-1" });
+    expect(res.status).toBe(200);
+    expect(services.mcp.removeServerAsync).toHaveBeenCalledWith("srv-1");
+    if (!res.body.ok) throw new Error("expected ok");
+    expect(res.body.data).toEqual({ id: "srv-1", removed: true });
+  });
+
+  it("POST /mcp/servers/:id/enabled toggles enabled state", async () => {
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers/srv-1/enabled",
+      body: { enabled: false },
+    });
+    expect(res.status).toBe(200);
+    expect(services.mcp.updateServerAsync).toHaveBeenCalledWith(
+      "srv-1",
+      expect.objectContaining({ id: "srv-1", enabled: false }),
+    );
+  });
+
+  it("POST /mcp/servers/:id/enabled 404s on unknown server", async () => {
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "POST",
+      path: "/mcp/servers/does-not-exist/enabled",
+      body: { enabled: true },
+    });
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("decodes url-encoded ids", async () => {
+    await routeRequest(services, {
+      method: "DELETE",
+      path: `/mcp/servers/${encodeURIComponent("id with spaces")}`,
+    });
+    expect(services.mcp.removeServerAsync).toHaveBeenCalledWith("id with spaces");
+  });
+
+  it("returns 405 for an unsupported method", async () => {
+    const res = await routeRequest(services, { method: "PATCH", path: "/mcp/servers" });
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("routeRequest - LLM", () => {
+  it("GET /llm/config redacts apiKeys but reports hasApiKey", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/llm/config" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    const data = res.body.data as {
+      languageModel: { apiKey: string; hasApiKey: boolean };
+      providerApiKeys: Record<string, string>;
+    };
+    expect(data.languageModel.apiKey).toBe(REDACTED);
+    expect(data.languageModel.hasApiKey).toBe(true);
+    expect(data.providerApiKeys.openai).toBe(REDACTED);
+    expect(JSON.stringify(data)).not.toContain("sk-secret-123");
+  });
+
+  it("POST /llm/config stores a v2 config and never returns the raw key", async () => {
+    const services = makeServices();
+    const body = {
+      version: 2,
+      languageModel: { provider: "openai", model: "gpt-4", apiKey: "sk-brand-new" },
+      transcriptionModel: null,
+    };
+    const res = await routeRequest(services, { method: "POST", path: "/llm/config", body });
+    expect(res.status).toBe(200);
+    expect(services.llm.storeLLMConfig).toHaveBeenCalledWith(body);
+    if (!res.body.ok) throw new Error("expected ok");
+    expect(JSON.stringify(res.body.data)).not.toContain("sk-secret-123");
+  });
+
+  it("POST /llm/config rejects non-v2 payloads", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config",
+      body: { version: 1 },
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe("routeRequest - settings", () => {
+  it("GET /settings returns user settings", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/settings" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    expect((res.body.data as { toolApprovalMode: string }).toolApprovalMode).toBe("ask");
+  });
+
+  it("PATCH /settings validates via the shared zod schema", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "PATCH",
+      path: "/settings",
+      body: { toolApprovalMode: "yolo" },
+    });
+    expect(res.status).toBe(200);
+    expect(services.settings.updateSettingsAsync).toHaveBeenCalledWith({
+      toolApprovalMode: "yolo",
+    });
+  });
+
+  it("PATCH /settings rejects an invalid approval mode", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "PATCH",
+      path: "/settings",
+      body: { toolApprovalMode: "nonsense" },
+    });
+    expect(res.status).toBe(400);
+    expect(services.settings.updateSettingsAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe("routeRequest - misc", () => {
+  it("404s an unknown route", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/nope" });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 and the message when a service throws", async () => {
+    const services = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        listAvailableServers: vi.fn().mockRejectedValue(new Error("boom")),
+      },
+    });
+    const res = await routeRequest(services, { method: "GET", path: "/mcp/servers" });
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    if (res.body.ok) throw new Error("expected error");
+    expect(res.body.error).toBe("boom");
+  });
+});

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,0 +1,202 @@
+import type { LLMConfigV2 } from "@shared/types/llm";
+import {
+  type BridgeResponse,
+  McpEnabledInputSchema,
+  McpServerInputSchema,
+} from "../../../shared/cli-bridge/protocol";
+import {
+  redactLlmConfig,
+  redactMcpServer,
+  redactMcpServers,
+} from "../../../shared/cli-bridge/redact";
+import type { PartialUserSettings, UserSettings } from "../../../shared/types/user-settings";
+import { PartialUserSettingsSchema } from "../../../shared/types/user-settings";
+import type { MCPServerConfig } from "../mcp/types";
+
+/**
+ * Service surface the router depends on. The real bridge wires this to the
+ * existing singletons (MCPServerManager, LlmStorage, UserSettingsStorage); tests
+ * pass mocks. This keeps the routing logic free of Electron and easily testable.
+ */
+export interface BridgeServices {
+  mcp: {
+    listAvailableServers(): Promise<MCPServerConfig[]>;
+    addServerAsync(config: MCPServerConfig): Promise<MCPServerConfig>;
+    updateServerAsync(serverId: string, config: MCPServerConfig): Promise<void>;
+    removeServerAsync(serverId: string): Promise<void>;
+    getServerByIdAsync(serverId: string): Promise<MCPServerConfig | undefined>;
+  };
+  llm: {
+    getLLMConfig(): Promise<LLMConfigV2 | null>;
+    storeLLMConfig(config: LLMConfigV2): Promise<void>;
+  };
+  settings: {
+    getSettingsAsync(): Promise<UserSettings>;
+    updateSettingsAsync(patch: PartialUserSettings): Promise<void>;
+  };
+}
+
+export interface BridgeRequest {
+  method: string;
+  /** Path WITHOUT query string, e.g. "/mcp/servers/abc". */
+  path: string;
+  /** Parsed JSON body (already validated as JSON upstream). */
+  body?: unknown;
+}
+
+export interface BridgeResult {
+  status: number;
+  body: BridgeResponse;
+}
+
+const ok = <T>(data: T, status = 200): BridgeResult => ({ status, body: { ok: true, data } });
+const fail = (error: string, status = 400): BridgeResult => ({
+  status,
+  body: { ok: false, error },
+});
+
+/**
+ * Route a single parsed request to the backing services and produce a JSON
+ * envelope. Auth is handled by the HTTP layer BEFORE this is ever called.
+ */
+export async function routeRequest(
+  services: BridgeServices,
+  req: BridgeRequest,
+): Promise<BridgeResult> {
+  try {
+    const segments = req.path.split("/").filter(Boolean);
+
+    // /mcp/...
+    if (segments[0] === "mcp" && segments[1] === "servers") {
+      return await routeMcp(services, req, segments.slice(2));
+    }
+
+    // /llm/config
+    if (segments[0] === "llm" && segments[1] === "config") {
+      return await routeLlm(services, req);
+    }
+
+    // /settings
+    if (segments[0] === "settings" && segments.length === 1) {
+      return await routeSettings(services, req);
+    }
+
+    return fail(`Unknown route: ${req.method} ${req.path}`, 404);
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err), 500);
+  }
+}
+
+async function routeMcp(
+  services: BridgeServices,
+  req: BridgeRequest,
+  rest: string[],
+): Promise<BridgeResult> {
+  // /mcp/servers
+  if (rest.length === 0) {
+    if (req.method === "GET") {
+      const servers = await services.mcp.listAvailableServers();
+      return ok(redactMcpServers(servers));
+    }
+    if (req.method === "POST") {
+      const parsed = McpServerInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
+      }
+      const created = await services.mcp.addServerAsync(parsed.data as MCPServerConfig);
+      return ok(redactMcpServer(created), 201);
+    }
+    return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+  }
+
+  const serverId = decodeURIComponent(rest[0]);
+
+  // /mcp/servers/:id/enabled
+  if (rest.length === 2 && rest[1] === "enabled") {
+    if (req.method !== "POST") {
+      return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+    }
+    const parsed = McpEnabledInputSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid payload: ${formatZodError(parsed.error)}`);
+    }
+    const existing = await services.mcp.getServerByIdAsync(serverId);
+    if (!existing) {
+      return fail(`MCP server '${serverId}' not found`, 404);
+    }
+    const updated = { ...existing, enabled: parsed.data.enabled } as MCPServerConfig;
+    await services.mcp.updateServerAsync(serverId, updated);
+    return ok(redactMcpServer(updated));
+  }
+
+  // /mcp/servers/:id
+  if (rest.length === 1) {
+    if (req.method === "PUT") {
+      const parsed = McpServerInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
+      }
+      const existing = await services.mcp.getServerByIdAsync(serverId);
+      const merged = {
+        ...(existing ?? {}),
+        ...(parsed.data as object),
+        id: serverId,
+      } as MCPServerConfig;
+      await services.mcp.updateServerAsync(serverId, merged);
+      return ok(redactMcpServer(merged));
+    }
+    if (req.method === "DELETE") {
+      await services.mcp.removeServerAsync(serverId);
+      return ok({ id: serverId, removed: true });
+    }
+    return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+  }
+
+  return fail(`Unknown route: ${req.method} ${req.path}`, 404);
+}
+
+async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {
+  if (req.method === "GET") {
+    const config = await services.llm.getLLMConfig();
+    return ok(redactLlmConfig(config));
+  }
+  if (req.method === "POST") {
+    if (!req.body || typeof req.body !== "object") {
+      return fail("Invalid LLM config payload");
+    }
+    const config = req.body as LLMConfigV2;
+    if (config.version !== 2) {
+      return fail("LLM config must be version 2");
+    }
+    await services.llm.storeLLMConfig(config);
+    const stored = await services.llm.getLLMConfig();
+    return ok(redactLlmConfig(stored));
+  }
+  return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+async function routeSettings(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {
+  if (req.method === "GET") {
+    return ok(await services.settings.getSettingsAsync());
+  }
+  if (req.method === "PATCH") {
+    const parsed = PartialUserSettingsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid settings patch: ${formatZodError(parsed.error)}`);
+    }
+    await services.settings.updateSettingsAsync(parsed.data);
+    return ok(await services.settings.getSettingsAsync());
+  }
+  return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+function formatZodError(error: {
+  issues: Array<{ path: PropertyKey[]; message: string }>;
+}): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,6 +1,7 @@
 import type { LLMConfigV2 } from "@shared/types/llm";
 import {
   type BridgeResponse,
+  LlmConfigInputSchema,
   McpEnabledInputSchema,
   McpServerInputSchema,
 } from "../../../shared/cli-bridge/protocol";
@@ -179,14 +180,11 @@ async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<B
     return ok(redactLlmConfig(config));
   }
   if (req.method === "POST") {
-    if (!req.body || typeof req.body !== "object") {
-      return fail("Invalid LLM config payload");
+    const parsed = LlmConfigInputSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid LLM config: ${formatZodError(parsed.error)}`);
     }
-    const config = req.body as LLMConfigV2;
-    if (config.version !== 2) {
-      return fail("LLM config must be version 2");
-    }
-    await services.llm.storeLLMConfig(config);
+    await services.llm.storeLLMConfig(parsed.data as LLMConfigV2);
     const stored = await services.llm.getLLMConfig();
     return ok(redactLlmConfig(stored));
   }

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -49,6 +49,14 @@ export interface BridgeResult {
   body: BridgeResponse;
 }
 
+/**
+ * Built-in (internal/preset) MCP servers are managed by the app and must not be
+ * mutated through the bridge — the desktop UI excludes them from its
+ * enable/edit/delete surface (McpServerManager.tsx), so the bridge mirrors that
+ * invariant instead of silently persisting a phantom row the merge logic ignores.
+ */
+const BUILTIN_IMMUTABLE_MESSAGE = "Cannot modify a built-in MCP server";
+
 const ok = <T>(data: T, status = 200): BridgeResult => ({ status, body: { ok: true, data } });
 const fail = (error: string, status = 400): BridgeResult => ({
   status,
@@ -124,6 +132,9 @@ async function routeMcp(
     if (!existing) {
       return fail(`MCP server '${serverId}' not found`, 404);
     }
+    if (existing.builtin) {
+      return fail(BUILTIN_IMMUTABLE_MESSAGE, 409);
+    }
     const updated = { ...existing, enabled: parsed.data.enabled } as MCPServerConfig;
     await services.mcp.updateServerAsync(serverId, updated);
     return ok(redactMcpServer(updated));
@@ -137,6 +148,9 @@ async function routeMcp(
         return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
       }
       const existing = await services.mcp.getServerByIdAsync(serverId);
+      if (existing?.builtin) {
+        return fail(BUILTIN_IMMUTABLE_MESSAGE, 409);
+      }
       const merged = {
         ...(existing ?? {}),
         ...(parsed.data as object),
@@ -146,6 +160,10 @@ async function routeMcp(
       return ok(redactMcpServer(merged));
     }
     if (req.method === "DELETE") {
+      const existing = await services.mcp.getServerByIdAsync(serverId);
+      if (existing?.builtin) {
+        return fail(BUILTIN_IMMUTABLE_MESSAGE, 409);
+      }
       await services.mcp.removeServerAsync(serverId);
       return ok({ id: serverId, removed: true });
     }

--- a/src/backend/services/cli-bridge/cli-bridge-e2e.integration.test.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-e2e.integration.test.ts
@@ -1,0 +1,153 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CliBridgeTokenFileSchema, REDACTED } from "../../../shared/cli-bridge/protocol";
+import type { MCPServerConfig } from "../mcp/types";
+import type { BridgeServices } from "./bridge-router";
+
+/**
+ * End-to-end coverage of the ASSEMBLED bridge path that no other suite exercises:
+ *
+ *   HTTP server (real fetch) -> bearer-token auth -> JSON body reader/parser
+ *     -> routeRequest -> REAL MCPServerManager (in-memory McpStorage)
+ *
+ * cli-bridge-server.test.ts drives the real HTTP/auth layer but with fully MOCKED
+ * services; bridge-router.integration.test.ts drives the real manager but calls
+ * routeRequest() directly, bypassing HTTP/auth/body-parse. This test wires the
+ * real CliBridgeServer to a real-manager-backed BridgeServices and proves a valid
+ * POST body survives the wire AND that secrets are redacted in the HTTP response
+ * while the real value is persisted underneath.
+ */
+
+const { TEST_USER_DATA } = vi.hoisted(() => {
+  const os = require("node:os") as typeof import("node:os");
+  const path = require("node:path") as typeof import("node:path");
+  return { TEST_USER_DATA: path.join(os.tmpdir(), `yakshaver-bridge-e2e-${process.pid}`) };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue(TEST_USER_DATA),
+    getVersion: vi.fn().mockReturnValue("0.0.0-test"),
+    setLoginItemSettings: vi.fn(),
+  },
+}));
+
+// In-memory stand-in for the secure McpStorage (no Electron safeStorage / DB).
+const memStore: { configs: MCPServerConfig[] } = { configs: [] };
+vi.mock("../storage/mcp-storage", () => ({
+  McpStorage: {
+    getInstance: () => ({
+      getMcpServerConfigsAsync: async () => structuredClone(memStore.configs),
+      storeMcpServers: async (servers: MCPServerConfig[]) => {
+        memStore.configs = structuredClone(servers);
+      },
+      hasMcpServersAsync: async () => memStore.configs.length > 0,
+    }),
+  },
+}));
+
+// The manager's client/transport layer is never needed for config CRUD.
+vi.mock("./mcp-server-client", () => ({ MCPServerClient: class {} }));
+
+import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { CliBridgeServer } from "./cli-bridge-server";
+
+/** Same MCP surface createDefaultServices() builds, backed by the real manager. */
+async function realServices(): Promise<BridgeServices> {
+  const manager = await MCPServerManager.getInstanceAsync();
+  return {
+    mcp: {
+      listAvailableServers: () => manager.listAvailableServers(),
+      addServerAsync: (config) => manager.addServerAsync(config),
+      updateServerAsync: (serverId, config) => manager.updateServerAsync(serverId, config),
+      removeServerAsync: (serverId) => manager.removeServerAsync(serverId),
+      getServerByIdAsync: (serverId) => MCPServerManager.getServerConfigByIdAsync(serverId),
+    },
+    llm: { getLLMConfig: async () => null, storeLLMConfig: async () => {} },
+    settings: {
+      getSettingsAsync: async () => ({ toolApprovalMode: "ask" }) as never,
+      updateSettingsAsync: async () => {},
+    },
+  };
+}
+
+async function readToken(): Promise<{ port: number; token: string }> {
+  const filePath = join(TEST_USER_DATA, "yakshaver-tokens", "cli-bridge.json");
+  const raw = JSON.parse(await fs.readFile(filePath, "utf8"));
+  return CliBridgeTokenFileSchema.parse(raw);
+}
+
+describe("CLI bridge end-to-end (HTTP + auth + body + real manager)", () => {
+  let server: CliBridgeServer;
+
+  beforeEach(async () => {
+    memStore.configs = [];
+    // biome-ignore lint/suspicious/noExplicitAny: reset private statics for isolation
+    (MCPServerManager as any).instance = undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: reset private statics for isolation
+    (MCPServerManager as any).internalServerConfigs = [];
+    // @ts-expect-error reset private static for isolation
+    CliBridgeServer.instance = null;
+    server = CliBridgeServer.getInstance(await realServices());
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    await fs.rm(TEST_USER_DATA, { recursive: true, force: true });
+    memStore.configs = [];
+  });
+
+  it("POSTs a valid body over HTTP, redacts the secret in the response, persists the real value, then lists it", async () => {
+    const { port, token } = await readToken();
+    const base = `http://127.0.0.1:${port}`;
+    const auth = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+
+    // POST /mcp/servers with a secret header — through real readJsonBody + JSON.parse.
+    const addRes = await fetch(`${base}/mcp/servers`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        name: "Round Trip",
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+        headers: { Authorization: "Bearer top-secret" },
+      }),
+    });
+    expect(addRes.status).toBe(201);
+    const addBody = await addRes.json();
+    expect(addBody.ok).toBe(true);
+    const id = addBody.data.id as string;
+    expect(id).toBeTruthy();
+
+    // Secret redacted on the wire, real value persisted underneath.
+    expect(addBody.data.headers.Authorization).toBe(REDACTED);
+    const storedHeaders = (memStore.configs[0] as { headers?: Record<string, string> }).headers;
+    expect(storedHeaders?.Authorization).toBe("Bearer top-secret");
+
+    // GET /mcp/servers over HTTP lists it with the secret still redacted.
+    const listRes = await fetch(`${base}/mcp/servers`, { headers: auth });
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    expect(listBody.ok).toBe(true);
+    expect((listBody.data as MCPServerConfig[]).some((s) => s.id === id)).toBe(true);
+    expect(JSON.stringify(listBody.data)).not.toContain("top-secret");
+
+    // DELETE over HTTP removes it for real.
+    const delRes = await fetch(`${base}/mcp/servers/${id}`, { method: "DELETE", headers: auth });
+    expect(delRes.status).toBe(200);
+    expect(memStore.configs.find((s) => s.id === id)).toBeUndefined();
+  });
+
+  it("rejects an unauthenticated POST without ever reaching the manager", async () => {
+    const { port } = await readToken();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Nope", transport: "stdio", command: "node" }),
+    });
+    expect(res.status).toBe(401);
+    expect(memStore.configs).toHaveLength(0);
+  });
+});

--- a/src/backend/services/cli-bridge/cli-bridge-server.test.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.test.ts
@@ -1,0 +1,140 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CliBridgeTokenFileSchema } from "../../../shared/cli-bridge/protocol";
+import type { BridgeServices } from "./bridge-router";
+
+// A throwaway userData dir so the token file lands somewhere harmless.
+// vi.mock factories are hoisted above imports, so compute the path via
+// vi.hoisted so the electron mock can reference it.
+const { TEST_USER_DATA } = vi.hoisted(() => {
+  const os = require("node:os") as typeof import("node:os");
+  const path = require("node:path") as typeof import("node:path");
+  return { TEST_USER_DATA: path.join(os.tmpdir(), `yakshaver-bridge-test-${process.pid}`) };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue(TEST_USER_DATA),
+    getVersion: vi.fn().mockReturnValue("0.0.0-test"),
+  },
+}));
+
+// Stub the storage singletons the default services would reach for. We pass
+// explicit services into getInstance() so these are only a safety net.
+vi.mock("../storage/llm-storage", () => ({ LlmStorage: { getInstance: () => ({}) } }));
+vi.mock("../storage/user-settings-storage", () => ({
+  UserSettingsStorage: { getInstance: () => ({}) },
+}));
+vi.mock("../mcp/mcp-server-manager", () => ({ MCPServerManager: {} }));
+
+import { CliBridgeServer } from "./cli-bridge-server";
+
+function makeServices(): BridgeServices {
+  return {
+    mcp: {
+      listAvailableServers: vi.fn().mockResolvedValue([{ id: "a", name: "A", transport: "stdio" }]),
+      addServerAsync: vi.fn(),
+      updateServerAsync: vi.fn(),
+      removeServerAsync: vi.fn(),
+      getServerByIdAsync: vi.fn(),
+    },
+    llm: { getLLMConfig: vi.fn().mockResolvedValue(null), storeLLMConfig: vi.fn() },
+    settings: {
+      getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: "ask" }),
+      updateSettingsAsync: vi.fn(),
+    },
+  };
+}
+
+async function readToken(): Promise<{ port: number; token: string }> {
+  const filePath = join(TEST_USER_DATA, "yakshaver-tokens", "cli-bridge.json");
+  const raw = JSON.parse(await fs.readFile(filePath, "utf8"));
+  return CliBridgeTokenFileSchema.parse(raw);
+}
+
+describe("CliBridgeServer", () => {
+  let server: CliBridgeServer;
+
+  beforeEach(() => {
+    // Force a fresh singleton each test.
+    // @ts-expect-error reset private static for isolation
+    CliBridgeServer.instance = null;
+    server = CliBridgeServer.getInstance(makeServices());
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    await fs.rm(TEST_USER_DATA, { recursive: true, force: true });
+  });
+
+  it("binds to 127.0.0.1 and writes a token file with port + token", async () => {
+    const started = await server.start();
+    expect(started).toBe(true);
+
+    const { port, token } = await readToken();
+    expect(port).toBeGreaterThan(0);
+    expect(token).toMatch(/^[0-9a-f]{64}$/); // 32 random bytes hex
+    expect(server.getPort()).toBe(port);
+  });
+
+  it("rejects requests without a bearer token (401)", async () => {
+    await server.start();
+    const { port } = await readToken();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("rejects requests with the wrong token (401)", async () => {
+    await server.start();
+    const { port } = await readToken();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`, {
+      headers: { Authorization: "Bearer not-the-real-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("serves authorized requests through the router", async () => {
+    await server.start();
+    const { port, token } = await readToken();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("rejects an oversized body", async () => {
+    await server.start();
+    const { port, token } = await readToken();
+    const big = "x".repeat(300 * 1024);
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ data: big }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("does not start when disabled via env", async () => {
+    process.env.YAKSHAVER_DISABLE_CLI_BRIDGE = "1";
+    try {
+      const started = await server.start();
+      expect(started).toBe(false);
+      expect(server.getPort()).toBeNull();
+    } finally {
+      delete process.env.YAKSHAVER_DISABLE_CLI_BRIDGE;
+    }
+  });
+
+  it("removes the token file on stop", async () => {
+    await server.start();
+    const filePath = join(TEST_USER_DATA, "yakshaver-tokens", "cli-bridge.json");
+    await server.stop();
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+});

--- a/src/backend/services/cli-bridge/cli-bridge-server.test.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.test.ts
@@ -7,16 +7,23 @@ import type { BridgeServices } from "./bridge-router";
 // A throwaway userData dir so the token file lands somewhere harmless.
 // vi.mock factories are hoisted above imports, so compute the path via
 // vi.hoisted so the electron mock can reference it.
-const { TEST_USER_DATA } = vi.hoisted(() => {
-  const os = require("node:os") as typeof import("node:os");
-  const path = require("node:path") as typeof import("node:path");
-  return { TEST_USER_DATA: path.join(os.tmpdir(), `yakshaver-bridge-test-${process.pid}`) };
-});
+const { TEST_USER_DATA, setLoginItemSettingsMock, updateSettingsAsyncMock, getSettingsAsyncMock } =
+  vi.hoisted(() => {
+    const os = require("node:os") as typeof import("node:os");
+    const path = require("node:path") as typeof import("node:path");
+    return {
+      TEST_USER_DATA: path.join(os.tmpdir(), `yakshaver-bridge-test-${process.pid}`),
+      setLoginItemSettingsMock: vi.fn(),
+      updateSettingsAsyncMock: vi.fn().mockResolvedValue(undefined),
+      getSettingsAsyncMock: vi.fn().mockResolvedValue({}),
+    };
+  });
 
 vi.mock("electron", () => ({
   app: {
     getPath: vi.fn().mockReturnValue(TEST_USER_DATA),
     getVersion: vi.fn().mockReturnValue("0.0.0-test"),
+    setLoginItemSettings: setLoginItemSettingsMock,
   },
 }));
 
@@ -24,11 +31,16 @@ vi.mock("electron", () => ({
 // explicit services into getInstance() so these are only a safety net.
 vi.mock("../storage/llm-storage", () => ({ LlmStorage: { getInstance: () => ({}) } }));
 vi.mock("../storage/user-settings-storage", () => ({
-  UserSettingsStorage: { getInstance: () => ({}) },
+  UserSettingsStorage: {
+    getInstance: () => ({
+      getSettingsAsync: getSettingsAsyncMock,
+      updateSettingsAsync: updateSettingsAsyncMock,
+    }),
+  },
 }));
 vi.mock("../mcp/mcp-server-manager", () => ({ MCPServerManager: {} }));
 
-import { CliBridgeServer } from "./cli-bridge-server";
+import { CliBridgeServer, createDefaultServices } from "./cli-bridge-server";
 
 function makeServices(): BridgeServices {
   return {
@@ -136,5 +148,41 @@ describe("CliBridgeServer", () => {
     const filePath = join(TEST_USER_DATA, "yakshaver-tokens", "cli-bridge.json");
     await server.stop();
     await expect(fs.access(filePath)).rejects.toThrow();
+  });
+});
+
+describe("createDefaultServices - settings side effects", () => {
+  beforeEach(() => {
+    setLoginItemSettingsMock.mockClear();
+    updateSettingsAsyncMock.mockClear();
+  });
+
+  it("registers the OS login item when openAtLogin is set", async () => {
+    const services = createDefaultServices();
+    await services.settings.updateSettingsAsync({ openAtLogin: true });
+
+    expect(updateSettingsAsyncMock).toHaveBeenCalledWith({ openAtLogin: true });
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({
+      openAtLogin: true,
+      openAsHidden: false,
+    });
+  });
+
+  it("unregisters the OS login item when openAtLogin is cleared", async () => {
+    const services = createDefaultServices();
+    await services.settings.updateSettingsAsync({ openAtLogin: false });
+
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({
+      openAtLogin: false,
+      openAsHidden: false,
+    });
+  });
+
+  it("does not touch the login item when openAtLogin is absent from the patch", async () => {
+    const services = createDefaultServices();
+    await services.settings.updateSettingsAsync({ toolApprovalMode: "yolo" });
+
+    expect(updateSettingsAsyncMock).toHaveBeenCalledWith({ toolApprovalMode: "yolo" });
+    expect(setLoginItemSettingsMock).not.toHaveBeenCalled();
   });
 });

--- a/src/backend/services/cli-bridge/cli-bridge-server.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.ts
@@ -1,0 +1,293 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { dirname, join } from "node:path";
+import { app } from "electron";
+import {
+  CLI_BRIDGE_DEFAULT_PORT,
+  CLI_BRIDGE_DISABLE_ENV,
+  CLI_BRIDGE_HOST,
+  CLI_BRIDGE_TOKEN_DIR,
+  CLI_BRIDGE_TOKEN_FILE,
+  type CliBridgeTokenFile,
+} from "../../../shared/cli-bridge/protocol";
+import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { LlmStorage } from "../storage/llm-storage";
+import { UserSettingsStorage } from "../storage/user-settings-storage";
+import { type BridgeServices, routeRequest } from "./bridge-router";
+
+const MAX_BODY_BYTES = 256 * 1024; // 256 KB is plenty for config payloads.
+
+/**
+ * Localhost-only HTTP bridge that lets the `yakshaver` CLI read and mutate the
+ * desktop app's MCP/LLM/settings configuration.
+ *
+ * Security model:
+ *  - Binds to 127.0.0.1 ONLY (never 0.0.0.0), so it is unreachable off-box.
+ *  - A random 256-bit token is generated at startup and written, alongside the
+ *    chosen port, to `userData/yakshaver-tokens/cli-bridge.json` (same-user
+ *    readable). Every request must present `Authorization: Bearer <token>`.
+ *  - Secrets (api keys, header/env values) are redacted in every response.
+ *  - Opt-out via the YAKSHAVER_DISABLE_CLI_BRIDGE env var.
+ */
+export class CliBridgeServer {
+  private static instance: CliBridgeServer | null = null;
+
+  private server: Server | null = null;
+  private token: string | null = null;
+  private port: number | null = null;
+
+  private constructor(private readonly services: BridgeServices) {}
+
+  static getInstance(services?: BridgeServices): CliBridgeServer {
+    if (!CliBridgeServer.instance) {
+      CliBridgeServer.instance = new CliBridgeServer(services ?? createDefaultServices());
+    }
+    return CliBridgeServer.instance;
+  }
+
+  /** Resolve the token file path the same way the secure storage does. */
+  private static getTokenFilePath(): string {
+    return join(app.getPath("userData"), CLI_BRIDGE_TOKEN_DIR, CLI_BRIDGE_TOKEN_FILE);
+  }
+
+  /**
+   * Start the bridge. Idempotent and best-effort: any failure is logged but
+   * never crashes app startup. Returns true if the server is now listening.
+   */
+  async start(): Promise<boolean> {
+    if (process.env[CLI_BRIDGE_DISABLE_ENV]) {
+      console.log("[CliBridge] Disabled via env; not starting.");
+      return false;
+    }
+    if (this.server) {
+      return true;
+    }
+
+    this.token = randomBytes(32).toString("hex");
+
+    try {
+      this.port = await this.listen(CLI_BRIDGE_DEFAULT_PORT);
+    } catch (err) {
+      console.warn(
+        `[CliBridge] Default port ${CLI_BRIDGE_DEFAULT_PORT} unavailable, trying ephemeral port:`,
+        err,
+      );
+      try {
+        this.port = await this.listen(0); // OS-assigned ephemeral port.
+      } catch (err2) {
+        console.error("[CliBridge] Failed to bind localhost bridge:", err2);
+        this.server = null;
+        return false;
+      }
+    }
+
+    try {
+      await this.writeTokenFile();
+    } catch (err) {
+      console.error("[CliBridge] Failed to write token file:", err);
+      await this.stop();
+      return false;
+    }
+
+    console.log(`[CliBridge] Listening on http://${CLI_BRIDGE_HOST}:${this.port}`);
+    return true;
+  }
+
+  private listen(port: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const server = createServer((req, res) => {
+        this.handleRequest(req, res).catch((err) => {
+          console.error("[CliBridge] Unhandled request error:", err);
+          this.sendJson(res, 500, { ok: false, error: "Internal error" });
+        });
+      });
+
+      server.on("error", reject);
+      // Bind to localhost ONLY. Never 0.0.0.0.
+      server.listen(port, CLI_BRIDGE_HOST, () => {
+        server.removeListener("error", reject);
+        this.server = server;
+        const address = server.address();
+        const boundPort = typeof address === "object" && address ? address.port : port;
+        resolve(boundPort);
+      });
+    });
+  }
+
+  private async writeTokenFile(): Promise<void> {
+    const filePath = CliBridgeServer.getTokenFilePath();
+    await fs.mkdir(dirname(filePath), { recursive: true });
+
+    const payload: CliBridgeTokenFile = {
+      port: this.port ?? CLI_BRIDGE_DEFAULT_PORT,
+      token: this.token ?? "",
+      startedAt: new Date().toISOString(),
+      version: safeAppVersion(),
+    };
+
+    // Owner-only permissions where the platform honours them (no-op on Windows).
+    await fs.writeFile(filePath, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!this.isAuthorized(req)) {
+      this.sendJson(res, 401, { ok: false, error: "Unauthorized" });
+      return;
+    }
+
+    const url = new URL(req.url ?? "/", `http://${CLI_BRIDGE_HOST}`);
+    const path = url.pathname;
+    const method = req.method ?? "GET";
+
+    let body: unknown;
+    try {
+      body = await this.readJsonBody(req);
+    } catch (err) {
+      this.sendJson(res, 400, {
+        ok: false,
+        error: err instanceof Error ? err.message : "Invalid JSON body",
+      });
+      return;
+    }
+
+    const result = await routeRequest(this.services, { method, path, body });
+    this.sendJson(res, result.status, result.body);
+  }
+
+  private isAuthorized(req: IncomingMessage): boolean {
+    if (!this.token) return false;
+    const header = req.headers.authorization ?? "";
+    const prefix = "Bearer ";
+    if (!header.startsWith(prefix)) return false;
+    const provided = header.slice(prefix.length);
+    return safeStringEquals(provided, this.token);
+  }
+
+  private readJsonBody(req: IncomingMessage): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      let settled = false;
+
+      const settleReject = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        // Drain remaining data without buffering so the socket stays usable and
+        // the handler can still write an error response (don't destroy it).
+        req.removeAllListeners("data");
+        req.on("data", () => {});
+        reject(err);
+      };
+
+      req.on("data", (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > MAX_BODY_BYTES) {
+          settleReject(new Error("Request body too large"));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on("end", () => {
+        if (settled) return;
+        settled = true;
+        if (chunks.length === 0) {
+          resolve(undefined);
+          return;
+        }
+        const raw = Buffer.concat(chunks).toString("utf8").trim();
+        if (!raw) {
+          resolve(undefined);
+          return;
+        }
+        try {
+          resolve(JSON.parse(raw));
+        } catch {
+          reject(new Error("Invalid JSON body"));
+        }
+      });
+      req.on("error", (err) => settleReject(err instanceof Error ? err : new Error(String(err))));
+    });
+  }
+
+  private sendJson(res: ServerResponse, status: number, body: unknown): void {
+    const payload = JSON.stringify(body);
+    res.writeHead(status, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload),
+    });
+    res.end(payload);
+  }
+
+  /** Stop the server and remove the token file. Safe to call multiple times. */
+  async stop(): Promise<void> {
+    const server = this.server;
+    this.server = null;
+    this.token = null;
+
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+
+    try {
+      await fs.unlink(CliBridgeServer.getTokenFilePath());
+    } catch {
+      // Already gone — ignore.
+    }
+  }
+
+  /** Test/diagnostic helper. */
+  getPort(): number | null {
+    return this.port;
+  }
+}
+
+function safeStringEquals(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+function safeAppVersion(): string | undefined {
+  try {
+    return app.getVersion();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Wire the router to the real app singletons. */
+function createDefaultServices(): BridgeServices {
+  return {
+    mcp: {
+      async listAvailableServers() {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.listAvailableServers();
+      },
+      async addServerAsync(config) {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.addServerAsync(config);
+      },
+      async updateServerAsync(serverId, config) {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.updateServerAsync(serverId, config);
+      },
+      async removeServerAsync(serverId) {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.removeServerAsync(serverId);
+      },
+      async getServerByIdAsync(serverId) {
+        return MCPServerManager.getServerConfigByIdAsync(serverId);
+      },
+    },
+    llm: {
+      getLLMConfig: () => LlmStorage.getInstance().getLLMConfig(),
+      storeLLMConfig: (config) => LlmStorage.getInstance().storeLLMConfig(config),
+    },
+    settings: {
+      getSettingsAsync: () => UserSettingsStorage.getInstance().getSettingsAsync(),
+      updateSettingsAsync: (patch) => UserSettingsStorage.getInstance().updateSettingsAsync(patch),
+    },
+  };
+}

--- a/src/backend/services/cli-bridge/cli-bridge-server.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.ts
@@ -12,6 +12,7 @@ import {
   type CliBridgeTokenFile,
 } from "../../../shared/cli-bridge/protocol";
 import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { applyOpenAtLoginSetting } from "../settings/login-item";
 import { LlmStorage } from "../storage/llm-storage";
 import { UserSettingsStorage } from "../storage/user-settings-storage";
 import { type BridgeServices, routeRequest } from "./bridge-router";
@@ -258,7 +259,7 @@ function safeAppVersion(): string | undefined {
 }
 
 /** Wire the router to the real app singletons. */
-function createDefaultServices(): BridgeServices {
+export function createDefaultServices(): BridgeServices {
   return {
     mcp: {
       async listAvailableServers() {
@@ -287,7 +288,15 @@ function createDefaultServices(): BridgeServices {
     },
     settings: {
       getSettingsAsync: () => UserSettingsStorage.getInstance().getSettingsAsync(),
-      updateSettingsAsync: (patch) => UserSettingsStorage.getInstance().updateSettingsAsync(patch),
+      async updateSettingsAsync(patch) {
+        await UserSettingsStorage.getInstance().updateSettingsAsync(patch);
+        // Apply the same OS-level side effect the Settings IPC handler applies,
+        // so a CLI-driven openAtLogin change actually registers/unregisters the
+        // login item instead of only being persisted.
+        if (patch.openAtLogin !== undefined) {
+          applyOpenAtLoginSetting(patch.openAtLogin);
+        }
+      },
     },
   };
 }

--- a/src/backend/services/settings/login-item.ts
+++ b/src/backend/services/settings/login-item.ts
@@ -1,0 +1,19 @@
+import { app } from "electron";
+
+/**
+ * Registers (or unregisters) the OS "open at login" item to match the desired
+ * state.
+ *
+ * This is the OS-level side effect that must accompany every persisted change
+ * to `UserSettings.openAtLogin`. It lives here — not in the storage service —
+ * so that every write path (the Settings IPC handler AND the CLI bridge) applies
+ * it identically. Persisting the flag without calling this leaves the running
+ * app's auto-launch state out of sync with the stored/reported value until the
+ * next restart.
+ */
+export function applyOpenAtLoginSetting(openAtLogin: boolean): void {
+  app.setLoginItemSettings({
+    openAtLogin,
+    openAsHidden: false,
+  });
+}

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { ArgParseError, parseArgs } from "./args";
+
+describe("parseArgs", () => {
+  it("splits positionals from options", () => {
+    const r = parseArgs(["mcp", "add", "--name", "Foo", "--transport", "stdio"]);
+    expect(r.positionals).toEqual(["mcp", "add"]);
+    expect(r.options).toMatchObject({ name: "Foo", transport: "stdio" });
+  });
+
+  it("supports --key=value", () => {
+    const r = parseArgs(["mcp", "add", "--name=Foo Bar"]);
+    expect(r.options.name).toBe("Foo Bar");
+  });
+
+  it("treats known boolean flags and trailing flags as boolean", () => {
+    const r = parseArgs(["mcp", "enable", "abc", "--off"]);
+    expect(r.options.off).toBe(true);
+    expect(r.positionals).toEqual(["mcp", "enable", "abc"]);
+  });
+
+  it("collects repeated flags into multiOptions; options stays last-write-wins", () => {
+    const r = parseArgs(["mcp", "add", "--arg", "a b", "--arg=c", "--arg", "d"]);
+    expect(r.multiOptions.arg).toEqual(["a b", "c", "d"]);
+    expect(r.options.arg).toBe("d");
+  });
+
+  describe("--arg is a value-flag (takes its next token verbatim)", () => {
+    it("takes a value-shaped token", () => {
+      const r = parseArgs(["--arg", "one", "--arg", "three"]);
+      expect(r.multiOptions.arg).toEqual(["one", "three"]);
+    });
+
+    it("takes a flag-shaped (--prefixed) token verbatim instead of dropping it", () => {
+      // Regression: previously `--arg --flag` silently dropped "--flag" and set
+      // options.flag = true, launching a misconfigured MCP server with no error.
+      const r = parseArgs(["--arg", "one", "--arg", "--flag", "--arg", "three"]);
+      expect(r.multiOptions.arg).toEqual(["one", "--flag", "three"]);
+      expect(r.options.flag).toBeUndefined();
+    });
+
+    it("supports the natural `--arg --port --arg 3000` form", () => {
+      const r = parseArgs(["--arg", "--port", "--arg", "3000"]);
+      expect(r.multiOptions.arg).toEqual(["--port", "3000"]);
+    });
+
+    it("throws ArgParseError when --arg has no following value", () => {
+      expect(() => parseArgs(["mcp", "add", "--command", "node", "--arg"])).toThrow(ArgParseError);
+    });
+
+    it("still supports the equals form for a --prefixed value", () => {
+      const r = parseArgs(["--arg=--config=My File.json"]);
+      expect(r.multiOptions.arg).toEqual(["--config=My File.json"]);
+    });
+  });
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -18,6 +18,24 @@ export interface ParsedArgs {
 
 const BOOLEAN_FLAGS = new Set(["off", "help", "dev", "json"]);
 
+/**
+ * Flags whose immediately-following token is ALWAYS consumed verbatim as the
+ * value — even when that token itself begins with `--`. This is required for
+ * flags that legitimately carry an arbitrary value which may look like a flag,
+ * e.g. an MCP launch argument: `--arg --port` / `--arg --config`. Without this,
+ * the generic lookahead rule (treat a `--`-prefixed next token as the next flag)
+ * would silently swallow the value and produce a misconfigured server.
+ */
+const VALUE_FLAGS = new Set(["arg"]);
+
+/** A usage/parse error raised while splitting argv (e.g. a flag missing its value). */
+export class ArgParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgParseError";
+  }
+}
+
 export function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   const options: Record<string, string | boolean> = {};
@@ -48,6 +66,19 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
       const key = arg.slice(2);
       const next = argv[i + 1];
+
+      // A value-flag (e.g. --arg) always takes the very next token as its value,
+      // verbatim, even if it starts with "--". A missing value is a hard error
+      // rather than a silent drop.
+      if (VALUE_FLAGS.has(key)) {
+        if (next === undefined) {
+          throw new ArgParseError(`--${key} requires a value`);
+        }
+        recordValue(key, next);
+        i++;
+        continue;
+      }
+
       // Boolean flags, or a flag at the end / followed by another flag.
       if (BOOLEAN_FLAGS.has(key) || next === undefined || next.startsWith("--")) {
         options[key] = true;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -8,6 +8,12 @@
 export interface ParsedArgs {
   positionals: string[];
   options: Record<string, string | boolean>;
+  /**
+   * Every string value seen for a flag, keyed by flag name and preserving order
+   * and repeats. `options` is last-write-wins; this is where repeatable flags
+   * (e.g. `--arg`) collect their full list. Boolean flags do not appear here.
+   */
+  multiOptions: Record<string, string[]>;
 }
 
 const BOOLEAN_FLAGS = new Set(["off", "help", "dev", "json"]);
@@ -15,6 +21,14 @@ const BOOLEAN_FLAGS = new Set(["off", "help", "dev", "json"]);
 export function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   const options: Record<string, string | boolean> = {};
+  const multiOptions: Record<string, string[]> = {};
+
+  const recordValue = (key: string, value: string): void => {
+    options[key] = value;
+    const existing = multiOptions[key] ?? [];
+    existing.push(value);
+    multiOptions[key] = existing;
+  };
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -28,7 +42,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       const eq = arg.indexOf("=");
       if (eq !== -1) {
         const key = arg.slice(2, eq);
-        options[key] = arg.slice(eq + 1);
+        recordValue(key, arg.slice(eq + 1));
         continue;
       }
 
@@ -38,7 +52,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       if (BOOLEAN_FLAGS.has(key) || next === undefined || next.startsWith("--")) {
         options[key] = true;
       } else {
-        options[key] = next;
+        recordValue(key, next);
         i++;
       }
       continue;
@@ -47,7 +61,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     positionals.push(arg);
   }
 
-  return { positionals, options };
+  return { positionals, options, multiOptions };
 }
 
 /** Read a string option, throwing a clear error when required and missing. */
@@ -66,6 +80,19 @@ export function optionalString(
 ): string | undefined {
   const value = options[name];
   return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Read every value supplied for a repeatable flag (e.g. `--arg a --arg b`),
+ * preserving order and never splitting on spaces — so a single value may safely
+ * contain spaces (a Windows path, a `--config=My File.json`, etc.).
+ */
+export function optionalStringArray(
+  multiOptions: Record<string, string[]>,
+  name: string,
+): string[] | undefined {
+  const values = multiOptions[name];
+  return values && values.length > 0 ? [...values] : undefined;
 }
 
 /** Parse a `key=value,key2=value2` style option into a record. */

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,83 @@
+/**
+ * Minimal, dependency-free arg parser for the `yakshaver` CLI.
+ *
+ * Splits an argv list into positionals and `--flag value` / `--flag=value` /
+ * boolean `--flag` options. Kept tiny and pure so it's trivially unit-testable.
+ */
+
+export interface ParsedArgs {
+  positionals: string[];
+  options: Record<string, string | boolean>;
+}
+
+const BOOLEAN_FLAGS = new Set(["off", "help", "dev", "json"]);
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const options: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      const eq = arg.indexOf("=");
+      if (eq !== -1) {
+        const key = arg.slice(2, eq);
+        options[key] = arg.slice(eq + 1);
+        continue;
+      }
+
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      // Boolean flags, or a flag at the end / followed by another flag.
+      if (BOOLEAN_FLAGS.has(key) || next === undefined || next.startsWith("--")) {
+        options[key] = true;
+      } else {
+        options[key] = next;
+        i++;
+      }
+      continue;
+    }
+
+    positionals.push(arg);
+  }
+
+  return { positionals, options };
+}
+
+/** Read a string option, throwing a clear error when required and missing. */
+export function requireString(options: Record<string, string | boolean>, name: string): string {
+  const value = options[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required --${name} option`);
+  }
+  return value;
+}
+
+/** Read an optional string option. */
+export function optionalString(
+  options: Record<string, string | boolean>,
+  name: string,
+): string | undefined {
+  const value = options[name];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Parse a `key=value,key2=value2` style option into a record. */
+export function parseKeyValueList(value: string | undefined): Record<string, string> | undefined {
+  if (!value) return undefined;
+  const out: Record<string, string> = {};
+  for (const pair of value.split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    const key = pair.slice(0, eq).trim();
+    const val = pair.slice(eq + 1).trim();
+    if (key) out[key] = val;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/src/cli/bridge-client.test.ts
+++ b/src/cli/bridge-client.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CliBridgeTokenFile } from "../shared/cli-bridge/protocol";
+import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
+
+const token: CliBridgeTokenFile = {
+  port: 8765,
+  token: "test-token-abc",
+  startedAt: new Date().toISOString(),
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("BridgeClient", () => {
+  it("builds an authorized request against the token's port", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ ok: true, data: [{ id: "a" }] }));
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    const data = await client.get("/mcp/servers");
+
+    expect(data).toEqual([{ id: "a" }]);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8765/mcp/servers");
+    expect(init.method).toBe("GET");
+    expect(init.headers.Authorization).toBe("Bearer test-token-abc");
+  });
+
+  it("serializes the body and sets content-type for writes", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ ok: true, data: { id: "x" } }));
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    await client.post("/mcp/servers", { name: "X", transport: "stdio", command: "node" });
+
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({ name: "X", transport: "stdio", command: "node" });
+  });
+
+  it("caches the token across requests (loads it once)", async () => {
+    const tokenLoader = vi.fn().mockResolvedValue(token);
+    // Fresh Response per call — a Response body stream can only be read once.
+    const fetchFn = vi.fn().mockImplementation(async () => jsonResponse({ ok: true, data: null }));
+    const client = new BridgeClient({ fetchFn, tokenLoader });
+
+    await client.get("/settings");
+    await client.get("/settings");
+
+    expect(tokenLoader).toHaveBeenCalledOnce();
+  });
+
+  it("throws the bridge error message on { ok: false }", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ ok: false, error: "Server with id 'a' already exists" }, 400),
+      );
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    await expect(client.post("/mcp/servers", {})).rejects.toThrow(
+      "Server with id 'a' already exists",
+    );
+  });
+
+  it("maps a connection failure to BridgeUnavailableError", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    await expect(client.get("/mcp/servers")).rejects.toBeInstanceOf(BridgeUnavailableError);
+  });
+
+  it("surfaces a token-loader failure (app not running)", async () => {
+    const client = new BridgeClient({
+      fetchFn: vi.fn(),
+      tokenLoader: async () => {
+        throw new BridgeUnavailableError("not running");
+      },
+    });
+    await expect(client.get("/mcp/servers")).rejects.toBeInstanceOf(BridgeUnavailableError);
+  });
+});

--- a/src/cli/bridge-client.ts
+++ b/src/cli/bridge-client.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import {
+  type BridgeResponse,
+  CLI_BRIDGE_HOST,
+  CLI_BRIDGE_TOKEN_DIR,
+  CLI_BRIDGE_TOKEN_FILE,
+  type CliBridgeTokenFile,
+  CliBridgeTokenFileSchema,
+} from "../shared/cli-bridge/protocol";
+import { getUserDataDir } from "./user-data-path";
+
+/** Thrown when the app/bridge isn't reachable. The CLI prints a friendly hint. */
+export class BridgeUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BridgeUnavailableError";
+  }
+}
+
+const NOT_RUNNING_HINT =
+  "YakShaver Desktop doesn't appear to be running (or the CLI bridge is disabled). " +
+  "Start the app and retry.";
+
+/** Read + validate the token file the app wrote. */
+export async function readTokenFile(dev?: boolean): Promise<CliBridgeTokenFile> {
+  const filePath = join(getUserDataDir(dev), CLI_BRIDGE_TOKEN_DIR, CLI_BRIDGE_TOKEN_FILE);
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new BridgeUnavailableError(NOT_RUNNING_HINT);
+    }
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new BridgeUnavailableError(
+      `CLI bridge token file is corrupt (${filePath}). ${NOT_RUNNING_HINT}`,
+    );
+  }
+
+  const result = CliBridgeTokenFileSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new BridgeUnavailableError(
+      `CLI bridge token file is invalid (${filePath}). ${NOT_RUNNING_HINT}`,
+    );
+  }
+  return result.data;
+}
+
+export interface BridgeClientOptions {
+  dev?: boolean;
+  /** Injectable for testing. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+  /** Injectable for testing. Defaults to readTokenFile. */
+  tokenLoader?: (dev?: boolean) => Promise<CliBridgeTokenFile>;
+}
+
+/** Tiny typed client over the bridge HTTP API. */
+export class BridgeClient {
+  private readonly fetchFn: typeof fetch;
+  private readonly tokenLoader: (dev?: boolean) => Promise<CliBridgeTokenFile>;
+  private readonly dev?: boolean;
+  private tokenFile: CliBridgeTokenFile | null = null;
+
+  constructor(options: BridgeClientOptions = {}) {
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.tokenLoader = options.tokenLoader ?? readTokenFile;
+    this.dev = options.dev;
+  }
+
+  private async ensureToken(): Promise<CliBridgeTokenFile> {
+    if (!this.tokenFile) {
+      this.tokenFile = await this.tokenLoader(this.dev);
+    }
+    return this.tokenFile;
+  }
+
+  /** Build the absolute URL for a bridge path. */
+  async buildUrl(path: string): Promise<string> {
+    const { port } = await this.ensureToken();
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    return `http://${CLI_BRIDGE_HOST}:${port}${normalized}`;
+  }
+
+  async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+    const token = await this.ensureToken();
+    const url = await this.buildUrl(path);
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token.token}`,
+          ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      // Connection refused etc. → app not actually listening.
+      throw new BridgeUnavailableError(
+        `${NOT_RUNNING_HINT} (${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+
+    let payload: BridgeResponse<T>;
+    try {
+      payload = (await response.json()) as BridgeResponse<T>;
+    } catch {
+      throw new Error(`Bridge returned a non-JSON response (HTTP ${response.status}).`);
+    }
+
+    if (!payload.ok) {
+      throw new Error(payload.error || `Request failed (HTTP ${response.status}).`);
+    }
+    return payload.data;
+  }
+
+  get<T = unknown>(path: string): Promise<T> {
+    return this.request<T>("GET", path);
+  }
+  post<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+  put<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PUT", path, body);
+  }
+  patch<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PATCH", path, body);
+  }
+  del<T = unknown>(path: string): Promise<T> {
+    return this.request<T>("DELETE", path);
+  }
+}

--- a/src/cli/bridge-client.ts
+++ b/src/cli/bridge-client.ts
@@ -12,9 +12,13 @@ import { getUserDataDir } from "./user-data-path";
 
 /** Thrown when the app/bridge isn't reachable. The CLI prints a friendly hint. */
 export class BridgeUnavailableError extends Error {
-  constructor(message: string) {
+  /** True when the token file simply did not exist (vs. corrupt/unreachable). */
+  readonly notFound: boolean;
+
+  constructor(message: string, options?: { notFound?: boolean }) {
     super(message);
     this.name = "BridgeUnavailableError";
+    this.notFound = options?.notFound ?? false;
   }
 }
 
@@ -22,8 +26,40 @@ const NOT_RUNNING_HINT =
   "YakShaver Desktop doesn't appear to be running (or the CLI bridge is disabled). " +
   "Start the app and retry.";
 
-/** Read + validate the token file the app wrote. */
+/**
+ * Read + validate the token file the app wrote.
+ *
+ * The desktop app and the CLI are separate processes that do NOT share an env,
+ * and they detect "dev" differently (the app keys off NODE_ENV/--dev-protocol;
+ * a developer's plain shell has neither). To avoid a misleading "not running"
+ * error when the dev app is up but the CLI looked in the prod folder (or vice
+ * versa), an UNSPECIFIED `dev` (the default) tries BOTH the prod and the dev
+ * token locations before giving up. Passing `dev: true`/`false` explicitly
+ * (e.g. via `--dev`) pins the search to that single location.
+ */
 export async function readTokenFile(dev?: boolean): Promise<CliBridgeTokenFile> {
+  // When dev is unspecified, probe both builds (prod first, then dev).
+  const candidates: boolean[] = dev === undefined ? [false, true] : [dev];
+
+  let lastError: Error | undefined;
+  for (const candidate of candidates) {
+    try {
+      return await readTokenFileFrom(candidate);
+    } catch (err) {
+      // Keep probing other locations only when this one simply isn't there.
+      if (err instanceof BridgeUnavailableError && err.notFound) {
+        lastError = err;
+        continue;
+      }
+      // A present-but-corrupt/invalid file is a real signal — surface it.
+      throw err;
+    }
+  }
+  throw lastError ?? new BridgeUnavailableError(NOT_RUNNING_HINT);
+}
+
+/** Read + validate the token file from one specific build's userData dir. */
+async function readTokenFileFrom(dev: boolean): Promise<CliBridgeTokenFile> {
   const filePath = join(getUserDataDir(dev), CLI_BRIDGE_TOKEN_DIR, CLI_BRIDGE_TOKEN_FILE);
 
   let raw: string;
@@ -31,7 +67,7 @@ export async function readTokenFile(dev?: boolean): Promise<CliBridgeTokenFile> 
     raw = await fs.readFile(filePath, "utf8");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new BridgeUnavailableError(NOT_RUNNING_HINT);
+      throw new BridgeUnavailableError(NOT_RUNNING_HINT, { notFound: true });
     }
     throw err;
   }

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -23,6 +23,12 @@ describe("parseArgs", () => {
     expect(r.options.off).toBe(true);
     expect(r.positionals).toEqual(["mcp", "enable", "abc"]);
   });
+
+  it("collects repeated flags into multiOptions while options stays last-write-wins", () => {
+    const r = parseArgs(["mcp", "add", "--arg", "a b", "--arg=c", "--arg", "d"]);
+    expect(r.multiOptions.arg).toEqual(["a b", "c", "d"]);
+    expect(r.options.arg).toBe("d");
+  });
 });
 
 describe("buildRequest - mcp", () => {
@@ -55,6 +61,76 @@ describe("buildRequest - mcp", () => {
       args: ["server.js", "--port", "3000"],
       env: { API_KEY: "abc", DEBUG: "1" },
     });
+  });
+
+  it("mcp add stdio collects repeatable --arg values verbatim, preserving spaces", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Local",
+      "--transport",
+      "stdio",
+      "--command",
+      "node",
+      "--arg",
+      "C:\\My Tools\\server.js",
+      // A value that itself begins with -- must use the equals form so the
+      // parser doesn't read it as a new flag.
+      "--arg=--config=My File.json",
+    ]);
+    expect(req.body).toMatchObject({
+      command: "node",
+      args: ["C:\\My Tools\\server.js", "--config=My File.json"],
+    });
+  });
+
+  it("mcp add stdio supports a single --arg containing spaces via the equals form", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Local",
+      "--transport",
+      "stdio",
+      "--command",
+      "node",
+      "--arg=C:\\My Tools\\server.js",
+    ]);
+    expect(req.body).toMatchObject({ args: ["C:\\My Tools\\server.js"] });
+  });
+
+  it("mcp add stdio rejects mixing --arg and --args", () => {
+    expect(() =>
+      build([
+        "mcp",
+        "add",
+        "--name",
+        "Local",
+        "--transport",
+        "stdio",
+        "--command",
+        "node",
+        "--arg",
+        "server.js",
+        "--args",
+        "server.js --port 3000",
+      ]),
+    ).toThrow(UsageError);
+  });
+
+  it("mcp add stdio omits args when neither --arg nor --args is given", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Local",
+      "--transport",
+      "stdio",
+      "--command",
+      "node",
+    ]);
+    expect(req.body).toMatchObject({ args: undefined });
   });
 
   it("mcp add http builds a POST with url + headers", () => {

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "./args";
+import { buildRequest, UsageError } from "./commands";
+
+function build(argv: string[]) {
+  return buildRequest(parseArgs(argv));
+}
+
+describe("parseArgs", () => {
+  it("splits positionals and options", () => {
+    const r = parseArgs(["mcp", "add", "--name", "Foo", "--transport", "stdio"]);
+    expect(r.positionals).toEqual(["mcp", "add"]);
+    expect(r.options).toEqual({ name: "Foo", transport: "stdio" });
+  });
+
+  it("supports --key=value", () => {
+    const r = parseArgs(["mcp", "add", "--name=Foo Bar"]);
+    expect(r.options.name).toBe("Foo Bar");
+  });
+
+  it("treats trailing/known flags as boolean", () => {
+    const r = parseArgs(["mcp", "enable", "abc", "--off"]);
+    expect(r.options.off).toBe(true);
+    expect(r.positionals).toEqual(["mcp", "enable", "abc"]);
+  });
+});
+
+describe("buildRequest - mcp", () => {
+  it("mcp list -> GET /mcp/servers", () => {
+    expect(build(["mcp", "list"])).toMatchObject({ method: "GET", path: "/mcp/servers" });
+  });
+
+  it("mcp add stdio builds a POST with command + args + env", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Local",
+      "--transport",
+      "stdio",
+      "--command",
+      "node",
+      "--args",
+      "server.js --port 3000",
+      "--env",
+      "API_KEY=abc,DEBUG=1",
+    ]);
+    expect(req.method).toBe("POST");
+    expect(req.path).toBe("/mcp/servers");
+    expect(req.body).toEqual({
+      name: "Local",
+      description: undefined,
+      transport: "stdio",
+      command: "node",
+      args: ["server.js", "--port", "3000"],
+      env: { API_KEY: "abc", DEBUG: "1" },
+    });
+  });
+
+  it("mcp add http builds a POST with url + headers", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Remote",
+      "--transport",
+      "http",
+      "--url",
+      "https://example.com/mcp",
+      "--header",
+      "Authorization=Bearer xyz",
+    ]);
+    expect(req.body).toMatchObject({
+      transport: "streamableHttp",
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer xyz" },
+    });
+  });
+
+  it("mcp add throws when required option missing", () => {
+    expect(() => build(["mcp", "add", "--transport", "stdio"])).toThrow(/Missing required --name/);
+    expect(() => build(["mcp", "add", "--name", "X", "--transport", "stdio"])).toThrow(
+      /Missing required --command/,
+    );
+  });
+
+  it("mcp add rejects unknown transport", () => {
+    expect(() => build(["mcp", "add", "--name", "X", "--transport", "carrier-pigeon"])).toThrow(
+      UsageError,
+    );
+  });
+
+  it("mcp remove <id> -> DELETE", () => {
+    expect(build(["mcp", "remove", "srv-9"])).toMatchObject({
+      method: "DELETE",
+      path: "/mcp/servers/srv-9",
+    });
+  });
+
+  it("mcp remove without id throws usage error", () => {
+    expect(() => build(["mcp", "remove"])).toThrow(UsageError);
+  });
+
+  it("mcp enable <id> -> POST enabled:true", () => {
+    expect(build(["mcp", "enable", "srv-9"])).toMatchObject({
+      method: "POST",
+      path: "/mcp/servers/srv-9/enabled",
+      body: { enabled: true },
+    });
+  });
+
+  it("mcp enable <id> --off -> POST enabled:false", () => {
+    expect(build(["mcp", "enable", "srv-9", "--off"])).toMatchObject({
+      body: { enabled: false },
+    });
+  });
+
+  it("url-encodes ids with special chars", () => {
+    expect(build(["mcp", "remove", "a/b c"]).path).toBe("/mcp/servers/a%2Fb%20c");
+  });
+});
+
+describe("buildRequest - config", () => {
+  it("config get llm -> GET /llm/config", () => {
+    expect(build(["config", "get", "llm"])).toMatchObject({ method: "GET", path: "/llm/config" });
+  });
+
+  it("config get defaults to settings", () => {
+    expect(build(["config", "get"])).toMatchObject({ method: "GET", path: "/settings" });
+  });
+
+  it("config set settings builds a PATCH patch", () => {
+    const req = build([
+      "config",
+      "set",
+      "settings",
+      "--tool-approval-mode",
+      "yolo",
+      "--open-at-login",
+      "true",
+    ]);
+    expect(req.method).toBe("PATCH");
+    expect(req.path).toBe("/settings");
+    expect(req.body).toEqual({ toolApprovalMode: "yolo", openAtLogin: true });
+  });
+
+  it("config set settings with no fields throws usage error", () => {
+    expect(() => build(["config", "set", "settings"])).toThrow(UsageError);
+  });
+
+  it("config set llm is unsupported", () => {
+    expect(() => build(["config", "set", "llm"])).toThrow(/not supported/);
+  });
+});
+
+describe("buildRequest - errors", () => {
+  it("unknown top-level command throws UsageError", () => {
+    expect(() => build(["frobnicate"])).toThrow(UsageError);
+  });
+  it("unknown mcp subcommand throws UsageError", () => {
+    expect(() => build(["mcp", "wat"])).toThrow(UsageError);
+  });
+});

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -75,13 +75,38 @@ describe("buildRequest - mcp", () => {
       "node",
       "--arg",
       "C:\\My Tools\\server.js",
-      // A value that itself begins with -- must use the equals form so the
-      // parser doesn't read it as a new flag.
-      "--arg=--config=My File.json",
+      // A value that itself begins with -- is taken verbatim, no equals form needed.
+      "--arg",
+      "--config",
+      "--arg",
+      "My File.json",
     ]);
     expect(req.body).toMatchObject({
       command: "node",
-      args: ["C:\\My Tools\\server.js", "--config=My File.json"],
+      args: ["C:\\My Tools\\server.js", "--config", "My File.json"],
+    });
+  });
+
+  it("mcp add stdio passes a flag-shaped --arg value through verbatim (no silent drop)", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Local",
+      "--transport",
+      "stdio",
+      "--command",
+      "node",
+      "--arg",
+      "server.js",
+      "--arg",
+      "--port",
+      "--arg",
+      "3000",
+    ]);
+    expect(req.body).toMatchObject({
+      command: "node",
+      args: ["server.js", "--port", "3000"],
     });
   });
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,167 @@
+import { optionalString, type ParsedArgs, parseKeyValueList, requireString } from "./args";
+
+/** A resolved request the CLI should issue against the bridge. */
+export interface CommandRequest {
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  path: string;
+  body?: unknown;
+  /** Short human label used when pretty-printing the result. */
+  label: string;
+}
+
+/**
+ * Translate parsed CLI args into a bridge request.
+ *
+ * Pure and side-effect free (no fetch, no fs) so the routing/validation logic is
+ * unit-testable in isolation. Throws on bad usage with a clear message.
+ */
+export function buildRequest(parsed: ParsedArgs): CommandRequest {
+  const [group, action, ...rest] = parsed.positionals;
+  const { options } = parsed;
+
+  if (group === "mcp") {
+    return buildMcpRequest(action, rest, options);
+  }
+  if (group === "config") {
+    return buildConfigRequest(action, rest, options);
+  }
+
+  throw new UsageError(`Unknown command: ${[group, action].filter(Boolean).join(" ")}`);
+}
+
+function buildMcpRequest(
+  action: string | undefined,
+  rest: string[],
+  options: Record<string, string | boolean>,
+): CommandRequest {
+  switch (action) {
+    case "list":
+      return { method: "GET", path: "/mcp/servers", label: "MCP servers" };
+
+    case "add": {
+      const transport = requireString(options, "transport");
+      if (transport !== "stdio" && transport !== "streamableHttp" && transport !== "http") {
+        throw new UsageError(`--transport must be one of: stdio, http (streamableHttp)`);
+      }
+      const name = requireString(options, "name");
+      const description = optionalString(options, "description");
+
+      if (transport === "stdio") {
+        const command = requireString(options, "command");
+        const argsValue = optionalString(options, "args");
+        const body = {
+          name,
+          description,
+          transport: "stdio" as const,
+          command,
+          args: argsValue ? argsValue.split(" ").filter(Boolean) : undefined,
+          env: parseKeyValueList(optionalString(options, "env")),
+        };
+        return { method: "POST", path: "/mcp/servers", body, label: "Added MCP server" };
+      }
+
+      // http / streamableHttp
+      const url = requireString(options, "url");
+      const body = {
+        name,
+        description,
+        transport: "streamableHttp" as const,
+        url,
+        headers: parseKeyValueList(optionalString(options, "header")),
+      };
+      return { method: "POST", path: "/mcp/servers", body, label: "Added MCP server" };
+    }
+
+    case "remove": {
+      const id = rest[0];
+      if (!id) throw new UsageError("Usage: yakshaver mcp remove <id>");
+      return {
+        method: "DELETE",
+        path: `/mcp/servers/${encodeURIComponent(id)}`,
+        label: "Removed MCP server",
+      };
+    }
+
+    case "enable": {
+      const id = rest[0];
+      if (!id) throw new UsageError("Usage: yakshaver mcp enable <id> [--off]");
+      const enabled = options.off !== true;
+      return {
+        method: "POST",
+        path: `/mcp/servers/${encodeURIComponent(id)}/enabled`,
+        body: { enabled },
+        label: enabled ? "Enabled MCP server" : "Disabled MCP server",
+      };
+    }
+
+    default:
+      throw new UsageError(`Unknown mcp subcommand: ${action ?? "(none)"}`);
+  }
+}
+
+function buildConfigRequest(
+  action: string | undefined,
+  rest: string[],
+  options: Record<string, string | boolean>,
+): CommandRequest {
+  const target = rest[0] ?? "settings"; // default to settings
+
+  if (action === "get") {
+    if (target === "llm") {
+      return { method: "GET", path: "/llm/config", label: "LLM config" };
+    }
+    if (target === "settings") {
+      return { method: "GET", path: "/settings", label: "User settings" };
+    }
+    throw new UsageError("Usage: yakshaver config get [llm|settings]");
+  }
+
+  if (action === "set") {
+    if (target === "settings") {
+      const body = buildSettingsPatch(options);
+      return { method: "PATCH", path: "/settings", body, label: "Updated settings" };
+    }
+    if (target === "llm") {
+      throw new UsageError(
+        "Setting the full LLM config via the CLI is not supported (it requires secrets). " +
+          "Configure providers in the app UI.",
+      );
+    }
+    throw new UsageError("Usage: yakshaver config set settings --<key> <value>");
+  }
+
+  throw new UsageError(`Unknown config subcommand: ${action ?? "(none)"}`);
+}
+
+function buildSettingsPatch(options: Record<string, string | boolean>): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+
+  const toolApprovalMode = optionalString(options, "tool-approval-mode");
+  if (toolApprovalMode !== undefined) {
+    patch.toolApprovalMode = toolApprovalMode;
+  }
+
+  if (options["open-at-login"] !== undefined) {
+    patch.openAtLogin = coerceBoolean(options["open-at-login"]);
+  }
+
+  if (Object.keys(patch).length === 0) {
+    throw new UsageError(
+      "No settings provided. Try --tool-approval-mode <yolo|wait|ask> or --open-at-login <true|false>",
+    );
+  }
+  return patch;
+}
+
+function coerceBoolean(value: string | boolean): boolean {
+  if (typeof value === "boolean") return value;
+  return value === "true" || value === "1" || value === "yes";
+}
+
+/** A usage/validation error (distinct from runtime/bridge errors). */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,4 +1,10 @@
-import { optionalString, type ParsedArgs, parseKeyValueList, requireString } from "./args";
+import {
+  optionalString,
+  optionalStringArray,
+  type ParsedArgs,
+  parseKeyValueList,
+  requireString,
+} from "./args";
 
 /** A resolved request the CLI should issue against the bridge. */
 export interface CommandRequest {
@@ -20,7 +26,7 @@ export function buildRequest(parsed: ParsedArgs): CommandRequest {
   const { options } = parsed;
 
   if (group === "mcp") {
-    return buildMcpRequest(action, rest, options);
+    return buildMcpRequest(action, rest, options, parsed.multiOptions);
   }
   if (group === "config") {
     return buildConfigRequest(action, rest, options);
@@ -33,6 +39,7 @@ function buildMcpRequest(
   action: string | undefined,
   rest: string[],
   options: Record<string, string | boolean>,
+  multiOptions: Record<string, string[]>,
 ): CommandRequest {
   switch (action) {
     case "list":
@@ -48,13 +55,12 @@ function buildMcpRequest(
 
       if (transport === "stdio") {
         const command = requireString(options, "command");
-        const argsValue = optionalString(options, "args");
         const body = {
           name,
           description,
           transport: "stdio" as const,
           command,
-          args: argsValue ? argsValue.split(" ").filter(Boolean) : undefined,
+          args: parseStdioArgs(options, multiOptions),
           env: parseKeyValueList(optionalString(options, "env")),
         };
         return { method: "POST", path: "/mcp/servers", body, label: "Added MCP server" };
@@ -97,6 +103,42 @@ function buildMcpRequest(
     default:
       throw new UsageError(`Unknown mcp subcommand: ${action ?? "(none)"}`);
   }
+}
+
+/**
+ * Resolve the stdio launch argv for `mcp add`.
+ *
+ * `--arg` is the primary, robust mechanism: it is repeatable and each value is
+ * taken verbatim, so a single argument may contain spaces (a Windows path like
+ * `--arg "C:\My Tools\server.js"`, or `--arg "--config=My File.json"`). The
+ * legacy `--args "a b c"` form is kept only as a convenience for the trivial,
+ * space-free case — it splits on spaces and therefore CANNOT express an
+ * individual argument that contains a space. The two are mutually exclusive to
+ * avoid silently merging an ambiguous mix.
+ */
+function parseStdioArgs(
+  options: Record<string, string | boolean>,
+  multiOptions: Record<string, string[]>,
+): string[] | undefined {
+  const repeatable = optionalStringArray(multiOptions, "arg");
+  const joined = optionalString(options, "args");
+
+  if (repeatable && joined !== undefined) {
+    throw new UsageError(
+      "Use either --arg (repeatable, supports spaces) or --args (space-separated), not both",
+    );
+  }
+
+  if (repeatable) {
+    return repeatable;
+  }
+
+  if (joined !== undefined) {
+    const split = joined.split(" ").filter(Boolean);
+    return split.length > 0 ? split : undefined;
+  }
+
+  return undefined;
 }
 
 function buildConfigRequest(

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -110,7 +110,8 @@ function buildMcpRequest(
  *
  * `--arg` is the primary, robust mechanism: it is repeatable and each value is
  * taken verbatim, so a single argument may contain spaces (a Windows path like
- * `--arg "C:\My Tools\server.js"`, or `--arg "--config=My File.json"`). The
+ * `--arg "C:\My Tools\server.js"`) and may itself begin with `--` (a flag-shaped
+ * argument such as `--arg --port --arg 3000`). The
  * legacy `--args "a b c"` form is kept only as a convenience for the trivial,
  * space-free case — it splits on spaces and therefore CANNOT express an
  * individual argument that contains a space. The two are mutually exclusive to

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { parseArgs } from "./args";
+import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
+import { buildRequest, type CommandRequest, UsageError } from "./commands";
+
+const HELP = `yakshaver — configure YakShaver Desktop from the terminal
+
+USAGE
+  yakshaver <command> [options]
+
+The desktop app must be running; the CLI talks to it over a localhost-only,
+token-authenticated bridge.
+
+MCP
+  yakshaver mcp list
+  yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b"] [--env "K=V,K2=V2"]
+  yakshaver mcp add --name <name> --transport http  --url <url> [--header "K=V"]
+  yakshaver mcp remove <id>
+  yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
+
+CONFIG
+  yakshaver config get [llm|settings]      # defaults to settings
+  yakshaver config set settings --tool-approval-mode <yolo|wait|ask>
+  yakshaver config set settings --open-at-login <true|false>
+
+GLOBAL
+  --dev      Target the dev build (YakShaverDev) userData
+  --json     Print raw JSON instead of pretty output
+  -h, --help Show this help
+
+Secrets (api keys, header/env values) are always redacted in output.`;
+
+async function main(argv: string[]): Promise<number> {
+  const parsed = parseArgs(argv);
+
+  if (parsed.options.help || parsed.positionals.length === 0) {
+    console.log(HELP);
+    return parsed.positionals.length === 0 && !parsed.options.help ? 1 : 0;
+  }
+
+  let request: CommandRequest;
+  try {
+    request = buildRequest(parsed);
+  } catch (err) {
+    if (err instanceof UsageError) {
+      console.error(`Error: ${err.message}\n`);
+      console.error(HELP);
+      return 2;
+    }
+    throw err;
+  }
+
+  const client = new BridgeClient({ dev: parsed.options.dev === true });
+
+  try {
+    const data = await client.request(request.method, request.path, request.body);
+    printResult(request.label, data, parsed.options.json === true);
+    return 0;
+  } catch (err) {
+    if (err instanceof BridgeUnavailableError) {
+      console.error(err.message);
+      return 3;
+    }
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+function printResult(label: string, data: unknown, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  // Pretty-print MCP server lists as a compact table-ish summary.
+  if (Array.isArray(data)) {
+    console.log(`${label} (${data.length}):`);
+    for (const item of data) {
+      printServerLine(item);
+    }
+    return;
+  }
+
+  if (label.startsWith("Added") || label.startsWith("Removed") || label.includes("MCP server")) {
+    console.log(`${label}:`);
+    printServerLine(data);
+    return;
+  }
+
+  console.log(`${label}:`);
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function printServerLine(item: unknown): void {
+  if (!item || typeof item !== "object") {
+    console.log(`  ${JSON.stringify(item)}`);
+    return;
+  }
+  const s = item as Record<string, unknown>;
+  const enabled = s.enabled === false ? "disabled" : "enabled";
+  const target = s.url ?? s.command ?? "";
+  const builtin = s.builtin ? " [builtin]" : "";
+  console.log(
+    `  - ${String(s.name ?? "(unnamed)")} [${String(s.transport ?? "?")}] (${enabled})${builtin}` +
+      `\n      id: ${String(s.id ?? "?")}` +
+      (target ? `\n      ${s.url ? "url" : "command"}: ${String(target)}` : ""),
+  );
+}
+
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    console.error(`Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,10 +14,16 @@ token-authenticated bridge.
 
 MCP
   yakshaver mcp list
-  yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b"] [--env "K=V,K2=V2"]
+  yakshaver mcp add --name <name> --transport stdio --command <cmd> [--arg <a> --arg <b> ...] [--env "K=V,K2=V2"]
   yakshaver mcp add --name <name> --transport http  --url <url> [--header "K=V"]
   yakshaver mcp remove <id>
   yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
+
+  Use --arg (repeatable) for each launch argument; values may contain spaces,
+  e.g. --arg "C:\\My Tools\\server.js". A value that itself begins with -- must
+  use the equals form, e.g. --arg=--config="My File.json". The legacy
+  --args "a b c" splits on spaces and cannot express an argument that itself
+  contains a space.
 
 CONFIG
   yakshaver config get [llm|settings]      # defaults to settings

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from "./args";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
 import { buildRequest, type CommandRequest, UsageError } from "./commands";
+import { printResult } from "./print";
 
 const HELP = `yakshaver — configure YakShaver Desktop from the terminal
 
@@ -64,47 +65,6 @@ async function main(argv: string[]): Promise<number> {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
   }
-}
-
-function printResult(label: string, data: unknown, asJson: boolean): void {
-  if (asJson) {
-    console.log(JSON.stringify(data, null, 2));
-    return;
-  }
-
-  // Pretty-print MCP server lists as a compact table-ish summary.
-  if (Array.isArray(data)) {
-    console.log(`${label} (${data.length}):`);
-    for (const item of data) {
-      printServerLine(item);
-    }
-    return;
-  }
-
-  if (label.startsWith("Added") || label.startsWith("Removed") || label.includes("MCP server")) {
-    console.log(`${label}:`);
-    printServerLine(data);
-    return;
-  }
-
-  console.log(`${label}:`);
-  console.log(JSON.stringify(data, null, 2));
-}
-
-function printServerLine(item: unknown): void {
-  if (!item || typeof item !== "object") {
-    console.log(`  ${JSON.stringify(item)}`);
-    return;
-  }
-  const s = item as Record<string, unknown>;
-  const enabled = s.enabled === false ? "disabled" : "enabled";
-  const target = s.url ?? s.command ?? "";
-  const builtin = s.builtin ? " [builtin]" : "";
-  console.log(
-    `  - ${String(s.name ?? "(unnamed)")} [${String(s.transport ?? "?")}] (${enabled})${builtin}` +
-      `\n      id: ${String(s.id ?? "?")}` +
-      (target ? `\n      ${s.url ? "url" : "command"}: ${String(target)}` : ""),
-  );
 }
 
 main(process.argv.slice(2))

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { parseArgs } from "./args";
+import { ArgParseError, parseArgs } from "./args";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
 import { buildRequest, type CommandRequest, UsageError } from "./commands";
 import { printResult } from "./print";
@@ -19,11 +19,10 @@ MCP
   yakshaver mcp remove <id>
   yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
 
-  Use --arg (repeatable) for each launch argument; values may contain spaces,
-  e.g. --arg "C:\\My Tools\\server.js". A value that itself begins with -- must
-  use the equals form, e.g. --arg=--config="My File.json". The legacy
-  --args "a b c" splits on spaces and cannot express an argument that itself
-  contains a space.
+  Use --arg (repeatable) for each launch argument; each value is taken verbatim,
+  so it may contain spaces, e.g. --arg "C:\\My Tools\\server.js", and it may even
+  begin with -- (e.g. --arg --port --arg 3000). The legacy --args "a b c" splits
+  on spaces and cannot express an argument that itself contains a space.
 
 CONFIG
   yakshaver config get [llm|settings]      # defaults to settings
@@ -38,7 +37,17 @@ GLOBAL
 Secrets (api keys, header/env values) are always redacted in output.`;
 
 async function main(argv: string[]): Promise<number> {
-  const parsed = parseArgs(argv);
+  let parsed: ReturnType<typeof parseArgs>;
+  try {
+    parsed = parseArgs(argv);
+  } catch (err) {
+    if (err instanceof ArgParseError) {
+      console.error(`Error: ${err.message}\n`);
+      console.error(HELP);
+      return 2;
+    }
+    throw err;
+  }
 
   if (parsed.options.help || parsed.positionals.length === 0) {
     console.log(HELP);
@@ -57,7 +66,9 @@ async function main(argv: string[]): Promise<number> {
     throw err;
   }
 
-  const client = new BridgeClient({ dev: parsed.options.dev === true });
+  // `--dev` forces the dev (YakShaverDev) build; without it we leave `dev`
+  // unset so the client auto-detects by trying both prod and dev token files.
+  const client = new BridgeClient({ dev: parsed.options.dev === true ? true : undefined });
 
   try {
     const data = await client.request(request.method, request.path, request.body);

--- a/src/cli/print.test.ts
+++ b/src/cli/print.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { printResult, printServerLine } from "./print";
+
+describe("printResult", () => {
+  let logs: string[];
+
+  beforeEach(() => {
+    logs = [];
+    vi.spyOn(console, "log").mockImplementation((msg?: unknown) => {
+      logs.push(String(msg));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints the removed id, not a misleading (unnamed) server line", () => {
+    // The DELETE endpoint returns a bare { id, removed: true } envelope.
+    printResult("Removed MCP server", { id: "http-1", removed: true }, false);
+    const out = logs.join("\n");
+    expect(out).toBe("Removed MCP server: http-1");
+    // Regression guard: must NOT render the phantom-server line.
+    expect(out).not.toContain("(unnamed)");
+    expect(out).not.toContain("[?]");
+    expect(out).not.toContain("(enabled)");
+  });
+
+  it("still pretty-prints a real server object on add", () => {
+    printResult(
+      "Added MCP server",
+      { id: "srv-1", name: "My Server", transport: "stdio", command: "node", enabled: true },
+      false,
+    );
+    const out = logs.join("\n");
+    expect(out).toContain("Added MCP server:");
+    expect(out).toContain("- My Server [stdio] (enabled)");
+    expect(out).toContain("id: srv-1");
+  });
+
+  it("emits raw JSON when asJson is true", () => {
+    printResult("Removed MCP server", { id: "http-1", removed: true }, true);
+    expect(JSON.parse(logs.join("\n"))).toEqual({ id: "http-1", removed: true });
+  });
+});
+
+describe("printServerLine", () => {
+  let logs: string[];
+
+  beforeEach(() => {
+    logs = [];
+    vi.spyOn(console, "log").mockImplementation((msg?: unknown) => {
+      logs.push(String(msg));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("marks disabled and built-in servers", () => {
+    printServerLine({
+      id: "b",
+      name: "Built In",
+      transport: "inMemory",
+      enabled: false,
+      builtin: true,
+    });
+    const out = logs.join("\n");
+    expect(out).toContain("- Built In [inMemory] (disabled) [builtin]");
+  });
+});

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -1,0 +1,55 @@
+/**
+ * Human-readable rendering of bridge responses for the `yakshaver` CLI.
+ * Extracted from index.ts so it can be unit-tested without executing main().
+ */
+
+export function printResult(label: string, data: unknown, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  // Pretty-print MCP server lists as a compact table-ish summary.
+  if (Array.isArray(data)) {
+    console.log(`${label} (${data.length}):`);
+    for (const item of data) {
+      printServerLine(item);
+    }
+    return;
+  }
+
+  // Removal responses are a bare { id, removed: true } envelope, not a server
+  // object — routing them through printServerLine would render a misleading
+  // "(unnamed) [?] (enabled)" line implying the server still exists. Print just
+  // the id instead.
+  if (data && typeof data === "object" && (data as Record<string, unknown>).removed === true) {
+    const id = (data as Record<string, unknown>).id;
+    console.log(`${label}: ${id !== undefined ? String(id) : ""}`.trimEnd());
+    return;
+  }
+
+  if (label.startsWith("Added") || label.startsWith("Removed") || label.includes("MCP server")) {
+    console.log(`${label}:`);
+    printServerLine(data);
+    return;
+  }
+
+  console.log(`${label}:`);
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export function printServerLine(item: unknown): void {
+  if (!item || typeof item !== "object") {
+    console.log(`  ${JSON.stringify(item)}`);
+    return;
+  }
+  const s = item as Record<string, unknown>;
+  const enabled = s.enabled === false ? "disabled" : "enabled";
+  const target = s.url ?? s.command ?? "";
+  const builtin = s.builtin ? " [builtin]" : "";
+  console.log(
+    `  - ${String(s.name ?? "(unnamed)")} [${String(s.transport ?? "?")}] (${enabled})${builtin}` +
+      `\n      id: ${String(s.id ?? "?")}` +
+      (target ? `\n      ${s.url ? "url" : "command"}: ${String(target)}` : ""),
+  );
+}

--- a/src/cli/read-token-file.test.ts
+++ b/src/cli/read-token-file.test.ts
@@ -1,0 +1,87 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CLI_BRIDGE_TOKEN_DIR,
+  CLI_BRIDGE_TOKEN_FILE,
+  type CliBridgeTokenFile,
+} from "../shared/cli-bridge/protocol";
+
+/**
+ * Exercises readTokenFile's dual-location fallback. The app and CLI detect "dev"
+ * differently, so when the caller does NOT pin a build (dev unspecified) the CLI
+ * must locate the token whether the app wrote it to the prod or the dev folder.
+ *
+ * We point getUserDataDir at a throwaway temp root by mocking user-data-path,
+ * then place the token in one build's folder and assert it is found without
+ * specifying `dev`.
+ */
+
+const root = join(tmpdir(), `yakshaver-token-fallback-${process.pid}`);
+
+vi.mock("./user-data-path", () => ({
+  getUserDataDir: (dev = false) => join(root, dev ? "YakShaverDev" : "YakShaver"),
+}));
+
+import { BridgeUnavailableError, readTokenFile } from "./bridge-client";
+
+const tokenFor = (port: number): CliBridgeTokenFile => ({
+  port,
+  token: "a".repeat(64),
+  startedAt: new Date().toISOString(),
+});
+
+async function writeToken(appName: "YakShaver" | "YakShaverDev", port: number): Promise<void> {
+  const dir = join(root, appName, CLI_BRIDGE_TOKEN_DIR);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(join(dir, CLI_BRIDGE_TOKEN_FILE), JSON.stringify(tokenFor(port)));
+}
+
+describe("readTokenFile dual-location fallback", () => {
+  beforeEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("finds a prod token when dev is unspecified", async () => {
+    await writeToken("YakShaver", 1111);
+    const t = await readTokenFile();
+    expect(t.port).toBe(1111);
+  });
+
+  it("falls back to the dev token when only the dev app is running", async () => {
+    await writeToken("YakShaverDev", 2222);
+    const t = await readTokenFile(); // no --dev, but the dev app wrote the token
+    expect(t.port).toBe(2222);
+  });
+
+  it("prefers prod when both exist and dev is unspecified", async () => {
+    await writeToken("YakShaver", 1111);
+    await writeToken("YakShaverDev", 2222);
+    const t = await readTokenFile();
+    expect(t.port).toBe(1111);
+  });
+
+  it("pins to the dev location when dev:true is explicit", async () => {
+    await writeToken("YakShaver", 1111);
+    await writeToken("YakShaverDev", 2222);
+    const t = await readTokenFile(true);
+    expect(t.port).toBe(2222);
+  });
+
+  it("throws BridgeUnavailableError when neither location has a token", async () => {
+    await expect(readTokenFile()).rejects.toBeInstanceOf(BridgeUnavailableError);
+  });
+
+  it("does not silently fall back past a corrupt prod token file", async () => {
+    const dir = join(root, "YakShaver", CLI_BRIDGE_TOKEN_DIR);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(join(dir, CLI_BRIDGE_TOKEN_FILE), "{ not json");
+    await writeToken("YakShaverDev", 2222);
+    // A present-but-corrupt prod file is a real signal, not "absent" — surface it.
+    await expect(readTokenFile()).rejects.toThrow(/corrupt/);
+  });
+});

--- a/src/cli/user-data-path.ts
+++ b/src/cli/user-data-path.ts
@@ -1,0 +1,41 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Replicate Electron's `app.getPath('userData')` for a plain Node process.
+ *
+ * The desktop app stores config under `<appData>/YakShaver` (or
+ * `<appData>/YakShaverDev` in development — see src/backend/index.ts). The CLI
+ * is NOT Electron, so we recompute the per-OS appData location here.
+ *
+ * Electron's appData maps to:
+ *   - Windows: %APPDATA%            (C:\Users\<user>\AppData\Roaming)
+ *   - macOS:   ~/Library/Application Support
+ *   - Linux:   $XDG_CONFIG_HOME or ~/.config
+ *
+ * The userData folder name is the Electron app name ("YakShaver"), overridden to
+ * "YakShaverDev" when running against a dev build.
+ */
+export function getAppDataDir(): string {
+  if (process.platform === "win32") {
+    return process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+  }
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Application Support");
+  }
+  return process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+}
+
+/** Resolve the YakShaver userData directory. Pass `dev: true` for a dev build. */
+export function getUserDataDir(dev = isDevEnv()): string {
+  const appName = dev ? "YakShaverDev" : "YakShaver";
+  return join(getAppDataDir(), appName);
+}
+
+/**
+ * Whether to target the dev build's userData. Controlled by the
+ * YAKSHAVER_ENV=development env var or a `--dev` flag handled by the caller.
+ */
+export function isDevEnv(): boolean {
+  return process.env.YAKSHAVER_ENV === "development" || process.env.NODE_ENV === "development";
+}

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -11,7 +11,15 @@ import { z } from "zod";
 /** Name of the token file written under `userData/yakshaver-tokens/`. */
 export const CLI_BRIDGE_TOKEN_FILE = "cli-bridge.json";
 
-/** Directory (relative to userData) where secure tokens live. */
+/**
+ * Directory (relative to userData) the handshake file is written to. It shares
+ * the `yakshaver-tokens` folder with the safeStorage-encrypted `*.enc`
+ * credentials, but unlike those the bridge handshake file is PLAINTEXT JSON: the
+ * non-Electron CLI cannot decrypt safeStorage, so it must be able to read the
+ * port + bearer token directly. The bridge binds to localhost only and the file
+ * is written owner-only (mode 0o600, a no-op on Windows). See AGENTS.md →
+ * "Security & Privacy" for the documented exception to the encrypt-all rule.
+ */
 export const CLI_BRIDGE_TOKEN_DIR = "yakshaver-tokens";
 
 /** Host the bridge binds to. Localhost ONLY — never expose to the network. */
@@ -64,7 +72,7 @@ const baseFields = {
 export const HttpServerInputSchema = z.object({
   ...baseFields,
   transport: z.literal("streamableHttp"),
-  url: z.string().url("url must be a valid URL"),
+  url: z.url("url must be a valid URL"),
   headers: stringRecord.optional(),
   version: z.string().optional(),
   timeoutMs: z.number().int().positive().optional(),

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+
+/**
+ * Shared protocol definitions for the YakShaver CLI bridge.
+ *
+ * The bridge is a localhost-only HTTP server started by the desktop app's main
+ * process. The `yakshaver` CLI talks to it. Both sides import the constants and
+ * Zod schemas here so the wire format stays in lockstep.
+ */
+
+/** Name of the token file written under `userData/yakshaver-tokens/`. */
+export const CLI_BRIDGE_TOKEN_FILE = "cli-bridge.json";
+
+/** Directory (relative to userData) where secure tokens live. */
+export const CLI_BRIDGE_TOKEN_DIR = "yakshaver-tokens";
+
+/** Host the bridge binds to. Localhost ONLY — never expose to the network. */
+export const CLI_BRIDGE_HOST = "127.0.0.1";
+
+/** Default port the bridge attempts to bind. May fall back to an ephemeral port. */
+export const CLI_BRIDGE_DEFAULT_PORT = 8765;
+
+/** Env var that, when truthy, disables the bridge entirely. */
+export const CLI_BRIDGE_DISABLE_ENV = "YAKSHAVER_DISABLE_CLI_BRIDGE";
+
+/** Placeholder shown instead of any secret value. */
+export const REDACTED = "***redacted***";
+
+/** Shape of the token file the app writes and the CLI reads. */
+export interface CliBridgeTokenFile {
+  port: number;
+  token: string;
+  /** ISO timestamp the bridge last (re)started. Informational only. */
+  startedAt: string;
+  /** App version, for diagnostics. */
+  version?: string;
+}
+
+export const CliBridgeTokenFileSchema = z.object({
+  port: z.number().int().positive(),
+  token: z.string().min(1),
+  startedAt: z.string(),
+  version: z.string().optional(),
+});
+
+/** Envelope every endpoint returns. */
+export type BridgeResponse<T = unknown> = { ok: true; data: T } | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// MCP server payload schemas (subset of MCPServerConfig the CLI can set).
+// Mirrors the validation the MCPServerManager performs internally, but lets us
+// reject bad input early at the bridge boundary.
+// ---------------------------------------------------------------------------
+
+const stringRecord = z.record(z.string(), z.string());
+
+const baseFields = {
+  name: z.string().min(1, "name is required"),
+  description: z.string().optional(),
+  enabled: z.boolean().optional(),
+  toolWhitelist: z.array(z.string()).optional(),
+};
+
+export const HttpServerInputSchema = z.object({
+  ...baseFields,
+  transport: z.literal("streamableHttp"),
+  url: z.string().url("url must be a valid URL"),
+  headers: stringRecord.optional(),
+  version: z.string().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+});
+
+export const StdioServerInputSchema = z.object({
+  ...baseFields,
+  transport: z.literal("stdio"),
+  command: z.string().min(1, "command is required"),
+  args: z.array(z.string()).optional(),
+  env: stringRecord.optional(),
+  cwd: z.string().optional(),
+  stderr: z.enum(["inherit", "ignore", "pipe"]).optional(),
+});
+
+/** Input accepted by POST /mcp/servers and PUT /mcp/servers/:id. */
+export const McpServerInputSchema = z.discriminatedUnion("transport", [
+  HttpServerInputSchema,
+  StdioServerInputSchema,
+]);
+export type McpServerInput = z.infer<typeof McpServerInputSchema>;
+
+/** Input accepted by POST /mcp/servers/:id/enabled. */
+export const McpEnabledInputSchema = z.object({
+  enabled: z.boolean(),
+});
+
+/**
+ * Keys on an MCP server config considered secret. Redacted in any response.
+ * `headers` and `env` often carry tokens/api keys so we redact their values.
+ */
+export const MCP_SECRET_KEYS = ["headers", "env"] as const;

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -100,6 +100,35 @@ export const McpEnabledInputSchema = z.object({
   enabled: z.boolean(),
 });
 
+// LLM config payload (V2). Mirrors LLMConfigV2 so POST /llm/config validates at
+// the boundary instead of trusting an `as` cast, like the MCP/settings routes.
+const ModelConfigInputSchema = z.discriminatedUnion("provider", [
+  z.object({
+    provider: z.literal("openai"),
+    model: z.string().nullable(),
+    apiKey: z.string(),
+  }),
+  z.object({
+    provider: z.literal("deepseek"),
+    model: z.string().nullable(),
+    apiKey: z.string(),
+  }),
+  z.object({
+    provider: z.literal("azure"),
+    model: z.string().nullable(),
+    apiKey: z.string(),
+    resourceName: z.string(),
+  }),
+]);
+
+/** Input accepted by POST /llm/config. */
+export const LlmConfigInputSchema = z.object({
+  version: z.literal(2),
+  languageModel: ModelConfigInputSchema.nullable(),
+  transcriptionModel: ModelConfigInputSchema.nullable(),
+  providerApiKeys: z.record(z.string(), z.string()).optional(),
+});
+
 /**
  * Keys on an MCP server config considered secret. Redacted in any response.
  * `headers` and `env` often carry tokens/api keys so we redact their values.

--- a/src/shared/cli-bridge/redact.ts
+++ b/src/shared/cli-bridge/redact.ts
@@ -1,0 +1,69 @@
+import type { MCPServerConfig } from "../types/mcp";
+import { REDACTED } from "./protocol";
+
+/**
+ * Redaction helpers shared by the bridge (so secrets never leave the app) and
+ * importable by the CLI/tests. We never echo full secret values back over the
+ * wire — api keys, bearer tokens, and arbitrary header/env values are masked.
+ */
+
+function redactStringMap(
+  map: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!map) return map;
+  const out: Record<string, string> = {};
+  for (const key of Object.keys(map)) {
+    out[key] = REDACTED;
+  }
+  return out;
+}
+
+/** Redact secret-bearing fields on a single MCP server config. */
+export function redactMcpServer(server: MCPServerConfig): MCPServerConfig {
+  const clone = { ...(server as unknown as Record<string, unknown>) };
+
+  if ("headers" in clone) {
+    clone.headers = redactStringMap(clone.headers as Record<string, string> | undefined);
+  }
+  if ("env" in clone) {
+    clone.env = redactStringMap(clone.env as Record<string, string> | undefined);
+  }
+
+  return clone as unknown as MCPServerConfig;
+}
+
+/** Redact a list of MCP server configs. */
+export function redactMcpServers(servers: MCPServerConfig[]): MCPServerConfig[] {
+  return servers.map(redactMcpServer);
+}
+
+/**
+ * Redact an LLM config (V2 shape). Replaces every `apiKey` with the placeholder
+ * but keeps `hasApiKey` booleans so callers can tell whether a key is set.
+ */
+export function redactLlmConfig(config: unknown): unknown {
+  if (!config || typeof config !== "object") return config;
+
+  const redactModel = (model: unknown): unknown => {
+    if (!model || typeof model !== "object") return model;
+    const m = model as Record<string, unknown>;
+    const hasApiKey = typeof m.apiKey === "string" && m.apiKey.length > 0;
+    return { ...m, apiKey: hasApiKey ? REDACTED : m.apiKey, hasApiKey };
+  };
+
+  const c = config as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...c };
+
+  if ("languageModel" in c) out.languageModel = redactModel(c.languageModel);
+  if ("transcriptionModel" in c) out.transcriptionModel = redactModel(c.transcriptionModel);
+
+  if (c.providerApiKeys && typeof c.providerApiKeys === "object") {
+    const masked: Record<string, string> = {};
+    for (const key of Object.keys(c.providerApiKeys as Record<string, unknown>)) {
+      masked[key] = REDACTED;
+    }
+    out.providerApiKeys = masked;
+  }
+
+  return out;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/backend/**/*", "src/shared/**/*"],
+  "include": ["src/backend/**/*", "src/shared/**/*", "src/cli/**/*"],
   "exclude": ["node_modules", "dist", "src/ui"]
 }


### PR DESCRIPTION
Closes #909.

Phase 2 of the YakShaver CLI work: a `yakshaver` terminal CLI plus a localhost config HTTP bridge so MCP servers and app settings can be configured from the command line. Scope is intentionally limited to Phase 2 — no Claude Code skill (Phase 3) and no orchestration-mode changes (#908).

## The bridge — security model
A small Node `http` server (`src/backend/services/cli-bridge/cli-bridge-server.ts`) started in the main-process `app.whenReady` chain and stopped cleanly on quit.

- **Localhost only.** Binds to `127.0.0.1` (never `0.0.0.0`), so it is unreachable off-box.
- **Token auth.** A random 256-bit token + the chosen port are written at startup to `userData/yakshaver-tokens/cli-bridge.json` (same-user readable, `mode 0o600`). Every request must send `Authorization: Bearer <token>`; otherwise → `401`. Token comparison is timing-safe.
- **Port.** Tries fixed `8765`, falls back to an OS-assigned ephemeral port (always recorded in the token file).
- **No duplicated logic.** Endpoints call the SAME services the IPC handlers use: `MCPServerManager`, `LlmStorage`, `UserSettingsStorage`.
- **Validation + redaction.** Inputs validated with shared Zod schemas (settings reuse `PartialUserSettingsSchema`). Secrets — `apiKey`, header values, env values — are redacted (`***redacted***`) in every response; `hasApiKey` booleans are surfaced instead.
- **Opt-out.** Set `YAKSHAVER_DISABLE_CLI_BRIDGE` to disable. Failures are best-effort and never block app startup. Body size capped at 256 KB.

### Endpoints (envelope: `{ ok, data }` / `{ ok: false, error }`)
| Method | Path | Action |
| --- | --- | --- |
| GET | `/mcp/servers` | list (redacted) |
| POST | `/mcp/servers` | add |
| PUT | `/mcp/servers/:id` | update (merges with existing) |
| DELETE | `/mcp/servers/:id` | remove |
| POST | `/mcp/servers/:id/enabled` | enable/disable |
| GET / POST | `/llm/config` | get (redacted) / set (v2 only) |
| GET / PATCH | `/settings` | get / patch |

## The CLI
`bin: { "yakshaver": "./dist/cli/index.js" }`; `src/cli/**` added to `tsconfig` `include` — a single `tsc` build emits `dist/cli/index.js` with a `#!/usr/bin/env node` shebang.

- Resolves the app's `userData` per-OS WITHOUT Electron (`%APPDATA%/YakShaver`, or `YakShaverDev` with `--dev`) and reads the token file.
- Commands:
  - `yakshaver mcp list`
  - `yakshaver mcp add --name <n> --transport stdio --command <cmd> [--args "a b"] [--env "K=V,K2=V2"]`
  - `yakshaver mcp add --name <n> --transport http --url <url> [--header "K=V"]`
  - `yakshaver mcp remove <id>`
  - `yakshaver mcp enable <id> [--off]`
  - `yakshaver config get [llm|settings]`
  - `yakshaver config set settings --tool-approval-mode <yolo|wait|ask> --open-at-login <true|false>`
- Pretty-prints results, redacts secrets, `--json` for raw output.
- If the app/bridge isn't reachable: prints "YakShaver Desktop doesn't appear to be running (or the CLI bridge is disabled). Start the app and retry." and exits non-zero (3).

## Tests
51 unit tests (all green):
- **Router** — routing, Zod validation rejection, secret redaction (MCP headers, LLM apiKeys), 404/405/500 paths.
- **HTTP server** — binds to 127.0.0.1, writes token file, rejects missing/wrong token (401), serves authorized requests, rejects oversized body, env opt-out, token-file removal on stop.
- **CLI** — arg parsing, request building for every command (incl. URL-encoding + usage errors), and the bridge client (mocked fetch/token: auth header, body serialization, token caching, error/unavailable mapping).

## Build / lint
- `npx tsc` green; emits `dist/cli/index.js`; `node dist/cli/index.js --help` runs.
- Biome (`@biomejs/biome@2.3.11`, pinned from `biome.json`) clean on all changed files.
- Pre-existing `src/backend/db/services/*` and `ffmpeg-service` test failures in CI-less local runs are a native-module ABI mismatch (better-sqlite3 / ffmpeg) unrelated to this change.

## PENDING — live verification (deferred, not yet run)
Needs a running desktop app (the bridge only exists when the app is up):
1. Start the app, then `yakshaver mcp list` → returns the configured servers (built-ins + presets).
2. `yakshaver mcp add ...` then `yakshaver mcp list` → the new server appears; `yakshaver mcp remove <id>` round-trips it away.
3. `yakshaver mcp enable <id> --off` / without `--off` toggles `enabled` and the UI reflects it.
4. `yakshaver config get settings` / `config set settings --tool-approval-mode wait` round-trips against the app.
5. Confirm `apiKey`/header/env values are redacted in `config get llm` and `mcp list` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)