### PR TITLE
XS✔ ◾ feat: yakshaver-config Claude Code skill (#911)

### DIFF
--- a/.claude/skills/yakshaver-config/SKILL.md
+++ b/.claude/skills/yakshaver-config/SKILL.md
@@ -95,15 +95,19 @@ instead of pretty output), `-h` / `--help`. Exit codes: `0` ok, `1` runtime/requ
 yakshaver mcp list
 yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b c"] [--env "K=V,K2=V2"]
 yakshaver mcp add --name <name> --transport http  --url <url>      [--header "K=V"]
-yakshaver mcp remove <id>
-yakshaver mcp enable <id> [--off]          # without --off enables; --off disables
+yakshaver mcp remove <id> | --name <name>
+yakshaver mcp enable <id> | --name <name> [--off]   # without --off enables; --off disables
 ```
 
 - `--transport` accepts `stdio` or `http` (aliased to the internal `streamableHttp`).
 - `--args` is a single **space-separated** string; it's split on spaces.
 - `--env` and `--header` are **comma-separated** `KEY=VALUE` lists (e.g. `--env "A=1,B=2"`).
-- `mcp remove <id>` and `mcp enable <id>` take the server **id** (a positional), not the
-  name. Get the id from `yakshaver mcp list` first.
+- `mcp remove` and `mcp enable` select the target server **either** by a positional
+  **id** **or** by `--name <name>` (resolved against `mcp list` at runtime). Name matching
+  is exact and case-sensitive: it **errors** if no server matches that name, and errors on
+  an **ambiguous** name (more than one match) telling you to use the positional `<id>`
+  instead. When you already have the id (e.g. from `yakshaver mcp list`), prefer the
+  positional `<id>`; otherwise `--name` saves a lookup round-trip.
 - `--description` is optional on `add`.
 
 ### Config (settings + LLM)
@@ -145,12 +149,26 @@ yakshaver mcp add \
   --name "Azure DevOps" \
   --transport stdio \
   --command "npx" \
-  --args "-y @azure-devops/mcp <your-org>" \
-  --env "AZURE_DEVOPS_PAT=<USER_PROVIDED_PAT>"
+  --args "-y @azure-devops/mcp <your-org> --authentication pat" \
+  --env "PERSONAL_ACCESS_TOKEN=<USER_PROVIDED_BASE64_EMAIL_COLON_PAT>"
 ```
 
-(Confirm the exact package / args with the user — the command, args, and env shown here are
-placeholders.)
+**Get the auth wiring from the official docs — don't invent it.** The example above is the
+Microsoft `@azure-devops/mcp` server, which selects its auth method with the
+`--authentication` / `-a` flag (one of `interactive | azcli | envvar | pat`), **not** an
+arbitrary `*_PAT` env var. With no `--authentication` flag it defaults to **interactive
+browser login**, which fails in a headless Claude Code context — so a non-interactive setup
+must pass the flag explicitly:
+
+- `--authentication pat` reads `PERSONAL_ACCESS_TOKEN`, which must be the **base64 encoding of
+  `<email>:<pat>`** (the email can be any non-empty string).
+- `--authentication envvar` reads a **raw bearer token** from `ADO_MCP_AUTH_TOKEN` (handy in
+  CI).
+
+Confirm the exact org, package, flag, and env var with the user against the server's own
+getting-started doc
+(<https://github.com/microsoft/azure-devops-mcp/blob/main/docs/GETTINGSTARTED.md>) before
+running this — never guess the env var name (see the "Never invent values" guardrail).
 
 ### List / inspect
 
@@ -164,8 +182,10 @@ yakshaver config get llm            # LLM config (keys redacted, hasApiKey boole
 ### Enable / disable a server
 
 ```bash
-yakshaver mcp enable <id>           # enable
-yakshaver mcp enable <id> --off     # disable
+yakshaver mcp enable <id>              # enable by id
+yakshaver mcp enable <id> --off        # disable by id
+yakshaver mcp enable --name "Jira"     # enable by name (errors if missing/ambiguous)
+yakshaver mcp enable --name "Jira" --off
 ```
 
 ### Change the tool-approval mode
@@ -177,8 +197,9 @@ yakshaver config set settings --tool-approval-mode wait   # one of: yolo | wait 
 ### Remove a server
 
 ```bash
-yakshaver mcp list                  # find the id
+yakshaver mcp list                  # find the id (or use --name below)
 yakshaver mcp remove <id>           # confirm with the user first (see Guardrails)
+yakshaver mcp remove --name "Jira"  # alternative: select by name (errors if missing/ambiguous)
 ```
 
 ## Guardrails
@@ -194,8 +215,8 @@ yakshaver mcp remove <id>           # confirm with the user first (see Guardrail
 - **The orchestration-backend toggle (#908) is NOT settable via the CLI yet.** `config set
   settings` only supports `--tool-approval-mode` and `--open-at-login`. For orchestration
   mode, tell the user to change it in the app's Settings.
-- **Confirm before removing.** `mcp remove <id>` is destructive — show the user which server
-  (name + id) you're about to remove and get confirmation first.
+- **Confirm before removing.** `mcp remove` (by `<id>` or `--name`) is destructive — show the
+  user which server (name + id) you're about to remove and get confirmation first.
 - **Built-in servers.** `mcp list` marks built-ins with `[builtin]`; prefer
   enabling/disabling these over removing them, and check with the user.
 - **App-not-running (exit 3).** Surface the friendly message and ask the user to start the

--- a/.claude/skills/yakshaver-config/SKILL.md
+++ b/.claude/skills/yakshaver-config/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: yakshaver-config
+description: Configure YakShaver Desktop's MCP servers and supported settings by driving the `yakshaver` terminal CLI, which talks to the running app over its localhost-only, token-authenticated bridge (127.0.0.1:8765). Use when the user asks Claude Code to set up / add / remove / enable / disable an MCP server for YakShaver Desktop (GitHub, Azure DevOps, Jira, or a custom stdio/HTTP server), to inspect its MCP or LLM/settings config, or to change a supported setting such as the tool-approval mode. Trigger on phrases like "add a GitHub MCP server to YakShaver", "connect YakShaver to Azure DevOps", "list YakShaver's MCP servers", "disable the Jira server", "set YakShaver's tool-approval mode to wait", or "/yakshaver-config".
+---
+
+# Configure YakShaver Desktop (yakshaver CLI)
+
+Drive the `yakshaver` CLI to configure YakShaver Desktop's MCP servers and supported
+settings from the terminal. The CLI does NOT touch config files directly — it talks to
+the **running desktop app** over a localhost-only, token-authenticated HTTP bridge, so
+the app must be running and every change goes through the same services the app's own UI
+uses (no duplicated logic, shared Zod validation, secrets redacted).
+
+This skill depends on the `yakshaver` CLI shipped in PR #910 (`src/cli/**`).
+
+## What this skill is for
+
+Use it when the user asks Claude Code to:
+
+- **Add / remove an MCP server** for YakShaver Desktop — a backlog provider (GitHub,
+  Azure DevOps, Jira) or any custom stdio / HTTP (streamable-HTTP) MCP server.
+- **List / inspect** the configured MCP servers, the LLM config, or user settings.
+- **Enable / disable** an existing MCP server.
+- **Change a supported setting** (tool-approval mode, open-at-login).
+
+If the request is about something the CLI can't do (see Guardrails — e.g. setting LLM API
+keys, or the orchestration backend toggle from #908), say so and direct the user to the
+app's Settings UI instead of guessing.
+
+## Prerequisites — check these FIRST
+
+1. **YakShaver Desktop must be RUNNING.** The CLI reads a token file the app writes at
+   startup and connects to the app's bridge. If the app is not running (or the bridge is
+   disabled), every command exits **3** and prints:
+
+   > `YakShaver Desktop doesn't appear to be running (or the CLI bridge is disabled). Start the app and retry.`
+
+   When you see exit code 3 or that message, **stop and surface it to the user** — ask
+   them to start YakShaver Desktop, then retry. Do not try to edit config files as a
+   workaround.
+
+   - Token file: `userData/yakshaver-tokens/cli-bridge.json` (random 256-bit bearer token
+     + the port; same-user readable, `mode 0o600`). `userData` is `%APPDATA%/YakShaver` on
+     Windows, `~/Library/Application Support/YakShaver` on macOS, `$XDG_CONFIG_HOME`/`~/.config`
+     under `YakShaver` on Linux. For a dev build it's `YakShaverDev` — pass `--dev`.
+   - Bridge binds **127.0.0.1** only, tries port **8765**, falls back to an ephemeral port
+     (recorded in the token file). It can be disabled with `YAKSHAVER_DISABLE_CLI_BRIDGE`.
+
+2. **The `yakshaver` CLI must be built and available.** From the repo root:
+
+   ```bash
+   npm run build      # emits dist/cli/index.js (with a node shebang)
+   npm link           # exposes the `yakshaver` command on PATH
+   ```
+
+   If you can't / don't want to `npm link`, invoke it directly instead:
+
+   ```bash
+   node dist/cli/index.js <command> [options]
+   ```
+
+   Everywhere below that shows `yakshaver ...` you can substitute `node dist/cli/index.js ...`.
+
+3. Confirm reachability with a harmless read before making changes:
+
+   ```bash
+   yakshaver mcp list
+   ```
+
+   If that succeeds the app is up and the bridge is working.
+
+## Command reference
+
+Global flags: `--dev` (target the dev build's `YakShaverDev` userData), `--json` (raw JSON
+instead of pretty output), `-h` / `--help`. Exit codes: `0` ok, `1` runtime/request error,
+`2` usage error, `3` app/bridge not reachable.
+
+### MCP servers
+
+```text
+yakshaver mcp list
+yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b c"] [--env "K=V,K2=V2"]
+yakshaver mcp add --name <name> --transport http  --url <url>      [--header "K=V"]
+yakshaver mcp remove <id>
+yakshaver mcp enable <id> [--off]          # without --off enables; --off disables
+```
+
+- `--transport` accepts `stdio` or `http` (aliased to the internal `streamableHttp`).
+- `--args` is a single **space-separated** string; it's split on spaces.
+- `--env` and `--header` are **comma-separated** `KEY=VALUE` lists (e.g. `--env "A=1,B=2"`).
+- `mcp remove <id>` and `mcp enable <id>` take the server **id** (a positional), not the
+  name. Get the id from `yakshaver mcp list` first.
+- `--description` is optional on `add`.
+
+### Config (settings + LLM)
+
+```text
+yakshaver config get [llm|settings]        # defaults to "settings" if omitted
+yakshaver config set settings --tool-approval-mode <yolo|wait|ask>
+yakshaver config set settings --open-at-login <true|false>
+```
+
+- `config get llm` returns the LLM config with secrets redacted (see Guardrails).
+- `config set settings` requires at least one of the supported keys above, otherwise it's a
+  usage error. Multiple keys can be combined in one call.
+- `config set llm` is intentionally **not supported** (it would require secrets) — the CLI
+  tells you to configure providers in the app UI.
+
+## Common workflows (concrete examples)
+
+Always run `yakshaver mcp list` first so you know the current state and the server ids.
+
+### Add a GitHub MCP server (HTTP / streamable-HTTP)
+
+GitHub's hosted MCP server is HTTP-based and authenticated with a token header. Ask the
+user for the real URL and token — never invent them.
+
+```bash
+yakshaver mcp add \
+  --name "GitHub" \
+  --transport http \
+  --url "https://api.githubcopilot.com/mcp/" \
+  --header "Authorization=Bearer <USER_PROVIDED_PAT>"
+yakshaver mcp list          # confirm it appears
+```
+
+### Add a stdio MCP server (e.g. Azure DevOps via npx)
+
+```bash
+yakshaver mcp add \
+  --name "Azure DevOps" \
+  --transport stdio \
+  --command "npx" \
+  --args "-y @azure-devops/mcp <your-org>" \
+  --env "AZURE_DEVOPS_PAT=<USER_PROVIDED_PAT>"
+```
+
+(Confirm the exact package / args with the user — the command, args, and env shown here are
+placeholders.)
+
+### List / inspect
+
+```bash
+yakshaver mcp list                  # pretty: name [transport] (enabled/disabled), id, url/command
+yakshaver mcp list --json           # raw JSON for parsing
+yakshaver config get settings       # current user settings
+yakshaver config get llm            # LLM config (keys redacted, hasApiKey booleans)
+```
+
+### Enable / disable a server
+
+```bash
+yakshaver mcp enable <id>           # enable
+yakshaver mcp enable <id> --off     # disable
+```
+
+### Change the tool-approval mode
+
+```bash
+yakshaver config set settings --tool-approval-mode wait   # one of: yolo | wait | ask
+```
+
+### Remove a server
+
+```bash
+yakshaver mcp list                  # find the id
+yakshaver mcp remove <id>           # confirm with the user first (see Guardrails)
+```
+
+## Guardrails
+
+- **Never invent values.** Do not make up server URLs, commands, package names, env vars,
+  headers, tokens, or API keys. If you don't have a real value, **ask the user** for it.
+- **Secrets are redacted by the bridge.** `config get llm` and `mcp list` return
+  `***redacted***` for api keys, header values, and env values (and `hasApiKey` booleans).
+  Don't expect `config get` to echo a key back — you can't read existing secrets through the
+  CLI, only set new ones where supported.
+- **Setting LLM secrets is not supported via the CLI.** `config set llm` errors on purpose —
+  direct the user to the app's Settings UI to configure providers / API keys.
+- **The orchestration-backend toggle (#908) is NOT settable via the CLI yet.** `config set
+  settings` only supports `--tool-approval-mode` and `--open-at-login`. For orchestration
+  mode, tell the user to change it in the app's Settings.
+- **Confirm before removing.** `mcp remove <id>` is destructive — show the user which server
+  (name + id) you're about to remove and get confirmation first.
+- **Built-in servers.** `mcp list` marks built-ins with `[builtin]`; prefer
+  enabling/disabling these over removing them, and check with the user.
+- **App-not-running (exit 3).** Surface the friendly message and ask the user to start the
+  app; don't fall back to editing config files by hand.
+
+## Verifying a change
+
+After any mutating command, re-run a read to confirm the app accepted it:
+
+- After `mcp add` / `mcp remove` / `mcp enable`: `yakshaver mcp list`.
+- After `config set settings ...`: `yakshaver config get settings`.
+
+Because the bridge calls the same services the UI uses, changes should also be visible in the
+running app's UI.

--- a/.claude/skills/yakshaver-config/SKILL.md
+++ b/.claude/skills/yakshaver-config/SKILL.md
@@ -5,13 +5,23 @@ description: Configure YakShaver Desktop's MCP servers and supported settings by
 
 # Configure YakShaver Desktop (yakshaver CLI)
 
+> **⚠️ Availability: this skill is INERT until the `yakshaver` CLI lands.** It documents and
+> drives the `yakshaver` CLI introduced by PR #910 (`src/cli/**` + the localhost config
+> bridge), which is **not yet merged to `main`**. Until #910 is merged (or you are on a branch
+> that includes `src/cli/**`), there is no `dist/cli/index.js` to build and no `yakshaver`
+> command on PATH — the Prerequisites below will fail with *command not found* / missing
+> `dist/cli/index.js`. **Before running any command in this skill, verify the CLI exists**
+> (e.g. `yakshaver --help`, or `test -f dist/cli/index.js`); if it doesn't, tell the user the
+> CLI hasn't shipped yet and stop — do not fall back to editing config files by hand.
+
 Drive the `yakshaver` CLI to configure YakShaver Desktop's MCP servers and supported
 settings from the terminal. The CLI does NOT touch config files directly — it talks to
 the **running desktop app** over a localhost-only, token-authenticated HTTP bridge, so
 the app must be running and every change goes through the same services the app's own UI
 uses (no duplicated logic, shared Zod validation, secrets redacted).
 
-This skill depends on the `yakshaver` CLI shipped in PR #910 (`src/cli/**`).
+This skill depends on the `yakshaver` CLI introduced by PR #910 (`src/cli/**`), which must be
+merged before the skill is usable (see the availability note above).
 
 ## What this skill is for
 
@@ -46,7 +56,11 @@ app's Settings UI instead of guessing.
    - Bridge binds **127.0.0.1** only, tries port **8765**, falls back to an ephemeral port
      (recorded in the token file). It can be disabled with `YAKSHAVER_DISABLE_CLI_BRIDGE`.
 
-2. **The `yakshaver` CLI must be built and available.** From the repo root:
+2. **The `yakshaver` CLI must be built and available.** This requires PR #910 to be merged
+   (or to be on a branch that includes `src/cli/**`) — see the availability note at the top.
+   If `src/cli/` is absent, `npm run build` will **not** emit `dist/cli/index.js` and there is
+   no `yakshaver` command; stop and tell the user the CLI hasn't shipped yet. Otherwise, from
+   the repo root:
 
    ```bash
    npm run build      # emits dist/cli/index.js (with a node shebang)

--- a/.claude/skills/yakshaver-config/SKILL.md
+++ b/.claude/skills/yakshaver-config/SKILL.md
@@ -93,21 +93,19 @@ instead of pretty output), `-h` / `--help`. Exit codes: `0` ok, `1` runtime/requ
 
 ```text
 yakshaver mcp list
-yakshaver mcp add --name <name> --transport stdio --command <cmd> [--arg <a> --arg <b> ...] [--env "K=V,K2=V2"]
+yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b c"] [--env "K=V,K2=V2"]
 yakshaver mcp add --name <name> --transport http  --url <url>      [--header "K=V"]
 yakshaver mcp remove <id>
 yakshaver mcp enable <id> [--off]   # without --off enables; --off disables
 ```
 
 - `--transport` accepts `stdio` or `http` (aliased to the internal `streamableHttp`).
-- **Launch args (`stdio`): use `--arg` (repeatable), not `--args`.** `--arg` is the
-  primary, robust mechanism — it is repeatable and each value is taken **verbatim**, so a
-  single argument may contain spaces (a Windows path like `--arg "C:\My Tools\server.js"`).
-  A value that itself begins with `--` must use the equals form, e.g.
-  `--arg=--config="My File.json"`. The legacy `--args "a b c"` is a single
-  **space-separated** string that's split on spaces and therefore **cannot express an
-  individual argument that contains a space** — use it only for the trivial, space-free
-  case. The two are **mutually exclusive**; passing both is a usage error.
+- **Launch args (`stdio`): use `--args "a b c"`** — a single string that the CLI splits on
+  **spaces** into the argument list (e.g. `--args "-y @azure-devops/mcp <org>"` becomes
+  `["-y", "@azure-devops/mcp", "<org>"]`). Because the split is on whitespace, `--args`
+  **cannot express an individual argument that itself contains a space** (e.g. a Windows path
+  like `C:\My Tools\server.js`); the CLI has no flag for that today. If a server genuinely
+  needs a space-containing argument, tell the user and direct them to the app's Settings UI.
 - `--env` and `--header` are **comma-separated** `KEY=VALUE` lists (e.g. `--env "A=1,B=2"`).
 - `mcp remove` and `mcp enable` select the target server by its positional **id** (get the
   id from `yakshaver mcp list`). There is no `--name` selector for remove/enable in this
@@ -153,27 +151,24 @@ yakshaver mcp list          # confirm it appears
 
 ### Add a stdio MCP server (e.g. Azure DevOps via npx)
 
-Pass each launch argument as a separate repeatable `--arg` (verbatim, space-safe) rather
-than the legacy space-splitting `--args`:
+Pass the launch arguments as a single space-separated `--args` string; the CLI splits it on
+spaces into the argument list:
 
 ```bash
 yakshaver mcp add \
   --name "Azure DevOps" \
   --transport stdio \
   --command "npx" \
-  --arg "-y" \
-  --arg "@azure-devops/mcp" \
-  --arg "<your-org>" \
-  --arg=--authentication \
-  --arg "pat" \
+  --args "-y @azure-devops/mcp <your-org> --authentication pat" \
   --env "PERSONAL_ACCESS_TOKEN=$ADO_PAT_B64"
 ```
 
 (Set `export ADO_PAT_B64="<USER_PROVIDED_BASE64_EMAIL_COLON_PAT>"` first so the literal token
 isn't typed into the command line — see the secrets guardrail. Clear your history afterward.)
 
-(Use `--arg=--authentication` — the equals form — because the value begins with `--`; a
-bare `--arg --authentication` would be parsed as two flags.)
+(`--args` is split on spaces, so each token above — `-y`, `@azure-devops/mcp`, `<your-org>`,
+`--authentication`, `pat` — becomes a separate argument. None of these arguments contains a
+space, so the space-split is safe here.)
 
 **Get the auth wiring from the official docs — don't invent it.** The example above is the
 Microsoft `@azure-devops/mcp` server, which selects its auth method with the

--- a/.claude/skills/yakshaver-config/SKILL.md
+++ b/.claude/skills/yakshaver-config/SKILL.md
@@ -93,19 +93,26 @@ instead of pretty output), `-h` / `--help`. Exit codes: `0` ok, `1` runtime/requ
 
 ```text
 yakshaver mcp list
-yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b c"] [--env "K=V,K2=V2"]
+yakshaver mcp add --name <name> --transport stdio --command <cmd> [--arg <a> --arg <b> ...] [--env "K=V,K2=V2"]
 yakshaver mcp add --name <name> --transport http  --url <url>      [--header "K=V"]
 yakshaver mcp remove <id>
 yakshaver mcp enable <id> [--off]   # without --off enables; --off disables
 ```
 
 - `--transport` accepts `stdio` or `http` (aliased to the internal `streamableHttp`).
-- **Launch args (`stdio`): use `--args "a b c"`** — a single string that the CLI splits on
-  **spaces** into the argument list (e.g. `--args "-y @azure-devops/mcp <org>"` becomes
-  `["-y", "@azure-devops/mcp", "<org>"]`). Because the split is on whitespace, `--args`
-  **cannot express an individual argument that itself contains a space** (e.g. a Windows path
-  like `C:\My Tools\server.js`); the CLI has no flag for that today. If a server genuinely
-  needs a space-containing argument, tell the user and direct them to the app's Settings UI.
+- **Launch args (`stdio`): use the repeatable `--arg <value>` flag** — this is the primary,
+  robust mechanism. Pass one `--arg` per launch argument; each value is taken **verbatim**, so
+  a single argument may contain spaces (e.g. a Windows path: `--arg "C:\My Tools\server.js"`)
+  and may itself begin with `--` (a flag-shaped argument: `--arg --port --arg 3000`). For
+  example, `--arg -y --arg @azure-devops/mcp --arg <org>` becomes
+  `["-y", "@azure-devops/mcp", "<org>"]`.
+- **Legacy `--args "a b c"`** is kept only as a convenience for the trivial, space-free case:
+  it's a single string that the CLI splits on **spaces** into the argument list. Because the
+  split is on whitespace, `--args` **cannot express an individual argument that itself contains
+  a space** — use `--arg "C:\My Tools\server.js"` for that instead.
+- `--arg` and `--args` are **mutually exclusive** — passing both is a usage error
+  (`Use either --arg (repeatable, supports spaces) or --args (space-separated), not both`).
+  Prefer `--arg`; reach for `--args` only for a quick, space-free arg list.
 - `--env` and `--header` are **comma-separated** `KEY=VALUE` lists (e.g. `--env "A=1,B=2"`).
 - `mcp remove` and `mcp enable` select the target server by its positional **id** (get the
   id from `yakshaver mcp list`). There is no `--name` selector for remove/enable in this
@@ -151,24 +158,28 @@ yakshaver mcp list          # confirm it appears
 
 ### Add a stdio MCP server (e.g. Azure DevOps via npx)
 
-Pass the launch arguments as a single space-separated `--args` string; the CLI splits it on
-spaces into the argument list:
+Pass each launch argument with its own repeatable `--arg` flag (each value is taken verbatim):
 
 ```bash
 yakshaver mcp add \
   --name "Azure DevOps" \
   --transport stdio \
   --command "npx" \
-  --args "-y @azure-devops/mcp <your-org> --authentication pat" \
+  --arg -y \
+  --arg @azure-devops/mcp \
+  --arg <your-org> \
+  --arg --authentication \
+  --arg pat \
   --env "PERSONAL_ACCESS_TOKEN=$ADO_PAT_B64"
 ```
 
 (Set `export ADO_PAT_B64="<USER_PROVIDED_BASE64_EMAIL_COLON_PAT>"` first so the literal token
 isn't typed into the command line — see the secrets guardrail. Clear your history afterward.)
 
-(`--args` is split on spaces, so each token above — `-y`, `@azure-devops/mcp`, `<your-org>`,
-`--authentication`, `pat` — becomes a separate argument. None of these arguments contains a
-space, so the space-split is safe here.)
+(Each `--arg` value above — `-y`, `@azure-devops/mcp`, `<your-org>`, `--authentication`, `pat`
+— becomes one argument verbatim. Note `--arg --authentication` works because `--arg` takes its
+following token literally even when that token is itself flag-shaped. If any argument needed to
+contain a space — e.g. a Windows path — you'd quote it: `--arg "C:\My Tools\server.js"`.)
 
 **Get the auth wiring from the official docs — don't invent it.** The example above is the
 Microsoft `@azure-devops/mcp` server, which selects its auth method with the

--- a/.claude/skills/yakshaver-config/SKILL.md
+++ b/.claude/skills/yakshaver-config/SKILL.md
@@ -93,21 +93,25 @@ instead of pretty output), `-h` / `--help`. Exit codes: `0` ok, `1` runtime/requ
 
 ```text
 yakshaver mcp list
-yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b c"] [--env "K=V,K2=V2"]
+yakshaver mcp add --name <name> --transport stdio --command <cmd> [--arg <a> --arg <b> ...] [--env "K=V,K2=V2"]
 yakshaver mcp add --name <name> --transport http  --url <url>      [--header "K=V"]
-yakshaver mcp remove <id> | --name <name>
-yakshaver mcp enable <id> | --name <name> [--off]   # without --off enables; --off disables
+yakshaver mcp remove <id>
+yakshaver mcp enable <id> [--off]   # without --off enables; --off disables
 ```
 
 - `--transport` accepts `stdio` or `http` (aliased to the internal `streamableHttp`).
-- `--args` is a single **space-separated** string; it's split on spaces.
+- **Launch args (`stdio`): use `--arg` (repeatable), not `--args`.** `--arg` is the
+  primary, robust mechanism — it is repeatable and each value is taken **verbatim**, so a
+  single argument may contain spaces (a Windows path like `--arg "C:\My Tools\server.js"`).
+  A value that itself begins with `--` must use the equals form, e.g.
+  `--arg=--config="My File.json"`. The legacy `--args "a b c"` is a single
+  **space-separated** string that's split on spaces and therefore **cannot express an
+  individual argument that contains a space** — use it only for the trivial, space-free
+  case. The two are **mutually exclusive**; passing both is a usage error.
 - `--env` and `--header` are **comma-separated** `KEY=VALUE` lists (e.g. `--env "A=1,B=2"`).
-- `mcp remove` and `mcp enable` select the target server **either** by a positional
-  **id** **or** by `--name <name>` (resolved against `mcp list` at runtime). Name matching
-  is exact and case-sensitive: it **errors** if no server matches that name, and errors on
-  an **ambiguous** name (more than one match) telling you to use the positional `<id>`
-  instead. When you already have the id (e.g. from `yakshaver mcp list`), prefer the
-  positional `<id>`; otherwise `--name` saves a lookup round-trip.
+- `mcp remove` and `mcp enable` select the target server by its positional **id** (get the
+  id from `yakshaver mcp list`). There is no `--name` selector for remove/enable in this
+  CLI surface — always look up the id with `mcp list` first.
 - `--description` is optional on `add`.
 
 ### Config (settings + LLM)
@@ -133,25 +137,43 @@ Always run `yakshaver mcp list` first so you know the current state and the serv
 GitHub's hosted MCP server is HTTP-based and authenticated with a token header. Ask the
 user for the real URL and token — never invent them.
 
+To keep the literal PAT out of shell history and the process table (see the secrets
+guardrail), set it in an environment variable first and reference it in the header rather
+than typing the token inline:
+
 ```bash
+export GITHUB_PAT="<USER_PROVIDED_PAT>"   # not persisted to history if you prefer; clear afterward
 yakshaver mcp add \
   --name "GitHub" \
   --transport http \
   --url "https://api.githubcopilot.com/mcp/" \
-  --header "Authorization=Bearer <USER_PROVIDED_PAT>"
+  --header "Authorization=Bearer $GITHUB_PAT"
 yakshaver mcp list          # confirm it appears
 ```
 
 ### Add a stdio MCP server (e.g. Azure DevOps via npx)
+
+Pass each launch argument as a separate repeatable `--arg` (verbatim, space-safe) rather
+than the legacy space-splitting `--args`:
 
 ```bash
 yakshaver mcp add \
   --name "Azure DevOps" \
   --transport stdio \
   --command "npx" \
-  --args "-y @azure-devops/mcp <your-org> --authentication pat" \
-  --env "PERSONAL_ACCESS_TOKEN=<USER_PROVIDED_BASE64_EMAIL_COLON_PAT>"
+  --arg "-y" \
+  --arg "@azure-devops/mcp" \
+  --arg "<your-org>" \
+  --arg=--authentication \
+  --arg "pat" \
+  --env "PERSONAL_ACCESS_TOKEN=$ADO_PAT_B64"
 ```
+
+(Set `export ADO_PAT_B64="<USER_PROVIDED_BASE64_EMAIL_COLON_PAT>"` first so the literal token
+isn't typed into the command line — see the secrets guardrail. Clear your history afterward.)
+
+(Use `--arg=--authentication` — the equals form — because the value begins with `--`; a
+bare `--arg --authentication` would be parsed as two flags.)
 
 **Get the auth wiring from the official docs — don't invent it.** The example above is the
 Microsoft `@azure-devops/mcp` server, which selects its auth method with the
@@ -181,11 +203,13 @@ yakshaver config get llm            # LLM config (keys redacted, hasApiKey boole
 
 ### Enable / disable a server
 
+Select the server by its **id** — run `yakshaver mcp list` first to find it (the list shows
+each server's name alongside its id).
+
 ```bash
+yakshaver mcp list                     # find the id for "Jira"
 yakshaver mcp enable <id>              # enable by id
 yakshaver mcp enable <id> --off        # disable by id
-yakshaver mcp enable --name "Jira"     # enable by name (errors if missing/ambiguous)
-yakshaver mcp enable --name "Jira" --off
 ```
 
 ### Change the tool-approval mode
@@ -197,9 +221,8 @@ yakshaver config set settings --tool-approval-mode wait   # one of: yolo | wait 
 ### Remove a server
 
 ```bash
-yakshaver mcp list                  # find the id (or use --name below)
+yakshaver mcp list                  # find the id for the server to remove
 yakshaver mcp remove <id>           # confirm with the user first (see Guardrails)
-yakshaver mcp remove --name "Jira"  # alternative: select by name (errors if missing/ambiguous)
 ```
 
 ## Guardrails
@@ -212,11 +235,21 @@ yakshaver mcp remove --name "Jira"  # alternative: select by name (errors if mis
   CLI, only set new ones where supported.
 - **Setting LLM secrets is not supported via the CLI.** `config set llm` errors on purpose —
   direct the user to the app's Settings UI to configure providers / API keys.
+- **Inline secrets in `--header` / `--env` leak into shell history and the process table.**
+  A PAT or token typed directly into a `yakshaver mcp add` command line (e.g.
+  `--header "Authorization=Bearer <PAT>"`, `--env "PERSONAL_ACCESS_TOKEN=<PAT>"`) is
+  persisted to the operator's shell history (`.bash_history` / PSReadLine) and is visible to
+  other processes on the host (`ps`, `/proc/<pid>/cmdline`) for the lifetime of the command.
+  Prefer routing credential-bearing setup through the app's **Settings UI**, where the bridge
+  redacts secrets (mirroring the unsupported `config set llm`). If you must use the CLI,
+  reference the secret from an environment variable rather than typing the literal token
+  (e.g. set `$GITHUB_PAT` first, then `--header "Authorization=Bearer $GITHUB_PAT"`), and
+  warn the user to clear their shell history afterward.
 - **The orchestration-backend toggle (#908) is NOT settable via the CLI yet.** `config set
   settings` only supports `--tool-approval-mode` and `--open-at-login`. For orchestration
   mode, tell the user to change it in the app's Settings.
-- **Confirm before removing.** `mcp remove` (by `<id>` or `--name`) is destructive — show the
-  user which server (name + id) you're about to remove and get confirmation first.
+- **Confirm before removing.** `mcp remove <id>` is destructive — show the user which server
+  (name + id, from `mcp list`) you're about to remove and get confirmation first.
 - **Built-in servers.** `mcp list` marks built-ins with `[builtin]`; prefer
   enabling/disabling these over removing them, and check with the user.
 - **App-not-running (exit 3).** Surface the friendly message and ask the user to start the

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,9 @@ data/
 # Claude temp files
 tmpclaude*
 .claude/
+# Keep shared, version-controlled Claude Code skills
+!.claude/
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/yakshaver-config/


### PR DESCRIPTION
Closes #911. Phase 3 of the YakShaver CLI work.

## What this adds
A Claude Code **skill** (`.claude/skills/yakshaver-config/SKILL.md`) that lets Claude Code configure **YakShaver Desktop's MCP servers and supported settings** by driving the `yakshaver` terminal CLI — no app code, just a documented, model-invokable skill.

It enables natural-language requests like *"add a GitHub MCP server to YakShaver"*, *"connect YakShaver to Azure DevOps"*, *"list/disable YakShaver's MCP servers"*, or *"set the tool-approval mode to wait"*, and teaches Claude to:
- check the app is running first (the CLI exits **3** with a friendly message when it isn't — surface it and ask the user to start the app),
- use the real CLI surface — `yakshaver mcp list|add|remove|enable` (with `--name` on `add`, `--transport stdio|http`, `--command`/`--url`, repeatable `--arg` (preferred) / legacy `--args`, `--env`, `--header`, `--off`; `remove`/`enable` select by positional `<id>`) and `yakshaver config get [llm|settings]` / `config set settings --tool-approval-mode <yolo|wait|ask> --open-at-login <true|false>`,
- follow guardrails — secrets are redacted by the bridge (so `config get` won't echo keys), inline `--header`/`--env` secrets land in shell history and the process table (prefer the Settings UI or an env-var reference), never invent URLs/commands/tokens (ask the user), confirm before removing a server, and note the orchestration-backend toggle (#908) is **not** CLI-settable yet (do it in Settings).

The skill's command reference and examples are scoped to the **#910** CLI surface (`src/cli/{index,args,commands,bridge-client,user-data-path}.ts`) and were validated against that source — in particular, `remove`/`enable` select by positional `<id>` only (the `--name` selector and `mcp update` are later #913/#914 work and are intentionally **not** documented here yet).

## Dependency
This depends on the **`yakshaver` CLI from #910** (`src/cli/**` + the localhost config bridge). It is documentation-only and ships nothing executable itself.

## How to try it
1. Build + expose the CLI from the repo root: `npm run build` then `npm link` (or invoke `node dist/cli/index.js` directly).
2. Start **YakShaver Desktop** (the CLI talks to its localhost bridge on `127.0.0.1:8765` via the token file at `userData/yakshaver-tokens/cli-bridge.json`; with the app down the CLI exits 3).
3. In Claude Code, ask: *"add a GitHub MCP server to YakShaver"* (or "list YakShaver's MCP servers"). The skill triggers and drives the CLI.

## Note
`.claude/` is gitignored in this repo; this PR adds a **targeted negation** so only `.claude/skills/yakshaver-config/` is tracked while the rest of `.claude/` (worktrees, local settings) stays ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
