### PR TITLE
feat(cli): orchestration backend setting, mcp update, --name lookups (#913)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ YakShaver is a desktop AI agent with the following capabilities:
 
 - **AI/LLM**: `@ai-sdk/openai`, `@ai-sdk/azure`, `@ai-sdk/deepseek`, `@ai-sdk/mcp`, `ai`, `openai`
 - **MCP**: `@modelcontextprotocol/sdk`
+- **Validation**: `zod` (form schemas + the CLI bridge wire protocol in `src/shared/cli-bridge/`)
 - **Database**: `drizzle-orm`, `better-sqlite3`
 - **APIs**: `googleapis`, `@microsoft/microsoft-graph-client`, `google-auth-library`, `@azure/msal-node`
 - **Video/Media**: `@ffmpeg-installer/ffmpeg`, `youtube-dl-exec`
@@ -91,6 +92,7 @@ SSW.YakShaver.Desktop/
 │   │   │   └── channels.ts           # All IPC channel name constants
 │   │   ├── services/                  # Business logic services
 │   │   │   ├── auth/                  # YouTube & Microsoft OAuth
+│   │   │   ├── cli-bridge/            # Localhost HTTP bridge for the `yakshaver` CLI
 │   │   │   ├── ffmpeg/                # Video codec conversion
 │   │   │   ├── mcp/                   # MCP orchestration (central AI hub)
 │   │   │   ├── recording/             # Screen capture (singleton + EventEmitter)
@@ -105,9 +107,10 @@ SSW.YakShaver.Desktop/
 │   ├── shared/                        # Shared types between frontend & backend
 │   │   ├── types/                     # LLM, workflow, MCP, user-settings, telemetry types
 │   │   ├── llm/                       # Provider factory configuration
+│   │   ├── cli-bridge/                # CLI bridge wire protocol (zod) + redaction
 │   │   └── constants/                 # Shared error messages
 │   │
-│   └── ui/                            # React frontend (Vite)
+│   ├── ui/                            # React frontend (Vite)
 │       ├── vite.config.mts            # Vite build config (multi-entry)
 │       ├── tsconfig.json              # Frontend TypeScript config
 │       └── src/
@@ -129,6 +132,13 @@ SSW.YakShaver.Desktop/
 │           ├── lib/utils.ts           # cn() helper for Tailwind classes
 │           ├── types/                 # Frontend type definitions & enums
 │           └── utils/                 # formatErrorMessage, helpers
+│   │
+│   └── cli/                           # `yakshaver` CLI (plain Node, no Electron)
+│       ├── index.ts                  # CLI entry (bin: `yakshaver`)
+│       ├── commands.ts               # Arg parsing -> bridge request mapping
+│       ├── bridge-client.ts          # Talks to the localhost CLI bridge
+│       ├── resolve-name.ts           # Resolve MCP server name -> id
+│       └── user-data-path.ts         # Locate the app's userData dir (token file)
 │
 ├── docs/adr/                          # Architecture Decision Records
 ├── .github/workflows/                 # CI/CD (biome-check, release, build)
@@ -407,6 +417,29 @@ Channels are defined as constants in `src/backend/ipc/channels.ts`:
 
 All encrypted credential storage extends `BaseSecureStorage` (which uses Electron's `safeStorage` API). Each storage class is a singleton with `encryptAndStore()`/`decryptAndLoad()` methods. Classes: `LlmStorage`, `YoutubeStorage`, `GitHubTokenStorage`, `McpStorage`, `McpOAuthTokenStorage`, `CustomPromptStorage`, `UserSettingsStorage`, `ReleaseChannelStorage`.
 
+#### CLI Bridge Pattern (Localhost HTTP Control Plane)
+
+The standalone `yakshaver` CLI (`src/cli/`, exposed via the `bin.yakshaver` entry
+in `package.json`) configures a running desktop app from the terminal. Because
+the CLI is a separate plain-Node process, it cannot use IPC (which is renderer
+<-> main only). Instead the main process runs `CliBridgeServer`
+(`src/backend/services/cli-bridge/`), a localhost-only HTTP control plane:
+
+- Binds to `127.0.0.1` ONLY (never `0.0.0.0`); unreachable off-box. Opt out with
+  `YAKSHAVER_DISABLE_CLI_BRIDGE`.
+- On start it writes a handshake file (`port` + a random 256-bit bearer token) to
+  `userData/yakshaver-tokens/cli-bridge.json` (plaintext JSON, `0o600`; see the
+  Security note — it cannot be `safeStorage`-encrypted because the CLI can't
+  decrypt it). Every request must send `Authorization: Bearer <token>`.
+- Routing/validation live in `bridge-router.ts` and are Electron-free and unit
+  tested with mocked services. Every mutating endpoint validates its body with a
+  shared **zod** schema from `src/shared/cli-bridge/protocol.ts` via `safeParse`
+  and returns 400 on failure. Secrets (api keys, header/env values) are redacted
+  in every response via `src/shared/cli-bridge/redact.ts`.
+- The bridge delegates to the same backend singletons the UI uses
+  (`MCPServerManager`, `LlmStorage`, `UserSettingsStorage`) so there is one
+  source of truth for config.
+
 #### Database Service Pattern (Functions, Not Classes)
 
 Database services use plain exported functions (not classes) because better-sqlite3 is synchronous. No `async/await` in DB services. Use Drizzle ORM methods: `.get()` for single row, `.all()` for multiple rows, `.run()` for mutations. See `src/backend/db/services/shave-service.ts` for the pattern.
@@ -575,11 +608,21 @@ APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...;IngestionEndpoint=.
 
 ### Storage Locations
 
-- **Windows**: `%APPDATA%\SSW.YakShaver\`
-- **macOS**: `~/Library/Application Support/SSW.YakShaver/`
-- **Linux**: `~/.config/SSW.YakShaver/`
+The userData directory is named after the Electron app (`YakShaver`), with a
+separate `YakShaverDev` directory for development builds (see
+`src/backend/index.ts`):
+
+- **Windows**: `%APPDATA%\YakShaver\` (dev: `%APPDATA%\YakShaverDev\`)
+- **macOS**: `~/Library/Application Support/YakShaver/`
+- **Linux**: `~/.config/YakShaver/`
 
 Encrypted tokens: `yakshaver-tokens/*.enc`
+CLI bridge token: `yakshaver-tokens/cli-bridge.json` — a plaintext JSON handshake
+file (port + bearer token) written with owner-only permissions (`0o600` where the
+OS honours it). It is intentionally NOT `safeStorage`-encrypted: the standalone
+`yakshaver` CLI is a plain Node process that cannot use Electron's `safeStorage`
+to decrypt it. The token only guards the localhost-only (`127.0.0.1`) bridge and
+is regenerated on every app start. See "CLI Bridge" under Architecture Patterns.
 Database: `database.sqlite` (dev: `./data/database.sqlite`)
 Auth browser templates: `src/backend/assets/auth/*.html` (packaged via `extraResources`)
 
@@ -634,7 +677,12 @@ npm run db:generate    # Generate Drizzle ORM migrations
 - **Never commit API keys** - use `.env` file (gitignored)
 - **Never hardcode secrets** - even placeholder values like `"sk-..."`
 - **Use Electron's `safeStorage` API** - for all token/credential encryption
-- **Encrypt all stored credentials** - via `BaseSecureStorage` subclasses
+- **Encrypt all stored credentials** - via `BaseSecureStorage` subclasses. The
+  one documented exception is the CLI bridge handshake token
+  (`yakshaver-tokens/cli-bridge.json`): the external `yakshaver` CLI is a plain
+  Node process that cannot decrypt `safeStorage` blobs, so the token is stored as
+  plaintext JSON with `0o600` permissions and only ever gates the localhost-only
+  bridge. See "CLI Bridge" under Architecture Patterns.
 - **Use HTTPS for all non-local/external API calls** (HTTP is only acceptable for `localhost` in local development)
 - **Validate and sanitize user input** before processing
 - **No telemetry without consent**

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ for YouTube downloads. This avoids relying on the operating system's Python.
 
 - Keys are stored securely on your device using the operating system's encryption (Electron safeStorage) in the app's user data directory
 
-- **Windows**: `%APPDATA%\SSW.YakShaver\yakshaver-tokens\*.enc`
-- **macOS**: `~/Library/Application Support/SSW.YakShaver/yakshaver-tokens/*.enc`
-- **Linux**: `~/.config/SSW.YakShaver/yakshaver-tokens/*.enc`
+- **Windows**: `%APPDATA%\YakShaver\yakshaver-tokens\*.enc`
+- **macOS**: `~/Library/Application Support/YakShaver/yakshaver-tokens/*.enc`
+- **Linux**: `~/.config/YakShaver/yakshaver-tokens/*.enc`
+
+(Dev builds use a `YakShaverDev` folder in the same location.)
 
 
 ### OpenAI API Key (User-provided)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.6.0",
   "description": "YakShaver, an AI agent to help you trim the fluff and get straight to the point",
   "main": "dist/backend/index.js",
+  "bin": {
+    "yakshaver": "./dist/cli/index.js"
+  },
   "build": {},
   "scripts": {
     "setup": "concurrently \"npm run setup:root\" \"cd src/ui && npm install\"",
@@ -60,7 +63,8 @@
     "openai": "^6.16.0",
     "openid-client": "^6.8.2",
     "tmp": "^0.2.5",
-    "youtube-dl-exec": "^3.0.29"
+    "youtube-dl-exec": "^3.0.29",
+    "zod": "^4.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -27,6 +27,7 @@ import { UserSettingsIPCHandlers } from "./ipc/user-settings-handlers";
 import { handleProtocolUrl } from "./protocol/protocol-router";
 import { IdentityServerAuthService } from "./services/auth/identity-server-auth";
 import { MicrosoftAuthService } from "./services/auth/microsoft-auth";
+import { CliBridgeServer } from "./services/cli-bridge/cli-bridge-server";
 import { registerAllInternalMcpServers } from "./services/mcp/internal/register-internal-servers";
 import { MCPOrchestrator } from "./services/mcp/mcp-orchestrator";
 import { MCPServerManager } from "./services/mcp/mcp-server-manager";
@@ -447,6 +448,13 @@ app.whenReady().then(async () => {
 
   const mcpServerManager = await MCPServerManager.getInstanceAsync();
   _mcpHandlers = new McpIPCHandlers(mcpServerManager);
+
+  // Start the localhost-only CLI config bridge (best-effort; never blocks startup).
+  try {
+    await CliBridgeServer.getInstance().start();
+  } catch (err) {
+    console.error("Failed to start CLI bridge:", err);
+  }
   _customPromptSettingsHandlers = new CustomPromptSettingsIPCHandlers();
   _appControlHandlers = new AppControlIPCHandlers();
   _releaseChannelHandlers = new ReleaseChannelIPCHandlers();
@@ -504,6 +512,11 @@ const cleanup = async () => {
   trayManager.destroy();
 
   unregisterEventForwarders?.();
+  try {
+    await CliBridgeServer.getInstance().stop();
+  } catch (err) {
+    console.error("CLI bridge shutdown error:", err);
+  }
   try {
     await RecordingService.getInstance().cleanupAllTempFiles();
   } catch (err) {

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -13,12 +13,15 @@ import { IdentityServerAuthService } from "../services/auth/identity-server-auth
 import type { VideoUploadResult } from "../services/auth/types";
 import { YouTubeClient } from "../services/auth/youtube-client";
 import { FFmpegService } from "../services/ffmpeg/ffmpeg-service";
+import type { IBacklogOrchestrator } from "../services/mcp/backlog-orchestrator";
 import { LanguageModelProvider } from "../services/mcp/language-model-provider";
+import { LocalClaudeOrchestrator } from "../services/mcp/local-claude-orchestrator";
 import { MCPOrchestrator } from "../services/mcp/mcp-orchestrator";
 import { TranscriptionModelProvider } from "../services/mcp/transcription-model-provider";
 import { SendWorkItemDetailsToPortal, WorkItemDtoSchema } from "../services/portal/actions";
 import type { ProjectDto } from "../services/prompt/prompt-manager";
 import { ShaveService } from "../services/shave/shave-service";
+import { LlmStorage } from "../services/storage/llm-storage";
 import { UserInteractionService } from "../services/user-interaction/user-interaction-service";
 import { VideoMetadataBuilder } from "../services/video/video-metadata-builder";
 import { YouTubeDownloadService } from "../services/video/youtube-service";
@@ -136,7 +139,7 @@ export class ProcessVideoIPCHandlers {
 
           const mcpAdapter = new McpWorkflowAdapter(workflowManager);
 
-          const orchestrator = await MCPOrchestrator.getInstanceAsync();
+          const orchestrator = await this.getBacklogOrchestrator();
           const loopResult = await orchestrator.manualLoopAsync(
             intermediateOutput,
             videoUploadResult,
@@ -564,7 +567,7 @@ export class ProcessVideoIPCHandlers {
           intermediateOutput,
         });
 
-        const orchestrator = await MCPOrchestrator.getInstanceAsync();
+        const orchestrator = await this.getBacklogOrchestrator();
 
         // transcriptText guaranteed by: normal flow sets it in TRANSCRIBING; retry validated at entry
         const loopResult = await orchestrator.manualLoopAsync(
@@ -616,7 +619,11 @@ export class ProcessVideoIPCHandlers {
           (await IdentityServerAuthService.getInstance().isAuthenticated())
         ) {
           try {
-            const objectResult = await orchestrator.convertToObjectAsync(
+            // Portal serialization uses the OpenAI orchestrator's structured-output helper
+            // regardless of which backend drove the loop (the local Claude backend has no
+            // convertToObjectAsync). This is a separate LLM call from the orchestration step.
+            const portalOrchestrator = await MCPOrchestrator.getInstanceAsync();
+            const objectResult = await portalOrchestrator.convertToObjectAsync(
               mcpResult,
               WorkItemDtoSchema,
             );
@@ -721,6 +728,31 @@ export class ProcessVideoIPCHandlers {
     const outputFilePath = tmp.tmpNameSync({ postfix: ".mp3" });
     const result = await this.ffmpegService.ConvertVideoToMp3(inputPath, outputFilePath);
     return result;
+  }
+
+  /**
+   * Selects the orchestrator backend for the backlog-creation step from the persisted LLM config.
+   * `local-claude` drives the step with a headless `claude -p`; anything else (including a config
+   * with no `orchestrationBackend` field) uses the in-process OpenAI loop. Falls back to OpenAI if
+   * the config can't be read so the stage never hard-fails on a config hiccup.
+   */
+  private async getBacklogOrchestrator(): Promise<IBacklogOrchestrator> {
+    let backend: string | undefined;
+    try {
+      backend = (await LlmStorage.getInstance().getLLMConfig())?.orchestrationBackend;
+    } catch (error) {
+      console.warn(
+        "[ProcessVideo] Failed to read orchestration backend, defaulting to OpenAI",
+        error,
+      );
+    }
+
+    if (backend === "local-claude") {
+      console.log("[ProcessVideo] Using local Claude Code orchestrator");
+      return new LocalClaudeOrchestrator();
+    }
+
+    return await MCPOrchestrator.getInstanceAsync();
   }
 
   private async formatFinalResult(mcpResult: string | undefined): Promise<string | undefined> {

--- a/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
+++ b/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPServerConfig } from "../mcp/types";
+
+/**
+ * Integration test for the MCP transport-switch path that drives the bridge's
+ * `mergeMcpPatch` through the REAL `MCPServerManager.updateServerAsync` (with
+ * `McpStorage` mocked to an in-memory store), rather than a mocked manager.
+ *
+ * It guards the invariant the bridge's design comment promises: after an
+ * HTTP->stdio (or stdio->HTTP) switch, no stale fields of the OLD transport
+ * (e.g. a secret-bearing `headers`/`url`, or `command`/`args`/`env`) survive in
+ * the persisted config. A previous regression was masked because the unit tests
+ * mocked `updateServerAsync` and only asserted on the value PASSED to the mock,
+ * never the manager's own second merge against the re-fetched stored config.
+ */
+
+// In-memory backing store the mocked McpStorage reads/writes.
+let store: MCPServerConfig[] = [];
+
+vi.mock("../storage/mcp-storage", () => ({
+  McpStorage: {
+    getInstance: () => ({
+      getMcpServerConfigsAsync: async () => store.map((s) => ({ ...s })),
+      storeMcpServers: async (servers: MCPServerConfig[]) => {
+        store = servers.map((s) => ({ ...s }));
+      },
+    }),
+  },
+}));
+
+// Avoid pulling preset servers into the merge for this focused test.
+vi.mock("../../../shared/mcp/preset-servers", () => ({
+  PRESET_MCP_SERVERS: [],
+}));
+
+import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { routeRequest } from "./bridge-router";
+
+function makeServices() {
+  return {
+    mcp: {
+      listAvailableServers: async () => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.listAvailableServers();
+      },
+      addServerAsync: async (config: MCPServerConfig) => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.addServerAsync(config);
+      },
+      updateServerAsync: async (serverId: string, config: MCPServerConfig) => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.updateServerAsync(serverId, config);
+      },
+      removeServerAsync: async (serverId: string) => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.removeServerAsync(serverId);
+      },
+      getServerByIdAsync: async (serverId: string) =>
+        MCPServerManager.getServerConfigByIdAsync(serverId),
+    },
+    llm: {
+      getLLMConfig: async () => null,
+      storeLLMConfig: async () => {},
+    },
+    settings: {
+      getSettingsAsync: async () => ({}) as never,
+      updateSettingsAsync: async () => {},
+    },
+  };
+}
+
+describe("bridge -> real MCPServerManager transport switch", () => {
+  beforeEach(() => {
+    store = [];
+  });
+
+  it("HTTP->stdio strips stale url/headers in the PERSISTED config (real manager merge)", async () => {
+    store = [
+      {
+        id: "srv-1",
+        name: "Test HTTP",
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+        headers: { Authorization: "Bearer super-secret" },
+        enabled: true,
+      },
+    ];
+
+    const res = await routeRequest(makeServices(), {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { transport: "stdio", command: "node" },
+    });
+    expect(res.status).toBe(200);
+
+    const persisted = store.find((s) => s.id === "srv-1") as unknown as Record<string, unknown>;
+    expect(persisted.transport).toBe("stdio");
+    expect(persisted.command).toBe("node");
+    // The real second merge must NOT re-introduce the stale HTTP fields.
+    expect(persisted.url).toBeUndefined();
+    expect(persisted.headers).toBeUndefined();
+    expect(JSON.stringify(persisted)).not.toContain("super-secret");
+  });
+
+  it("stdio->HTTP strips stale command/args/env in the PERSISTED config", async () => {
+    store = [
+      {
+        id: "srv-2",
+        name: "Test stdio",
+        transport: "stdio",
+        command: "node",
+        args: ["server.js"],
+        env: { TOKEN: "secret-token" },
+        enabled: true,
+      },
+    ];
+
+    const res = await routeRequest(makeServices(), {
+      method: "PUT",
+      path: "/mcp/servers/srv-2",
+      body: { transport: "streamableHttp", url: "https://new.example.com/mcp" },
+    });
+    expect(res.status).toBe(200);
+
+    const persisted = store.find((s) => s.id === "srv-2") as unknown as Record<string, unknown>;
+    expect(persisted.transport).toBe("streamableHttp");
+    expect(persisted.url).toBe("https://new.example.com/mcp");
+    expect(persisted.command).toBeUndefined();
+    expect(persisted.args).toBeUndefined();
+    expect(persisted.env).toBeUndefined();
+    expect(JSON.stringify(persisted)).not.toContain("secret-token");
+  });
+});

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -268,6 +268,80 @@ describe("routeRequest - MCP", () => {
     );
   });
 
+  it("POST /mcp/servers/:id/enabled rejects disabling a built-in server", async () => {
+    const builtin: MCPServerConfig = {
+      id: "yak_video_tools",
+      name: "Yak_Video_Tools",
+      transport: "inMemory",
+      builtin: true,
+      enabled: true,
+    };
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(builtin),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "POST",
+      path: "/mcp/servers/yak_video_tools/enabled",
+      body: { enabled: false },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    if (res.body.ok) throw new Error("expected error");
+    expect(res.body.error).toContain("built-in");
+    // Must NOT persist a shadow copy of the built-in server.
+    expect(svc.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
+  it("PUT /mcp/servers/:id rejects updating a built-in server", async () => {
+    const builtin: MCPServerConfig = {
+      id: "yak_video_tools",
+      name: "Yak_Video_Tools",
+      transport: "inMemory",
+      builtin: true,
+      enabled: true,
+    };
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(builtin),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "PUT",
+      path: "/mcp/servers/yak_video_tools",
+      body: { description: "hijacked" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(svc.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
+  it("DELETE /mcp/servers/:id rejects removing a built-in server", async () => {
+    const builtin: MCPServerConfig = {
+      id: "yak_video_tools",
+      name: "Yak_Video_Tools",
+      transport: "inMemory",
+      builtin: true,
+      enabled: true,
+    };
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(builtin),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "DELETE",
+      path: "/mcp/servers/yak_video_tools",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(svc.mcp.removeServerAsync).not.toHaveBeenCalled();
+  });
+
   it("POST /mcp/servers/:id/enabled 404s on unknown server", async () => {
     const svc = makeServices({
       mcp: {
@@ -377,6 +451,20 @@ describe("routeRequest - LLM", () => {
     expect(res.status).toBe(200);
     if (!res.body.ok) throw new Error("expected ok");
     expect((res.body.data as { orchestrationBackend: string }).orchestrationBackend).toBe("openai");
+  });
+
+  it("GET /llm/config returns the default backend on a fresh install (null config)", async () => {
+    const services = makeServices({
+      llm: {
+        getLLMConfig: vi.fn().mockResolvedValue(null),
+        storeLLMConfig: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(services, { method: "GET", path: "/llm/config" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    // Must surface a concrete value, never null, even when no config exists yet.
+    expect(res.body.data).toEqual({ orchestrationBackend: "openai" });
   });
 });
 

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -138,6 +138,89 @@ describe("routeRequest - MCP", () => {
     );
   });
 
+  it("PUT /mcp/servers/:id HTTP->stdio strips stale url/headers and keeps the new command", async () => {
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { transport: "stdio", command: "node" },
+    });
+    expect(res.status).toBe(200);
+    const persisted = vi.mocked(services.mcp.updateServerAsync).mock
+      .calls[0][1] as unknown as Record<string, unknown>;
+    expect(persisted.transport).toBe("stdio");
+    expect(persisted.command).toBe("node");
+    // Stale HTTP-only fields must NOT survive the transport switch.
+    expect(persisted.url).toBeUndefined();
+    expect(persisted.headers).toBeUndefined();
+  });
+
+  it("PUT /mcp/servers/:id stdio->HTTP strips stale command/args and keeps the new url", async () => {
+    const stdioServer: MCPServerConfig = {
+      id: "srv-1",
+      name: "Test stdio",
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      env: { TOKEN: "secret" },
+      enabled: true,
+    };
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(stdioServer),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { transport: "streamableHttp", url: "https://new.example.com/mcp" },
+    });
+    expect(res.status).toBe(200);
+    const persisted = vi.mocked(svc.mcp.updateServerAsync).mock.calls[0][1] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.transport).toBe("streamableHttp");
+    expect(persisted.url).toBe("https://new.example.com/mcp");
+    // Stale stdio-only fields must NOT survive the transport switch.
+    expect(persisted.command).toBeUndefined();
+    expect(persisted.args).toBeUndefined();
+    expect(persisted.env).toBeUndefined();
+  });
+
+  it("PUT /mcp/servers/:id rejects HTTP->stdio without a command", async () => {
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { transport: "stdio" },
+    });
+    expect(res.status).toBe(400);
+    expect(services.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
+  it("PUT /mcp/servers/:id rejects stdio->HTTP without a url", async () => {
+    const stdioServer: MCPServerConfig = {
+      id: "srv-1",
+      name: "Test stdio",
+      transport: "stdio",
+      command: "node",
+      enabled: true,
+    };
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(stdioServer),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { transport: "streamableHttp" },
+    });
+    expect(res.status).toBe(400);
+    expect(svc.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
   it("PUT /mcp/servers/:id 404s when the server does not exist", async () => {
     const svc = makeServices({
       mcp: {
@@ -251,6 +334,38 @@ describe("routeRequest - LLM", () => {
       method: "POST",
       path: "/llm/config",
       body: { version: 1 },
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("POST /llm/config rejects a malformed v2 body (wrong-typed languageModel)", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config",
+      body: {
+        version: 2,
+        // provider is not a known enum + apiKey missing -> must be rejected
+        languageModel: { provider: "bogus", model: "x" },
+        transcriptionModel: null,
+      },
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("POST /llm/config rejects unknown top-level fields", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config",
+      body: {
+        version: 2,
+        languageModel: null,
+        transcriptionModel: null,
+        bogus: "field",
+      },
     });
     expect(res.status).toBe(400);
     expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { REDACTED } from "../../../shared/cli-bridge/protocol";
+import type { MCPServerConfig } from "../mcp/types";
+import { type BridgeServices, routeRequest } from "./bridge-router";
+
+function makeServices(overrides: Partial<BridgeServices> = {}): BridgeServices {
+  const httpServer: MCPServerConfig = {
+    id: "srv-1",
+    name: "Test HTTP",
+    transport: "streamableHttp",
+    url: "https://example.com/mcp",
+    headers: { Authorization: "Bearer super-secret" },
+    enabled: true,
+  };
+
+  return {
+    mcp: {
+      listAvailableServers: vi.fn().mockResolvedValue([httpServer]),
+      addServerAsync: vi.fn().mockImplementation(async (c: MCPServerConfig) => ({
+        ...c,
+        id: "new-id",
+      })),
+      updateServerAsync: vi.fn().mockResolvedValue(undefined),
+      removeServerAsync: vi.fn().mockResolvedValue(undefined),
+      getServerByIdAsync: vi.fn().mockResolvedValue(httpServer),
+      ...overrides.mcp,
+    },
+    llm: {
+      getLLMConfig: vi.fn().mockResolvedValue({
+        version: 2,
+        languageModel: { provider: "openai", model: "gpt-4", apiKey: "sk-secret-123" },
+        transcriptionModel: null,
+        providerApiKeys: { openai: "sk-secret-123" },
+      }),
+      storeLLMConfig: vi.fn().mockResolvedValue(undefined),
+      ...overrides.llm,
+    },
+    settings: {
+      getSettingsAsync: vi.fn().mockResolvedValue({
+        toolApprovalMode: "ask",
+        openAtLogin: false,
+        hotkeys: { startRecording: "PrintScreen" },
+      }),
+      updateSettingsAsync: vi.fn().mockResolvedValue(undefined),
+      ...overrides.settings,
+    },
+  };
+}
+
+describe("routeRequest - MCP", () => {
+  let services: BridgeServices;
+  beforeEach(() => {
+    services = makeServices();
+  });
+
+  it("GET /mcp/servers lists servers with secrets redacted", async () => {
+    const res = await routeRequest(services, { method: "GET", path: "/mcp/servers" });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    if (!res.body.ok) throw new Error("expected ok");
+    const servers = res.body.data as MCPServerConfig[];
+    expect(servers).toHaveLength(1);
+    // header secret must be redacted, never echoed in full
+    const headers = (servers[0] as { headers?: Record<string, string> }).headers;
+    expect(headers?.Authorization).toBe(REDACTED);
+    expect(JSON.stringify(servers)).not.toContain("super-secret");
+  });
+
+  it("POST /mcp/servers adds a valid stdio server", async () => {
+    const body = {
+      name: "My Server",
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+    };
+    const res = await routeRequest(services, { method: "POST", path: "/mcp/servers", body });
+    expect(res.status).toBe(201);
+    expect(services.mcp.addServerAsync).toHaveBeenCalledOnce();
+    if (!res.body.ok) throw new Error("expected ok");
+    expect((res.body.data as MCPServerConfig).name).toBe("My Server");
+  });
+
+  it("POST /mcp/servers rejects invalid config via zod", async () => {
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers",
+      body: { name: "X", transport: "stdio" }, // missing command
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(services.mcp.addServerAsync).not.toHaveBeenCalled();
+  });
+
+  it("POST /mcp/servers rejects http server with a bad url", async () => {
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers",
+      body: { name: "X", transport: "streamableHttp", url: "not-a-url" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("PUT /mcp/servers/:id updates and merges with existing", async () => {
+    const body = {
+      name: "Renamed",
+      transport: "streamableHttp",
+      url: "https://new.example.com/mcp",
+    };
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body,
+    });
+    expect(res.status).toBe(200);
+    expect(services.mcp.updateServerAsync).toHaveBeenCalledWith(
+      "srv-1",
+      expect.objectContaining({ id: "srv-1", name: "Renamed" }),
+    );
+  });
+
+  it("DELETE /mcp/servers/:id removes the server", async () => {
+    const res = await routeRequest(services, { method: "DELETE", path: "/mcp/servers/srv-1" });
+    expect(res.status).toBe(200);
+    expect(services.mcp.removeServerAsync).toHaveBeenCalledWith("srv-1");
+    if (!res.body.ok) throw new Error("expected ok");
+    expect(res.body.data).toEqual({ id: "srv-1", removed: true });
+  });
+
+  it("POST /mcp/servers/:id/enabled toggles enabled state", async () => {
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/mcp/servers/srv-1/enabled",
+      body: { enabled: false },
+    });
+    expect(res.status).toBe(200);
+    expect(services.mcp.updateServerAsync).toHaveBeenCalledWith(
+      "srv-1",
+      expect.objectContaining({ id: "srv-1", enabled: false }),
+    );
+  });
+
+  it("POST /mcp/servers/:id/enabled 404s on unknown server", async () => {
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "POST",
+      path: "/mcp/servers/does-not-exist/enabled",
+      body: { enabled: true },
+    });
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("decodes url-encoded ids", async () => {
+    await routeRequest(services, {
+      method: "DELETE",
+      path: `/mcp/servers/${encodeURIComponent("id with spaces")}`,
+    });
+    expect(services.mcp.removeServerAsync).toHaveBeenCalledWith("id with spaces");
+  });
+
+  it("returns 405 for an unsupported method", async () => {
+    const res = await routeRequest(services, { method: "PATCH", path: "/mcp/servers" });
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("routeRequest - LLM", () => {
+  it("GET /llm/config redacts apiKeys but reports hasApiKey", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/llm/config" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    const data = res.body.data as {
+      languageModel: { apiKey: string; hasApiKey: boolean };
+      providerApiKeys: Record<string, string>;
+    };
+    expect(data.languageModel.apiKey).toBe(REDACTED);
+    expect(data.languageModel.hasApiKey).toBe(true);
+    expect(data.providerApiKeys.openai).toBe(REDACTED);
+    expect(JSON.stringify(data)).not.toContain("sk-secret-123");
+  });
+
+  it("POST /llm/config stores a v2 config and never returns the raw key", async () => {
+    const services = makeServices();
+    const body = {
+      version: 2,
+      languageModel: { provider: "openai", model: "gpt-4", apiKey: "sk-brand-new" },
+      transcriptionModel: null,
+    };
+    const res = await routeRequest(services, { method: "POST", path: "/llm/config", body });
+    expect(res.status).toBe(200);
+    expect(services.llm.storeLLMConfig).toHaveBeenCalledWith(body);
+    if (!res.body.ok) throw new Error("expected ok");
+    expect(JSON.stringify(res.body.data)).not.toContain("sk-secret-123");
+  });
+
+  it("POST /llm/config rejects non-v2 payloads", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config",
+      body: { version: 1 },
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe("routeRequest - settings", () => {
+  it("GET /settings returns user settings", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/settings" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    expect((res.body.data as { toolApprovalMode: string }).toolApprovalMode).toBe("ask");
+  });
+
+  it("PATCH /settings validates via the shared zod schema", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "PATCH",
+      path: "/settings",
+      body: { toolApprovalMode: "yolo" },
+    });
+    expect(res.status).toBe(200);
+    expect(services.settings.updateSettingsAsync).toHaveBeenCalledWith({
+      toolApprovalMode: "yolo",
+    });
+  });
+
+  it("PATCH /settings rejects an invalid approval mode", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "PATCH",
+      path: "/settings",
+      body: { toolApprovalMode: "nonsense" },
+    });
+    expect(res.status).toBe(400);
+    expect(services.settings.updateSettingsAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe("routeRequest - misc", () => {
+  it("404s an unknown route", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/nope" });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 and the message when a service throws", async () => {
+    const services = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        listAvailableServers: vi.fn().mockRejectedValue(new Error("boom")),
+      },
+    });
+    const res = await routeRequest(services, { method: "GET", path: "/mcp/servers" });
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    if (res.body.ok) throw new Error("expected error");
+    expect(res.body.error).toBe("boom");
+  });
+});

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -119,6 +119,51 @@ describe("routeRequest - MCP", () => {
     );
   });
 
+  it("PUT /mcp/servers/:id merges ONLY provided fields onto existing", async () => {
+    // Patch only the url; the existing name + headers must be preserved.
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { url: "https://patched.example.com/mcp" },
+    });
+    expect(res.status).toBe(200);
+    expect(services.mcp.updateServerAsync).toHaveBeenCalledWith(
+      "srv-1",
+      expect.objectContaining({
+        id: "srv-1",
+        name: "Test HTTP", // preserved from existing
+        transport: "streamableHttp", // preserved
+        url: "https://patched.example.com/mcp", // updated
+      }),
+    );
+  });
+
+  it("PUT /mcp/servers/:id 404s when the server does not exist", async () => {
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "PUT",
+      path: "/mcp/servers/nope",
+      body: { name: "X" },
+    });
+    expect(res.status).toBe(404);
+    expect(svc.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
+  it("PUT /mcp/servers/:id rejects unknown fields via the patch schema", async () => {
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { bogus: "field" },
+    });
+    expect(res.status).toBe(400);
+    expect(services.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
   it("DELETE /mcp/servers/:id removes the server", async () => {
     const res = await routeRequest(services, { method: "DELETE", path: "/mcp/servers/srv-1" });
     expect(res.status).toBe(200);
@@ -209,6 +254,101 @@ describe("routeRequest - LLM", () => {
     });
     expect(res.status).toBe(400);
     expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("GET /llm/config defaults orchestrationBackend to 'openai' when unset", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/llm/config" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    expect((res.body.data as { orchestrationBackend: string }).orchestrationBackend).toBe("openai");
+  });
+});
+
+describe("routeRequest - LLM orchestrator", () => {
+  it("POST /llm/config/orchestrator sets the backend, preserving models + keys", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: { orchestrationBackend: "local-claude" },
+    });
+    expect(res.status).toBe(200);
+    // Persisted config merges the backend onto the existing config (keys intact).
+    expect(services.llm.storeLLMConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 2,
+        orchestrationBackend: "local-claude",
+        languageModel: expect.objectContaining({ provider: "openai" }),
+        providerApiKeys: { openai: "sk-secret-123" },
+      }),
+    );
+    // The response never echoes the raw key.
+    if (!res.body.ok) throw new Error("expected ok");
+    expect(JSON.stringify(res.body.data)).not.toContain("sk-secret-123");
+  });
+
+  it("POST /llm/config/orchestrator creates a minimal v2 config when none exists", async () => {
+    const services = makeServices({
+      llm: {
+        getLLMConfig: vi
+          .fn()
+          // first call: none; second call (after store): the stored value
+          .mockResolvedValueOnce(null)
+          .mockResolvedValue({
+            version: 2,
+            languageModel: null,
+            transcriptionModel: null,
+            orchestrationBackend: "openai",
+          }),
+        storeLLMConfig: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: { orchestrationBackend: "openai" },
+    });
+    expect(res.status).toBe(200);
+    expect(services.llm.storeLLMConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 2,
+        languageModel: null,
+        transcriptionModel: null,
+        orchestrationBackend: "openai",
+      }),
+    );
+  });
+
+  it("POST /llm/config/orchestrator rejects an invalid backend via zod", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: { orchestrationBackend: "gpt5" },
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("POST /llm/config/orchestrator rejects a missing backend", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: {},
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-POST methods on /llm/config/orchestrator", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "GET",
+      path: "/llm/config/orchestrator",
+    });
+    expect(res.status).toBe(405);
   });
 });
 

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,14 +1,16 @@
-import type { LLMConfigV2 } from "@shared/types/llm";
 import {
   type BridgeResponse,
   McpEnabledInputSchema,
   McpServerInputSchema,
+  McpServerPatchSchema,
+  OrchestratorInputSchema,
 } from "../../../shared/cli-bridge/protocol";
 import {
   redactLlmConfig,
   redactMcpServer,
   redactMcpServers,
 } from "../../../shared/cli-bridge/redact";
+import { DEFAULT_ORCHESTRATION_BACKEND, type LLMConfigV2 } from "../../../shared/types/llm";
 import type { PartialUserSettings, UserSettings } from "../../../shared/types/user-settings";
 import { PartialUserSettingsSchema } from "../../../shared/types/user-settings";
 import type { MCPServerConfig } from "../mcp/types";
@@ -71,9 +73,14 @@ export async function routeRequest(
       return await routeMcp(services, req, segments.slice(2));
     }
 
-    // /llm/config
+    // /llm/config and /llm/config/orchestrator
     if (segments[0] === "llm" && segments[1] === "config") {
-      return await routeLlm(services, req);
+      if (segments.length === 2) {
+        return await routeLlm(services, req);
+      }
+      if (segments.length === 3 && segments[2] === "orchestrator") {
+        return await routeLlmOrchestrator(services, req);
+      }
     }
 
     // /settings
@@ -132,13 +139,18 @@ async function routeMcp(
   // /mcp/servers/:id
   if (rest.length === 1) {
     if (req.method === "PUT") {
-      const parsed = McpServerInputSchema.safeParse(req.body);
+      // Merge-update: validate ONLY the provided fields (every field optional)
+      // and overlay them on the existing server. The server must already exist.
+      const parsed = McpServerPatchSchema.safeParse(req.body);
       if (!parsed.success) {
         return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
       }
       const existing = await services.mcp.getServerByIdAsync(serverId);
+      if (!existing) {
+        return fail(`MCP server '${serverId}' not found`, 404);
+      }
       const merged = {
-        ...(existing ?? {}),
+        ...existing,
         ...(parsed.data as object),
         id: serverId,
       } as MCPServerConfig;
@@ -158,7 +170,16 @@ async function routeMcp(
 async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {
   if (req.method === "GET") {
     const config = await services.llm.getLLMConfig();
-    return ok(redactLlmConfig(config));
+    const redacted = redactLlmConfig(config);
+    // Surface the effective orchestration backend so `config get` always shows a
+    // concrete value even when the field has never been set (defaults to openai).
+    if (redacted && typeof redacted === "object") {
+      const r = redacted as Record<string, unknown>;
+      if (r.orchestrationBackend === undefined) {
+        r.orchestrationBackend = DEFAULT_ORCHESTRATION_BACKEND;
+      }
+    }
+    return ok(redacted);
   }
   if (req.method === "POST") {
     if (!req.body || typeof req.body !== "object") {
@@ -173,6 +194,40 @@ async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<B
     return ok(redactLlmConfig(stored));
   }
   return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+/**
+ * Set only the orchestration backend on the current LLMConfigV2.
+ *
+ * Merges server-side so the existing models + api keys are preserved (the CLI
+ * never sends or echoes secrets). When no config exists yet a minimal V2 config
+ * is created with the chosen backend.
+ */
+async function routeLlmOrchestrator(
+  services: BridgeServices,
+  req: BridgeRequest,
+): Promise<BridgeResult> {
+  if (req.method !== "POST") {
+    return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+  }
+  const parsed = OrchestratorInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(`Invalid orchestrator payload: ${formatZodError(parsed.error)}`);
+  }
+
+  const existing = await services.llm.getLLMConfig();
+  const merged: LLMConfigV2 = existing
+    ? { ...existing, orchestrationBackend: parsed.data.orchestrationBackend }
+    : {
+        version: 2,
+        languageModel: null,
+        transcriptionModel: null,
+        orchestrationBackend: parsed.data.orchestrationBackend,
+      };
+
+  await services.llm.storeLLMConfig(merged);
+  const stored = await services.llm.getLLMConfig();
+  return ok(redactLlmConfig(stored));
 }
 
 async function routeSettings(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,7 +1,9 @@
 import {
   type BridgeResponse,
+  LLMConfigV2Schema,
   McpEnabledInputSchema,
   McpServerInputSchema,
+  type McpServerPatch,
   McpServerPatchSchema,
   OrchestratorInputSchema,
 } from "../../../shared/cli-bridge/protocol";
@@ -149,11 +151,11 @@ async function routeMcp(
       if (!existing) {
         return fail(`MCP server '${serverId}' not found`, 404);
       }
-      const merged = {
-        ...existing,
-        ...(parsed.data as object),
-        id: serverId,
-      } as MCPServerConfig;
+      const mergeResult = mergeMcpPatch(existing, parsed.data);
+      if (!mergeResult.ok) {
+        return fail(mergeResult.error);
+      }
+      const merged = mergeResult.value;
       await services.mcp.updateServerAsync(serverId, merged);
       return ok(redactMcpServer(merged));
     }
@@ -182,14 +184,11 @@ async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<B
     return ok(redacted);
   }
   if (req.method === "POST") {
-    if (!req.body || typeof req.body !== "object") {
-      return fail("Invalid LLM config payload");
+    const parsed = LLMConfigV2Schema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid LLM config: ${formatZodError(parsed.error)}`);
     }
-    const config = req.body as LLMConfigV2;
-    if (config.version !== 2) {
-      return fail("LLM config must be version 2");
-    }
-    await services.llm.storeLLMConfig(config);
+    await services.llm.storeLLMConfig(parsed.data as LLMConfigV2);
     const stored = await services.llm.getLLMConfig();
     return ok(redactLlmConfig(stored));
   }
@@ -243,6 +242,59 @@ async function routeSettings(services: BridgeServices, req: BridgeRequest): Prom
     return ok(await services.settings.getSettingsAsync());
   }
   return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+/** Fields that belong ONLY to an HTTP (streamableHttp) server config. */
+const HTTP_ONLY_FIELDS = ["url", "headers", "version", "timeoutMs"] as const;
+/** Fields that belong ONLY to a stdio server config. */
+const STDIO_ONLY_FIELDS = ["command", "args", "env", "cwd", "stderr"] as const;
+
+type MergeResult = { ok: true; value: MCPServerConfig } | { ok: false; error: string };
+
+/**
+ * Merge a validated patch onto an existing MCP server config.
+ *
+ * When the patch CHANGES the transport, the config is normalized to the target
+ * transport's discriminated-union member: fields that belong only to the old
+ * transport are stripped so no stale `url`/`headers` (or `command`/`args`/...)
+ * survive a switch, and the new transport's required field (`url` for HTTP,
+ * `command` for stdio) must be supplied in the same patch (or already present
+ * on the existing config) — otherwise the update is rejected. When the
+ * transport is unchanged, fields are overlaid as-is.
+ */
+function mergeMcpPatch(existing: MCPServerConfig, patch: McpServerPatch): MergeResult {
+  const targetTransport = patch.transport ?? existing.transport;
+  const transportChanged = patch.transport !== undefined && patch.transport !== existing.transport;
+
+  const merged: Record<string, unknown> = {
+    ...(existing as unknown as Record<string, unknown>),
+    ...(patch as Record<string, unknown>),
+    id: existing.id,
+  };
+
+  if (transportChanged) {
+    // Strip the OTHER transport's fields so no stale config survives the switch.
+    const staleFields = targetTransport === "streamableHttp" ? STDIO_ONLY_FIELDS : HTTP_ONLY_FIELDS;
+    for (const field of staleFields) {
+      delete merged[field];
+    }
+
+    // Require the new transport's mandatory field (from the patch or existing).
+    if (targetTransport === "streamableHttp" && typeof merged.url !== "string") {
+      return {
+        ok: false,
+        error: "Changing transport to http requires --url",
+      };
+    }
+    if (targetTransport === "stdio" && typeof merged.command !== "string") {
+      return {
+        ok: false,
+        error: "Changing transport to stdio requires --command",
+      };
+    }
+  }
+
+  return { ok: true, value: merged as unknown as MCPServerConfig };
 }
 
 function formatZodError(error: {

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,0 +1,202 @@
+import type { LLMConfigV2 } from "@shared/types/llm";
+import {
+  type BridgeResponse,
+  McpEnabledInputSchema,
+  McpServerInputSchema,
+} from "../../../shared/cli-bridge/protocol";
+import {
+  redactLlmConfig,
+  redactMcpServer,
+  redactMcpServers,
+} from "../../../shared/cli-bridge/redact";
+import type { PartialUserSettings, UserSettings } from "../../../shared/types/user-settings";
+import { PartialUserSettingsSchema } from "../../../shared/types/user-settings";
+import type { MCPServerConfig } from "../mcp/types";
+
+/**
+ * Service surface the router depends on. The real bridge wires this to the
+ * existing singletons (MCPServerManager, LlmStorage, UserSettingsStorage); tests
+ * pass mocks. This keeps the routing logic free of Electron and easily testable.
+ */
+export interface BridgeServices {
+  mcp: {
+    listAvailableServers(): Promise<MCPServerConfig[]>;
+    addServerAsync(config: MCPServerConfig): Promise<MCPServerConfig>;
+    updateServerAsync(serverId: string, config: MCPServerConfig): Promise<void>;
+    removeServerAsync(serverId: string): Promise<void>;
+    getServerByIdAsync(serverId: string): Promise<MCPServerConfig | undefined>;
+  };
+  llm: {
+    getLLMConfig(): Promise<LLMConfigV2 | null>;
+    storeLLMConfig(config: LLMConfigV2): Promise<void>;
+  };
+  settings: {
+    getSettingsAsync(): Promise<UserSettings>;
+    updateSettingsAsync(patch: PartialUserSettings): Promise<void>;
+  };
+}
+
+export interface BridgeRequest {
+  method: string;
+  /** Path WITHOUT query string, e.g. "/mcp/servers/abc". */
+  path: string;
+  /** Parsed JSON body (already validated as JSON upstream). */
+  body?: unknown;
+}
+
+export interface BridgeResult {
+  status: number;
+  body: BridgeResponse;
+}
+
+const ok = <T>(data: T, status = 200): BridgeResult => ({ status, body: { ok: true, data } });
+const fail = (error: string, status = 400): BridgeResult => ({
+  status,
+  body: { ok: false, error },
+});
+
+/**
+ * Route a single parsed request to the backing services and produce a JSON
+ * envelope. Auth is handled by the HTTP layer BEFORE this is ever called.
+ */
+export async function routeRequest(
+  services: BridgeServices,
+  req: BridgeRequest,
+): Promise<BridgeResult> {
+  try {
+    const segments = req.path.split("/").filter(Boolean);
+
+    // /mcp/...
+    if (segments[0] === "mcp" && segments[1] === "servers") {
+      return await routeMcp(services, req, segments.slice(2));
+    }
+
+    // /llm/config
+    if (segments[0] === "llm" && segments[1] === "config") {
+      return await routeLlm(services, req);
+    }
+
+    // /settings
+    if (segments[0] === "settings" && segments.length === 1) {
+      return await routeSettings(services, req);
+    }
+
+    return fail(`Unknown route: ${req.method} ${req.path}`, 404);
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err), 500);
+  }
+}
+
+async function routeMcp(
+  services: BridgeServices,
+  req: BridgeRequest,
+  rest: string[],
+): Promise<BridgeResult> {
+  // /mcp/servers
+  if (rest.length === 0) {
+    if (req.method === "GET") {
+      const servers = await services.mcp.listAvailableServers();
+      return ok(redactMcpServers(servers));
+    }
+    if (req.method === "POST") {
+      const parsed = McpServerInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
+      }
+      const created = await services.mcp.addServerAsync(parsed.data as MCPServerConfig);
+      return ok(redactMcpServer(created), 201);
+    }
+    return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+  }
+
+  const serverId = decodeURIComponent(rest[0]);
+
+  // /mcp/servers/:id/enabled
+  if (rest.length === 2 && rest[1] === "enabled") {
+    if (req.method !== "POST") {
+      return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+    }
+    const parsed = McpEnabledInputSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid payload: ${formatZodError(parsed.error)}`);
+    }
+    const existing = await services.mcp.getServerByIdAsync(serverId);
+    if (!existing) {
+      return fail(`MCP server '${serverId}' not found`, 404);
+    }
+    const updated = { ...existing, enabled: parsed.data.enabled } as MCPServerConfig;
+    await services.mcp.updateServerAsync(serverId, updated);
+    return ok(redactMcpServer(updated));
+  }
+
+  // /mcp/servers/:id
+  if (rest.length === 1) {
+    if (req.method === "PUT") {
+      const parsed = McpServerInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
+      }
+      const existing = await services.mcp.getServerByIdAsync(serverId);
+      const merged = {
+        ...(existing ?? {}),
+        ...(parsed.data as object),
+        id: serverId,
+      } as MCPServerConfig;
+      await services.mcp.updateServerAsync(serverId, merged);
+      return ok(redactMcpServer(merged));
+    }
+    if (req.method === "DELETE") {
+      await services.mcp.removeServerAsync(serverId);
+      return ok({ id: serverId, removed: true });
+    }
+    return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+  }
+
+  return fail(`Unknown route: ${req.method} ${req.path}`, 404);
+}
+
+async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {
+  if (req.method === "GET") {
+    const config = await services.llm.getLLMConfig();
+    return ok(redactLlmConfig(config));
+  }
+  if (req.method === "POST") {
+    if (!req.body || typeof req.body !== "object") {
+      return fail("Invalid LLM config payload");
+    }
+    const config = req.body as LLMConfigV2;
+    if (config.version !== 2) {
+      return fail("LLM config must be version 2");
+    }
+    await services.llm.storeLLMConfig(config);
+    const stored = await services.llm.getLLMConfig();
+    return ok(redactLlmConfig(stored));
+  }
+  return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+async function routeSettings(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {
+  if (req.method === "GET") {
+    return ok(await services.settings.getSettingsAsync());
+  }
+  if (req.method === "PATCH") {
+    const parsed = PartialUserSettingsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid settings patch: ${formatZodError(parsed.error)}`);
+    }
+    await services.settings.updateSettingsAsync(parsed.data);
+    return ok(await services.settings.getSettingsAsync());
+  }
+  return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+function formatZodError(error: {
+  issues: Array<{ path: PropertyKey[]; message: string }>;
+}): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -133,6 +133,10 @@ async function routeMcp(
     if (!existing) {
       return fail(`MCP server '${serverId}' not found`, 404);
     }
+    const builtinError = rejectBuiltinMutation(existing, "modified");
+    if (builtinError) {
+      return builtinError;
+    }
     const updated = { ...existing, enabled: parsed.data.enabled } as MCPServerConfig;
     await services.mcp.updateServerAsync(serverId, updated);
     return ok(redactMcpServer(updated));
@@ -151,6 +155,10 @@ async function routeMcp(
       if (!existing) {
         return fail(`MCP server '${serverId}' not found`, 404);
       }
+      const builtinError = rejectBuiltinMutation(existing, "modified");
+      if (builtinError) {
+        return builtinError;
+      }
       const mergeResult = mergeMcpPatch(existing, parsed.data);
       if (!mergeResult.ok) {
         return fail(mergeResult.error);
@@ -160,6 +168,15 @@ async function routeMcp(
       return ok(redactMcpServer(merged));
     }
     if (req.method === "DELETE") {
+      // Built-in servers are not persisted in user storage, so removeServerAsync
+      // would no-op while the CLI reports success. Reject explicitly instead.
+      const existing = await services.mcp.getServerByIdAsync(serverId);
+      if (existing) {
+        const builtinError = rejectBuiltinMutation(existing, "removed");
+        if (builtinError) {
+          return builtinError;
+        }
+      }
       await services.mcp.removeServerAsync(serverId);
       return ok({ id: serverId, removed: true });
     }
@@ -175,13 +192,17 @@ async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<B
     const redacted = redactLlmConfig(config);
     // Surface the effective orchestration backend so `config get` always shows a
     // concrete value even when the field has never been set (defaults to openai).
+    // On a fresh install no LLM config exists yet (getLLMConfig() -> null, so the
+    // redacted value is null too); return a minimal object carrying the default
+    // rather than printing `null`.
     if (redacted && typeof redacted === "object") {
       const r = redacted as Record<string, unknown>;
       if (r.orchestrationBackend === undefined) {
         r.orchestrationBackend = DEFAULT_ORCHESTRATION_BACKEND;
       }
+      return ok(redacted);
     }
-    return ok(redacted);
+    return ok({ orchestrationBackend: DEFAULT_ORCHESTRATION_BACKEND });
   }
   if (req.method === "POST") {
     const parsed = LLMConfigV2Schema.safeParse(req.body);
@@ -242,6 +263,28 @@ async function routeSettings(services: BridgeServices, req: BridgeRequest): Prom
     return ok(await services.settings.getSettingsAsync());
   }
   return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+/**
+ * Reject any mutation targeting a built-in (internal) MCP server.
+ *
+ * Built-in servers are always-on, in-memory servers that are NOT persisted in
+ * user storage. Without this guard, enable/update/remove would silently no-op
+ * (or write a dead shadow copy into storage that is never surfaced) while the
+ * CLI still printed a success message. Returns a 400 BridgeResult to surface
+ * the rejection, or `undefined` when the config is a normal user/preset server.
+ *
+ * Preset servers are NOT built-in (they don't carry `builtin: true`), so this
+ * guard does not interfere with enabling/configuring them.
+ */
+function rejectBuiltinMutation(
+  existing: MCPServerConfig,
+  verb: "modified" | "removed",
+): BridgeResult | undefined {
+  if (existing.builtin === true) {
+    return fail(`'${existing.name}' is a built-in server and cannot be ${verb}.`);
+  }
+  return undefined;
 }
 
 /** Fields that belong ONLY to an HTTP (streamableHttp) server config. */

--- a/src/backend/services/cli-bridge/cli-bridge-server.test.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.test.ts
@@ -1,0 +1,140 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CliBridgeTokenFileSchema } from "../../../shared/cli-bridge/protocol";
+import type { BridgeServices } from "./bridge-router";
+
+// A throwaway userData dir so the token file lands somewhere harmless.
+// vi.mock factories are hoisted above imports, so compute the path via
+// vi.hoisted so the electron mock can reference it.
+const { TEST_USER_DATA } = vi.hoisted(() => {
+  const os = require("node:os") as typeof import("node:os");
+  const path = require("node:path") as typeof import("node:path");
+  return { TEST_USER_DATA: path.join(os.tmpdir(), `yakshaver-bridge-test-${process.pid}`) };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue(TEST_USER_DATA),
+    getVersion: vi.fn().mockReturnValue("0.0.0-test"),
+  },
+}));
+
+// Stub the storage singletons the default services would reach for. We pass
+// explicit services into getInstance() so these are only a safety net.
+vi.mock("../storage/llm-storage", () => ({ LlmStorage: { getInstance: () => ({}) } }));
+vi.mock("../storage/user-settings-storage", () => ({
+  UserSettingsStorage: { getInstance: () => ({}) },
+}));
+vi.mock("../mcp/mcp-server-manager", () => ({ MCPServerManager: {} }));
+
+import { CliBridgeServer } from "./cli-bridge-server";
+
+function makeServices(): BridgeServices {
+  return {
+    mcp: {
+      listAvailableServers: vi.fn().mockResolvedValue([{ id: "a", name: "A", transport: "stdio" }]),
+      addServerAsync: vi.fn(),
+      updateServerAsync: vi.fn(),
+      removeServerAsync: vi.fn(),
+      getServerByIdAsync: vi.fn(),
+    },
+    llm: { getLLMConfig: vi.fn().mockResolvedValue(null), storeLLMConfig: vi.fn() },
+    settings: {
+      getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: "ask" }),
+      updateSettingsAsync: vi.fn(),
+    },
+  };
+}
+
+async function readToken(): Promise<{ port: number; token: string }> {
+  const filePath = join(TEST_USER_DATA, "yakshaver-tokens", "cli-bridge.json");
+  const raw = JSON.parse(await fs.readFile(filePath, "utf8"));
+  return CliBridgeTokenFileSchema.parse(raw);
+}
+
+describe("CliBridgeServer", () => {
+  let server: CliBridgeServer;
+
+  beforeEach(() => {
+    // Force a fresh singleton each test.
+    // @ts-expect-error reset private static for isolation
+    CliBridgeServer.instance = null;
+    server = CliBridgeServer.getInstance(makeServices());
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    await fs.rm(TEST_USER_DATA, { recursive: true, force: true });
+  });
+
+  it("binds to 127.0.0.1 and writes a token file with port + token", async () => {
+    const started = await server.start();
+    expect(started).toBe(true);
+
+    const { port, token } = await readToken();
+    expect(port).toBeGreaterThan(0);
+    expect(token).toMatch(/^[0-9a-f]{64}$/); // 32 random bytes hex
+    expect(server.getPort()).toBe(port);
+  });
+
+  it("rejects requests without a bearer token (401)", async () => {
+    await server.start();
+    const { port } = await readToken();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("rejects requests with the wrong token (401)", async () => {
+    await server.start();
+    const { port } = await readToken();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`, {
+      headers: { Authorization: "Bearer not-the-real-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("serves authorized requests through the router", async () => {
+    await server.start();
+    const { port, token } = await readToken();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("rejects an oversized body", async () => {
+    await server.start();
+    const { port, token } = await readToken();
+    const big = "x".repeat(300 * 1024);
+    const res = await fetch(`http://127.0.0.1:${port}/mcp/servers`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ data: big }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("does not start when disabled via env", async () => {
+    process.env.YAKSHAVER_DISABLE_CLI_BRIDGE = "1";
+    try {
+      const started = await server.start();
+      expect(started).toBe(false);
+      expect(server.getPort()).toBeNull();
+    } finally {
+      delete process.env.YAKSHAVER_DISABLE_CLI_BRIDGE;
+    }
+  });
+
+  it("removes the token file on stop", async () => {
+    await server.start();
+    const filePath = join(TEST_USER_DATA, "yakshaver-tokens", "cli-bridge.json");
+    await server.stop();
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+});

--- a/src/backend/services/cli-bridge/cli-bridge-server.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.ts
@@ -287,7 +287,19 @@ function createDefaultServices(): BridgeServices {
     },
     settings: {
       getSettingsAsync: () => UserSettingsStorage.getInstance().getSettingsAsync(),
-      updateSettingsAsync: (patch) => UserSettingsStorage.getInstance().updateSettingsAsync(patch),
+      async updateSettingsAsync(patch) {
+        await UserSettingsStorage.getInstance().updateSettingsAsync(patch);
+        // Apply the same OS-level side effects the UI/IPC path applies, so a CLI
+        // settings change takes effect this session (not only after restart).
+        // Mirrors UserSettingsIPCHandlers.handleOpenAtLoginUpdate.
+        if (patch.openAtLogin !== undefined) {
+          try {
+            app.setLoginItemSettings({ openAtLogin: patch.openAtLogin, openAsHidden: false });
+          } catch (err) {
+            console.warn("[CliBridge] Failed to apply openAtLogin side effect:", err);
+          }
+        }
+      },
     },
   };
 }

--- a/src/backend/services/cli-bridge/cli-bridge-server.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.ts
@@ -1,0 +1,293 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { dirname, join } from "node:path";
+import { app } from "electron";
+import {
+  CLI_BRIDGE_DEFAULT_PORT,
+  CLI_BRIDGE_DISABLE_ENV,
+  CLI_BRIDGE_HOST,
+  CLI_BRIDGE_TOKEN_DIR,
+  CLI_BRIDGE_TOKEN_FILE,
+  type CliBridgeTokenFile,
+} from "../../../shared/cli-bridge/protocol";
+import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { LlmStorage } from "../storage/llm-storage";
+import { UserSettingsStorage } from "../storage/user-settings-storage";
+import { type BridgeServices, routeRequest } from "./bridge-router";
+
+const MAX_BODY_BYTES = 256 * 1024; // 256 KB is plenty for config payloads.
+
+/**
+ * Localhost-only HTTP bridge that lets the `yakshaver` CLI read and mutate the
+ * desktop app's MCP/LLM/settings configuration.
+ *
+ * Security model:
+ *  - Binds to 127.0.0.1 ONLY (never 0.0.0.0), so it is unreachable off-box.
+ *  - A random 256-bit token is generated at startup and written, alongside the
+ *    chosen port, to `userData/yakshaver-tokens/cli-bridge.json` (same-user
+ *    readable). Every request must present `Authorization: Bearer <token>`.
+ *  - Secrets (api keys, header/env values) are redacted in every response.
+ *  - Opt-out via the YAKSHAVER_DISABLE_CLI_BRIDGE env var.
+ */
+export class CliBridgeServer {
+  private static instance: CliBridgeServer | null = null;
+
+  private server: Server | null = null;
+  private token: string | null = null;
+  private port: number | null = null;
+
+  private constructor(private readonly services: BridgeServices) {}
+
+  static getInstance(services?: BridgeServices): CliBridgeServer {
+    if (!CliBridgeServer.instance) {
+      CliBridgeServer.instance = new CliBridgeServer(services ?? createDefaultServices());
+    }
+    return CliBridgeServer.instance;
+  }
+
+  /** Resolve the token file path the same way the secure storage does. */
+  private static getTokenFilePath(): string {
+    return join(app.getPath("userData"), CLI_BRIDGE_TOKEN_DIR, CLI_BRIDGE_TOKEN_FILE);
+  }
+
+  /**
+   * Start the bridge. Idempotent and best-effort: any failure is logged but
+   * never crashes app startup. Returns true if the server is now listening.
+   */
+  async start(): Promise<boolean> {
+    if (process.env[CLI_BRIDGE_DISABLE_ENV]) {
+      console.log("[CliBridge] Disabled via env; not starting.");
+      return false;
+    }
+    if (this.server) {
+      return true;
+    }
+
+    this.token = randomBytes(32).toString("hex");
+
+    try {
+      this.port = await this.listen(CLI_BRIDGE_DEFAULT_PORT);
+    } catch (err) {
+      console.warn(
+        `[CliBridge] Default port ${CLI_BRIDGE_DEFAULT_PORT} unavailable, trying ephemeral port:`,
+        err,
+      );
+      try {
+        this.port = await this.listen(0); // OS-assigned ephemeral port.
+      } catch (err2) {
+        console.error("[CliBridge] Failed to bind localhost bridge:", err2);
+        this.server = null;
+        return false;
+      }
+    }
+
+    try {
+      await this.writeTokenFile();
+    } catch (err) {
+      console.error("[CliBridge] Failed to write token file:", err);
+      await this.stop();
+      return false;
+    }
+
+    console.log(`[CliBridge] Listening on http://${CLI_BRIDGE_HOST}:${this.port}`);
+    return true;
+  }
+
+  private listen(port: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const server = createServer((req, res) => {
+        this.handleRequest(req, res).catch((err) => {
+          console.error("[CliBridge] Unhandled request error:", err);
+          this.sendJson(res, 500, { ok: false, error: "Internal error" });
+        });
+      });
+
+      server.on("error", reject);
+      // Bind to localhost ONLY. Never 0.0.0.0.
+      server.listen(port, CLI_BRIDGE_HOST, () => {
+        server.removeListener("error", reject);
+        this.server = server;
+        const address = server.address();
+        const boundPort = typeof address === "object" && address ? address.port : port;
+        resolve(boundPort);
+      });
+    });
+  }
+
+  private async writeTokenFile(): Promise<void> {
+    const filePath = CliBridgeServer.getTokenFilePath();
+    await fs.mkdir(dirname(filePath), { recursive: true });
+
+    const payload: CliBridgeTokenFile = {
+      port: this.port ?? CLI_BRIDGE_DEFAULT_PORT,
+      token: this.token ?? "",
+      startedAt: new Date().toISOString(),
+      version: safeAppVersion(),
+    };
+
+    // Owner-only permissions where the platform honours them (no-op on Windows).
+    await fs.writeFile(filePath, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!this.isAuthorized(req)) {
+      this.sendJson(res, 401, { ok: false, error: "Unauthorized" });
+      return;
+    }
+
+    const url = new URL(req.url ?? "/", `http://${CLI_BRIDGE_HOST}`);
+    const path = url.pathname;
+    const method = req.method ?? "GET";
+
+    let body: unknown;
+    try {
+      body = await this.readJsonBody(req);
+    } catch (err) {
+      this.sendJson(res, 400, {
+        ok: false,
+        error: err instanceof Error ? err.message : "Invalid JSON body",
+      });
+      return;
+    }
+
+    const result = await routeRequest(this.services, { method, path, body });
+    this.sendJson(res, result.status, result.body);
+  }
+
+  private isAuthorized(req: IncomingMessage): boolean {
+    if (!this.token) return false;
+    const header = req.headers.authorization ?? "";
+    const prefix = "Bearer ";
+    if (!header.startsWith(prefix)) return false;
+    const provided = header.slice(prefix.length);
+    return safeStringEquals(provided, this.token);
+  }
+
+  private readJsonBody(req: IncomingMessage): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      let settled = false;
+
+      const settleReject = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        // Drain remaining data without buffering so the socket stays usable and
+        // the handler can still write an error response (don't destroy it).
+        req.removeAllListeners("data");
+        req.on("data", () => {});
+        reject(err);
+      };
+
+      req.on("data", (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > MAX_BODY_BYTES) {
+          settleReject(new Error("Request body too large"));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      req.on("end", () => {
+        if (settled) return;
+        settled = true;
+        if (chunks.length === 0) {
+          resolve(undefined);
+          return;
+        }
+        const raw = Buffer.concat(chunks).toString("utf8").trim();
+        if (!raw) {
+          resolve(undefined);
+          return;
+        }
+        try {
+          resolve(JSON.parse(raw));
+        } catch {
+          reject(new Error("Invalid JSON body"));
+        }
+      });
+      req.on("error", (err) => settleReject(err instanceof Error ? err : new Error(String(err))));
+    });
+  }
+
+  private sendJson(res: ServerResponse, status: number, body: unknown): void {
+    const payload = JSON.stringify(body);
+    res.writeHead(status, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload),
+    });
+    res.end(payload);
+  }
+
+  /** Stop the server and remove the token file. Safe to call multiple times. */
+  async stop(): Promise<void> {
+    const server = this.server;
+    this.server = null;
+    this.token = null;
+
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+
+    try {
+      await fs.unlink(CliBridgeServer.getTokenFilePath());
+    } catch {
+      // Already gone — ignore.
+    }
+  }
+
+  /** Test/diagnostic helper. */
+  getPort(): number | null {
+    return this.port;
+  }
+}
+
+function safeStringEquals(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+function safeAppVersion(): string | undefined {
+  try {
+    return app.getVersion();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Wire the router to the real app singletons. */
+function createDefaultServices(): BridgeServices {
+  return {
+    mcp: {
+      async listAvailableServers() {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.listAvailableServers();
+      },
+      async addServerAsync(config) {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.addServerAsync(config);
+      },
+      async updateServerAsync(serverId, config) {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.updateServerAsync(serverId, config);
+      },
+      async removeServerAsync(serverId) {
+        const manager = await MCPServerManager.getInstanceAsync();
+        return manager.removeServerAsync(serverId);
+      },
+      async getServerByIdAsync(serverId) {
+        return MCPServerManager.getServerConfigByIdAsync(serverId);
+      },
+    },
+    llm: {
+      getLLMConfig: () => LlmStorage.getInstance().getLLMConfig(),
+      storeLLMConfig: (config) => LlmStorage.getInstance().storeLLMConfig(config),
+    },
+    settings: {
+      getSettingsAsync: () => UserSettingsStorage.getInstance().getSettingsAsync(),
+      updateSettingsAsync: (patch) => UserSettingsStorage.getInstance().updateSettingsAsync(patch),
+    },
+  };
+}

--- a/src/backend/services/mcp/backlog-orchestrator.ts
+++ b/src/backend/services/mcp/backlog-orchestrator.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+import type { MCPStep } from "../../../shared/types/mcp";
+import type { VideoUploadResult } from "../auth/types";
+
+export type MCPTerminationReason =
+  | "stop"
+  | "length"
+  | "content-filter"
+  | "cancelled"
+  | "max-iterations"
+  | "unknown";
+
+export interface BacklogArtifact {
+  /** e.g. "issue", "work_item", "ticket", "comment", "pull_request". */
+  type: string;
+  /** The concrete identifier or URL evidencing the created/updated item. */
+  idOrUrl: string;
+}
+
+export interface MCPLoopResult {
+  /** The model's final text output — the drafted work item, or a message explaining why it stopped. */
+  text: string;
+  /**
+   * True only when a backlog item was actually created/updated, decided from the TOOL RESULTS
+   * (not the model's narration). A graceful `stop` with only internal tools, no tools, or an
+   * errored mutation means nothing was filed.
+   */
+  backlogActionSucceeded: boolean;
+  /** The concrete created/updated artifacts the judge found (issue ids/URLs), if any. */
+  artifacts: BacklogArtifact[];
+  /** Why the loop ended — distinguishes a clean finish from hitting a safety cap. */
+  terminationReason: MCPTerminationReason;
+}
+
+/** One executed tool call and (a truncated view of) its result — the ground truth the judge reasons over. */
+export interface ToolActivity {
+  toolName: string;
+  ok: boolean;
+  resultText: string;
+}
+
+/**
+ * Options the backlog-creation step passes to whichever orchestrator backend drives it.
+ * Identical to what `MCPOrchestrator.manualLoopAsync` accepts so the call site is backend-agnostic.
+ */
+export interface ManualLoopOptions {
+  projectMetaData?: string;
+  desktopAgentProjectPrompt?: string;
+  maxToolIterations?: number; // safety cap to avoid infinite loops
+  videoFilePath?: string; // local video file path for screenshot capture
+  serverFilter?: string[]; // if provided, only include tools from these server IDs
+  shaveId?: string; // identifies the current shave for per-shave auto-approve
+  onStep?: (step: MCPStep) => void;
+}
+
+/**
+ * The seam the EXECUTING_TASK stage talks to. Both the in-process `MCPOrchestrator` (OpenAI loop)
+ * and the `LocalClaudeOrchestrator` (headless `claude -p`) implement this, so the call site can
+ * pick a backend without caring how the work gets done — both return the same `MCPLoopResult`,
+ * whose `backlogActionSucceeded` gates COMPLETE vs FAIL.
+ */
+export interface IBacklogOrchestrator {
+  manualLoopAsync(
+    videoTranscription: string,
+    videoUploadResult?: VideoUploadResult,
+    options?: ManualLoopOptions,
+  ): Promise<MCPLoopResult>;
+}
+
+/**
+ * Structured verdict from the outcome judge. Every field is REQUIRED — no `.optional()` / `.default()`.
+ * OpenAI strict structured outputs reject a schema whose `required` omits any property, so a
+ * `.default()` here makes the field optional and breaks the real `generateObject` call at runtime
+ * ("Invalid schema for response_format … Missing 'artifacts'"). That only surfaces against a live
+ * model, never in tests that stub generateObject — so keep this schema strict-compatible.
+ */
+export const BacklogOutcomeSchema = z.object({
+  achieved: z.boolean(),
+  artifacts: z.array(z.object({ type: z.string(), idOrUrl: z.string() })),
+  reasoning: z.string(),
+});
+
+/** The minimal LLM capability the outcome judge needs — kept narrow so it's trivial to stub in tests. */
+export interface OutcomeJudgeProvider {
+  generateObject(
+    prompt: string,
+    schema: typeof BacklogOutcomeSchema,
+    systemPrompt?: string,
+  ): Promise<{ achieved: boolean; artifacts: BacklogArtifact[]; reasoning?: string }>;
+}
+
+/**
+ * Decides whether the run ACTUALLY created/updated a backlog item, judging from the tool
+ * RESULTS (ground truth) rather than a tool-name heuristic or the model's own claims (#833).
+ *
+ * Shared by both orchestrator backends (OpenAI loop + local Claude Code) so success is judged
+ * identically regardless of who drove the tools.
+ *
+ * Short-circuits to "not achieved" when no tool call succeeded (the common signed-out case),
+ * so the extra LLM call only happens when something plausibly did get filed. Fails CLOSED
+ * (not achieved) if the judge is unavailable or errors — a false success is the costly mistake.
+ */
+export async function judgeBacklogOutcome(
+  provider: OutcomeJudgeProvider | null | undefined,
+  goal: string | undefined,
+  transcript: string,
+  toolActivity: ToolActivity[],
+  finalText: string,
+): Promise<{ achieved: boolean; artifacts: BacklogArtifact[] }> {
+  const succeeded = toolActivity.filter((t) => t.ok);
+  if (succeeded.length === 0) {
+    console.log("[judgeBacklogOutcome] no successful tool calls -> not achieved");
+    return { achieved: false, artifacts: [] };
+  }
+
+  if (!provider) {
+    console.warn("[judgeBacklogOutcome] outcome judge unavailable (no LLM) -> not achieved");
+    return { achieved: false, artifacts: [] };
+  }
+
+  const judgeSystemPrompt =
+    "You are a strict verifier deciding whether an automated agent ACTUALLY created or updated " +
+    "a backlog work item (e.g. a GitHub issue, an Azure DevOps work item, or a Jira ticket) as " +
+    "instructed. Judge ONLY from the tool results below (ground truth) — NEVER trust the agent's " +
+    "own final message, which may claim success it did not achieve. Set achieved=true only when a " +
+    "non-errored tool result contains concrete evidence of a created or updated item: an id, a " +
+    "number, or a URL. Put that evidence in artifacts. If no mutating tool produced such evidence — " +
+    "nothing ran, the call errored, or only read/internal tools ran — set achieved=false. When " +
+    "uncertain, set achieved=false.";
+
+  const judgePrompt = [
+    `TASK INSTRUCTIONS GIVEN TO THE AGENT:\n${goal?.slice(0, 4000) || "(create a backlog work item describing the user's request)"}`,
+    `USER REQUEST (video transcript):\n${transcript.slice(0, 2000)}`,
+    `TOOL CALLS AND THEIR RESULTS (ground truth — decide from these):\n${JSON.stringify(toolActivity)}`,
+    `AGENT FINAL MESSAGE (do NOT trust this for success):\n${finalText.slice(0, 2000)}`,
+  ].join("\n\n---\n\n");
+
+  try {
+    const verdict = await provider.generateObject(
+      judgePrompt,
+      BacklogOutcomeSchema,
+      judgeSystemPrompt,
+    );
+    // Enforce the contract in CODE, not just the prompt: a verdict is only trusted as success
+    // if it cites concrete evidence. A model that answers achieved=true but populates no
+    // artifacts is treated as not-achieved (conservative — a false success is the costly error).
+    const achieved = verdict.achieved && verdict.artifacts.length > 0;
+    console.log("[judgeBacklogOutcome] outcome judged:", {
+      achieved,
+      modelClaimedAchieved: verdict.achieved,
+      artifacts: verdict.artifacts,
+      tools: toolActivity.map((t) => `${t.toolName}${t.ok ? "" : "(errored)"}`),
+    });
+    return { achieved, artifacts: verdict.artifacts };
+  } catch (error) {
+    // Fail CLOSED: if the judge itself errors we cannot confirm a filing, so report
+    // not-achieved rather than risk a false success (the costly direction for #833).
+    console.warn(
+      "[judgeBacklogOutcome] outcome judge failed -> not achieved (failing closed)",
+      error,
+    );
+    return { achieved: false, artifacts: [] };
+  }
+}

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -1,0 +1,401 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The orchestrator pulls electron in transitively via LanguageModelProvider; stub it so the
+// real control flow runs in a plain node test environment.
+vi.mock("electron", () => ({
+  BrowserWindow: { getAllWindows: vi.fn().mockReturnValue([]) },
+}));
+vi.mock("../../utils/error-utils", () => ({
+  formatAndReportError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+import type { MCPStep } from "../../../shared/types/mcp";
+import type { ToolApprovalMode } from "../../../shared/types/user-settings";
+// vi.mock calls above are hoisted, so this static import sees the stubbed modules.
+import { LocalClaudeOrchestrator } from "./local-claude-orchestrator";
+import type { MCPServerConfig } from "./types";
+
+type MockChild = ChildProcess & {
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+};
+
+function createMockChild(): MockChild {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  return proc as unknown as MockChild;
+}
+
+/**
+ * A spawner that returns a `--version` child first (success), then the run child. The run child's
+ * scripted stream is emitted right after the run child is returned (a tick later), guaranteeing the
+ * orchestrator has attached its stdout/close listeners before any event fires — no race.
+ */
+function makeSpawner(versionExitCode: number, runChild: MockChild, runScript?: () => void) {
+  const versionChild = createMockChild();
+  const spawn = vi.fn((_cmd: string, args: string[]) => {
+    if (args.includes("--version")) {
+      setImmediate(() => versionChild.emit("close", versionExitCode));
+      return versionChild;
+    }
+    if (runScript) setImmediate(runScript);
+    return runChild;
+  });
+  return { spawn };
+}
+
+function makeManager(servers: MCPServerConfig[]) {
+  return { listAvailableServers: vi.fn().mockResolvedValue(servers) };
+}
+
+function makeSettings(mode: ToolApprovalMode) {
+  return { getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: mode }) };
+}
+
+function makeTokenStorage(tokenByServer: Record<string, string> = {}) {
+  return {
+    getTokensAsync: vi.fn(async (serverId: string) =>
+      tokenByServer[serverId] ? { access_token: tokenByServer[serverId] } : undefined,
+    ),
+  };
+}
+
+const httpServer: MCPServerConfig = {
+  id: "gh-1",
+  name: "GitHub",
+  transport: "streamableHttp",
+  url: "https://mcp.github.test/",
+  toolWhitelist: ["create_issue"],
+  enabled: true,
+};
+
+const stdioServer: MCPServerConfig = {
+  id: "fs-1",
+  name: "Local FS",
+  transport: "stdio",
+  command: "npx",
+  args: ["-y", "fs-mcp"],
+  env: { FOO: "bar" },
+  toolWhitelist: ["read_file"],
+  enabled: true,
+};
+
+describe("LocalClaudeOrchestrator", () => {
+  let runChild: MockChild;
+
+  beforeEach(() => {
+    runChild = createMockChild();
+  });
+
+  describe("claude availability", () => {
+    it("throws a clear error when `claude` is not found (--version fails)", async () => {
+      const { spawn } = makeSpawner(/* versionExitCode */ 127, runChild);
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("ask"),
+        { generateObject: vi.fn() },
+      );
+
+      await expect(orch.manualLoopAsync("transcript", undefined, {})).rejects.toThrow(
+        /Claude Code CLI not found on PATH/,
+      );
+    });
+
+    it("throws a clear error when spawning `claude --version` errors (ENOENT)", async () => {
+      const versionChild = createMockChild();
+      const spawn = vi.fn((_cmd: string, args: string[]) => {
+        if (args.includes("--version")) {
+          setImmediate(() => versionChild.emit("error", new Error("spawn ENOENT")));
+          return versionChild;
+        }
+        return runChild;
+      });
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("ask"),
+        { generateObject: vi.fn() },
+      );
+
+      await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
+        /Claude Code CLI not found on PATH/,
+      );
+    });
+  });
+
+  describe("MCP config serialization", () => {
+    it("serializes stdio (command/args/env) and http (url + injected bearer token)", async () => {
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn: vi.fn() },
+        makeManager([stdioServer, httpServer]),
+        makeTokenStorage({ "gh-1": "tok-123" }),
+        makeSettings("ask"),
+        { generateObject: vi.fn() },
+      );
+
+      const { mcpConfig, allowedTools } = await orch.serializeMcpServers(
+        makeManager([stdioServer, httpServer]),
+        undefined,
+      );
+
+      expect(mcpConfig.mcpServers).toEqual({
+        Local_FS: {
+          type: "stdio",
+          command: "npx",
+          args: ["-y", "fs-mcp"],
+          env: { FOO: "bar" },
+        },
+        GitHub: {
+          type: "http",
+          url: "https://mcp.github.test/",
+          headers: { Authorization: "Bearer tok-123" },
+        },
+      });
+      expect(allowedTools).toEqual(["mcp__Local_FS__read_file", "mcp__GitHub__create_issue"]);
+    });
+
+    it("respects the serverFilter and skips disabled + inMemory servers", async () => {
+      const disabled: MCPServerConfig = { ...stdioServer, id: "off", name: "Off", enabled: false };
+      const internal: MCPServerConfig = {
+        id: "in",
+        name: "Internal",
+        transport: "inMemory",
+        enabled: true,
+      };
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn: vi.fn() },
+        null,
+        makeTokenStorage(),
+      );
+      const mgr = makeManager([stdioServer, httpServer, disabled, internal]);
+
+      const { mcpConfig } = await orch.serializeMcpServers(mgr, ["gh-1"]);
+      expect(Object.keys(mcpConfig.mcpServers)).toEqual(["GitHub"]);
+    });
+
+    it("flags servers with no whitelist (under ask/wait) instead of hanging", async () => {
+      const noWhitelist: MCPServerConfig = { ...httpServer, toolWhitelist: [] };
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn: vi.fn() },
+        null,
+        makeTokenStorage(),
+      );
+      const { skippedNonWhitelistedServers, allowedTools } = await orch.serializeMcpServers(
+        makeManager([noWhitelist]),
+        undefined,
+      );
+      expect(skippedNonWhitelistedServers).toEqual(["GitHub"]);
+      expect(allowedTools).toEqual([]);
+    });
+  });
+
+  describe("argv building per approval mode", () => {
+    it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "yolo", ["mcp__GitHub__create_issue"]);
+      expect(argv).toContain("--permission-mode");
+      expect(argv).toContain("bypassPermissions");
+      expect(argv).not.toContain("--allowedTools");
+      expect(argv).toEqual(
+        expect.arrayContaining([
+          "-p",
+          "--mcp-config",
+          "/tmp/cfg.json",
+          "--output-format",
+          "stream-json",
+          "--verbose",
+        ]),
+      );
+    });
+
+    it("ask -> --allowedTools built from the whitelist", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "ask", [
+        "mcp__GitHub__create_issue",
+        "mcp__Local_FS__read_file",
+      ]);
+      const idx = argv.indexOf("--allowedTools");
+      expect(idx).toBeGreaterThan(-1);
+      expect(argv[idx + 1]).toBe("mcp__GitHub__create_issue,mcp__Local_FS__read_file");
+      expect(argv).not.toContain("bypassPermissions");
+    });
+
+    it("wait with empty whitelist -> no --allowedTools and no bypass (constrained run)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "wait", []);
+      expect(argv).not.toContain("--allowedTools");
+      expect(argv).not.toContain("bypassPermissions");
+    });
+  });
+
+  describe("stream-json parsing -> MCPStep sequence + judge", () => {
+    /** Builds a closure that emits the given newline-delimited JSON lines then closes the child. */
+    function streamScript(child: MockChild, lines: string[], exitCode = 0) {
+      return () => {
+        for (const line of lines) {
+          child.stdout?.emit("data", Buffer.from(`${line}\n`));
+        }
+        child.emit("close", exitCode);
+      };
+    }
+
+    it("maps assistant text/tool_use and user tool_result to MCPStep, then judges achieved", async () => {
+      const steps: MCPStep[] = [];
+      const generateObject = vi.fn().mockResolvedValue({
+        achieved: true,
+        artifacts: [{ type: "issue", idOrUrl: "https://github.com/o/r/issues/5" }],
+        reasoning: "created",
+      });
+
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "I'll create an issue." }] },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", name: "mcp__GitHub__create_issue", input: { title: "Bug" } },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "mcp__GitHub__create_issue",
+                content: "Created issue #5: https://github.com/o/r/issues/5",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          result: "Done! Created issue #5.",
+        }),
+      ];
+
+      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([httpServer]),
+        makeTokenStorage({ "gh-1": "tok" }),
+        makeSettings("yolo"),
+        { generateObject },
+      );
+
+      const result = await orch.manualLoopAsync("a bug report", undefined, {
+        onStep: (s) => steps.push(s),
+      });
+
+      // stdin received the system prompt + transcript
+      expect(runChild.stdin.write).toHaveBeenCalled();
+      const written = (runChild.stdin.write as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(written).toContain("video transcription: a bug report");
+
+      const types = steps.map((s) => s.type);
+      expect(types).toContain("reasoning");
+      expect(types).toContain("tool_call");
+      expect(types).toContain("tool_result");
+      expect(types).toContain("final_result");
+
+      expect(generateObject).toHaveBeenCalledTimes(1);
+      expect(result.backlogActionSucceeded).toBe(true);
+      expect(result.terminationReason).toBe("stop");
+      expect(result.artifacts).toEqual([
+        { type: "issue", idOrUrl: "https://github.com/o/r/issues/5" },
+      ]);
+      expect(result.text).toBe("Done! Created issue #5.");
+    });
+
+    it("an errored tool_result is recorded as not-ok, so the judge is not consulted -> not achieved", async () => {
+      const generateObject = vi.fn();
+      const lines = [
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "mcp__GitHub__create_issue",
+                is_error: true,
+                content: "401 Unauthorized",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({ type: "result", subtype: "success", result: "Could not create." }),
+      ];
+      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([httpServer]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject },
+      );
+
+      const result = await orch.manualLoopAsync("t", undefined, {});
+      expect(generateObject).not.toHaveBeenCalled();
+      expect(result.backlogActionSucceeded).toBe(false);
+    });
+
+    it("error_max_turns subtype -> terminationReason max-iterations", async () => {
+      const lines = [JSON.stringify({ type: "result", subtype: "error_max_turns", result: "" })];
+      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject: vi.fn() },
+      );
+
+      const result = await orch.manualLoopAsync("t", undefined, {});
+      expect(result.terminationReason).toBe("max-iterations");
+    });
+
+    it("rejects when the process exits non-zero before any result event", async () => {
+      const failScript = () => {
+        runChild.stderr?.emit("data", Buffer.from("boom"));
+        runChild.emit("close", 1);
+      };
+      const { spawn } = makeSpawner(0, runChild, failScript);
+      const orch = new LocalClaudeOrchestrator(
+        "claude",
+        { spawn },
+        makeManager([]),
+        makeTokenStorage(),
+        makeSettings("yolo"),
+        { generateObject: vi.fn() },
+      );
+
+      await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
+        /Claude Code process exited with code 1/,
+      );
+    });
+  });
+});

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -272,7 +272,13 @@ describe("LocalClaudeOrchestrator", () => {
           type: "assistant",
           message: {
             content: [
-              { type: "tool_use", name: "mcp__GitHub__create_issue", input: { title: "Bug" } },
+              {
+                type: "tool_use",
+                // Real Claude Code stream-json carries an OPAQUE id here, NOT the tool name.
+                id: "toolu_01ABCdef234567",
+                name: "mcp__GitHub__create_issue",
+                input: { title: "Bug" },
+              },
             ],
           },
         }),
@@ -282,7 +288,8 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_result",
-                tool_use_id: "mcp__GitHub__create_issue",
+                // The result references the tool_use block by its opaque id — never by tool name.
+                tool_use_id: "toolu_01ABCdef234567",
                 content: "Created issue #5: https://github.com/o/r/issues/5",
               },
             ],
@@ -321,6 +328,12 @@ describe("LocalClaudeOrchestrator", () => {
       expect(types).toContain("final_result");
 
       expect(generateObject).toHaveBeenCalledTimes(1);
+      // The judge must see the human-readable tool name (correlated from the opaque tool_use_id),
+      // NOT the raw `toolu_...` id — this is the #833 ground-truth signal.
+      const judgePrompt = (generateObject as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(judgePrompt).toContain("mcp__GitHub__create_issue");
+      expect(judgePrompt).not.toContain("toolu_01ABCdef234567");
+
       expect(result.backlogActionSucceeded).toBe(true);
       expect(result.terminationReason).toBe("stop");
       expect(result.artifacts).toEqual([
@@ -338,7 +351,7 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_result",
-                tool_use_id: "mcp__GitHub__create_issue",
+                tool_use_id: "toolu_01ERRoredcall99",
                 is_error: true,
                 content: "401 Unauthorized",
               },

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -1,0 +1,503 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ToolApprovalMode } from "../../../shared/types/user-settings";
+import { getDurationParts } from "../../utils/duration-utils";
+import type { VideoUploadResult } from "../auth/types";
+import { McpOAuthTokenStorage } from "../storage/mcp-oauth-token-storage";
+import { UserSettingsStorage } from "../storage/user-settings-storage";
+import {
+  type IBacklogOrchestrator,
+  judgeBacklogOutcome,
+  type ManualLoopOptions,
+  type MCPLoopResult,
+  type MCPTerminationReason,
+  type OutcomeJudgeProvider,
+  type ToolActivity,
+} from "./backlog-orchestrator";
+import { LanguageModelProvider } from "./language-model-provider";
+import { MCPServerManager } from "./mcp-server-manager";
+import { orchestratorSystemPrompt } from "./prompts";
+import type { MCPServerConfig } from "./types";
+
+/**
+ * Spawner abstraction mirroring ffmpeg-service's `IProcessSpawner`, kept here so the unit tests
+ * can inject a mock child process and assert on the exact argv without ever running `claude`.
+ */
+export interface IClaudeProcessSpawner {
+  spawn(command: string, args: string[]): ChildProcess;
+}
+
+const defaultClaudeSpawner: IClaudeProcessSpawner = {
+  spawn: (command, args) => spawn(command, args),
+};
+
+/** Claude Code's `--mcp-config` JSON entry for one stdio server. */
+interface ClaudeStdioServer {
+  type?: "stdio";
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/** Claude Code's `--mcp-config` JSON entry for one HTTP server. */
+interface ClaudeHttpServer {
+  type: "http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+type ClaudeMcpServer = ClaudeStdioServer | ClaudeHttpServer;
+
+export interface ClaudeMcpConfigFile {
+  mcpServers: Record<string, ClaudeMcpServer>;
+}
+
+/** Minimal token lookup the orchestrator needs — narrower than the full storage so tests stub it easily. */
+export interface TokenLookup {
+  getTokensAsync(serverId: string): Promise<{ access_token?: string } | undefined>;
+}
+
+/** Claude Code's tool name format is `mcp__<server>__<tool>`. Server names are sanitized to match. */
+function sanitizeServerName(name: string): string {
+  return name.replace(/\s+/g, "_");
+}
+
+/**
+ * Drives the backlog-creation step with a local headless `claude -p` process instead of the
+ * in-process OpenAI loop. Serializes the enabled MCP servers to a temp `--mcp-config`, maps the
+ * tool-approval mode to Claude's permission flags, streams `stream-json` events to `onStep`, and
+ * reuses the shared `judgeBacklogOutcome` on the collected tool results.
+ */
+export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
+  // Storage deps are resolved lazily — only when actually needed — so constructing the orchestrator
+  // (and the argv/serialization unit tests that do) never touches the electron-backed singletons.
+  constructor(
+    private readonly claudeCommand: string = "claude",
+    private readonly spawner: IClaudeProcessSpawner = defaultClaudeSpawner,
+    private readonly serverManager: Pick<MCPServerManager, "listAvailableServers"> | null = null,
+    private readonly tokenStorage: TokenLookup | null = null,
+    private readonly settingsStorage: Pick<UserSettingsStorage, "getSettingsAsync"> | null = null,
+    private readonly judgeProvider: OutcomeJudgeProvider | null = null,
+  ) {}
+
+  private getTokenStorage(): TokenLookup {
+    return this.tokenStorage ?? McpOAuthTokenStorage.getInstance();
+  }
+
+  private getSettingsStorage(): Pick<UserSettingsStorage, "getSettingsAsync"> {
+    return this.settingsStorage ?? UserSettingsStorage.getInstance();
+  }
+
+  /** Verifies the `claude` CLI is reachable; throws a user-actionable error if not. */
+  public async ensureClaudeAvailable(): Promise<void> {
+    const detected = await new Promise<boolean>((resolve) => {
+      let child: ChildProcess;
+      try {
+        child = this.spawner.spawn(this.claudeCommand, ["--version"]);
+      } catch {
+        resolve(false);
+        return;
+      }
+      child.on("error", () => resolve(false));
+      child.on("close", (code) => resolve(code === 0));
+    });
+
+    if (!detected) {
+      throw new Error(
+        "Claude Code CLI not found on PATH — install it, or switch Orchestrator to OpenAI in Settings.",
+      );
+    }
+  }
+
+  public async manualLoopAsync(
+    videoTranscription: string,
+    videoUploadResult?: VideoUploadResult,
+    options: ManualLoopOptions = {},
+  ): Promise<MCPLoopResult> {
+    await this.ensureClaudeAvailable();
+
+    const manager = this.serverManager ?? (await MCPServerManager.getInstanceAsync());
+    const approvalMode = (await this.getSettingsStorage().getSettingsAsync()).toolApprovalMode;
+
+    const systemPrompt = this.buildSystemPrompt(
+      options.projectMetaData,
+      options.desktopAgentProjectPrompt,
+      videoUploadResult,
+      options.videoFilePath,
+    );
+
+    const { mcpConfig, allowedTools, skippedNonWhitelistedServers } =
+      await this.serializeMcpServers(manager, options.serverFilter);
+
+    if (skippedNonWhitelistedServers.length > 0) {
+      console.warn(
+        `[LocalClaudeOrchestrator] No whitelisted tools for server(s): ${skippedNonWhitelistedServers.join(", ")} under "${approvalMode}" approval mode — proceeding with whatever is whitelisted; non-whitelisted tools were skipped.`,
+      );
+    }
+
+    const tmpConfigPath = join(tmpdir(), `yakshaver-mcp-${randomUUID()}.json`);
+    await fs.writeFile(tmpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf8");
+
+    try {
+      const argv = this.buildArgv(tmpConfigPath, approvalMode, allowedTools);
+      return await this.runClaude(argv, systemPrompt, videoTranscription, options);
+    } finally {
+      await fs.unlink(tmpConfigPath).catch(() => {
+        /* best-effort cleanup */
+      });
+    }
+  }
+
+  /**
+   * Builds the system prompt the same way `MCPOrchestrator` does: base orchestrator prompt +
+   * project metadata + project prompt + video info.
+   */
+  private buildSystemPrompt(
+    projectMetaData?: string,
+    desktopAgentProjectPrompt?: string,
+    videoUploadResult?: VideoUploadResult,
+    videoFilePath?: string,
+  ): string {
+    let systemPrompt = orchestratorSystemPrompt;
+
+    systemPrompt += projectMetaData ? `\n---\nProject Metadata:\n${projectMetaData}` : "";
+    systemPrompt += desktopAgentProjectPrompt
+      ? `\n---\nProject Prompt:\n${desktopAgentProjectPrompt}`
+      : "";
+
+    const videoUrl = videoUploadResult?.data?.url;
+    const duration = videoUploadResult?.data?.duration;
+    if (videoUrl) {
+      const isValidDuration = typeof duration === "number" && duration > 0;
+      if (isValidDuration) {
+        const outputDuration = getDurationParts(duration);
+        systemPrompt += `\n\nThis is the uploaded video URL: ${videoUrl}.
+Video duration:
+- totalSeconds: ${outputDuration.totalSeconds}
+- hours: ${outputDuration.hours}
+- minutes: ${outputDuration.minutes}
+- seconds: ${outputDuration.seconds}
+Embed this URL and duration in the task content that you create. Follow user requirements STRICTLY about the link formatting rule.`;
+      } else {
+        systemPrompt += `\n\nThis is the uploaded video URL: ${videoUrl}.
+Embed this URL in the task content that you create. Follow user requirements STRICTLY about the link formatting rule.`;
+      }
+    }
+
+    if (videoFilePath) {
+      systemPrompt += `\n\nVideo file available for screenshot capture: ${videoFilePath}.`;
+    }
+
+    return systemPrompt;
+  }
+
+  /**
+   * Serializes the enabled MCP servers (respecting `serverFilter`) into Claude Code's
+   * `--mcp-config` format. stdio → {command,args,env}; streamableHttp → {url, headers} with the
+   * OAuth bearer token injected from token storage when present. Also returns the `--allowedTools`
+   * derived from each server's whitelist (used under ask/wait approval modes).
+   */
+  public async serializeMcpServers(
+    manager: Pick<MCPServerManager, "listAvailableServers">,
+    serverFilter?: string[],
+  ): Promise<{
+    mcpConfig: ClaudeMcpConfigFile;
+    allowedTools: string[];
+    skippedNonWhitelistedServers: string[];
+  }> {
+    const all = await manager.listAvailableServers();
+    const filterSet = serverFilter && serverFilter.length > 0 ? new Set(serverFilter) : null;
+
+    const selected = all.filter((c) => {
+      if (c.enabled === false) return false;
+      if (!filterSet) return true;
+      return filterSet.has(c.id) || filterSet.has(c.name);
+    });
+
+    const mcpServers: Record<string, ClaudeMcpServer> = {};
+    const allowedTools: string[] = [];
+    const skippedNonWhitelistedServers: string[] = [];
+
+    for (const config of selected) {
+      // inMemory servers are YakShaver-internal; Claude Code can't reach them over its own
+      // transports, so they're skipped for the local backend.
+      if (config.transport === "inMemory") continue;
+
+      const serverKey = sanitizeServerName(config.name);
+      const entry = await this.toClaudeServerEntry(config);
+      if (!entry) continue;
+      mcpServers[serverKey] = entry;
+
+      const whitelist = config.toolWhitelist ?? [];
+      if (whitelist.length === 0) {
+        skippedNonWhitelistedServers.push(config.name);
+      }
+      for (const toolName of whitelist) {
+        allowedTools.push(`mcp__${serverKey}__${toolName}`);
+      }
+    }
+
+    return {
+      mcpConfig: { mcpServers },
+      allowedTools,
+      skippedNonWhitelistedServers,
+    };
+  }
+
+  private async toClaudeServerEntry(config: MCPServerConfig): Promise<ClaudeMcpServer | null> {
+    if (config.transport === "stdio") {
+      const entry: ClaudeStdioServer = {
+        type: "stdio",
+        command: config.command,
+      };
+      if (config.args && config.args.length > 0) entry.args = config.args;
+      if (config.env && Object.keys(config.env).length > 0) entry.env = config.env;
+      return entry;
+    }
+
+    if (config.transport === "streamableHttp") {
+      const headers: Record<string, string> = { ...config.headers };
+      // Inject the OAuth bearer token so Claude Code authenticates the same way the in-process
+      // client does (built-in servers don't use OAuth).
+      if (!config.builtin) {
+        const tokens = await this.getTokenStorage().getTokensAsync(config.id);
+        if (tokens?.access_token) {
+          headers.Authorization = `Bearer ${tokens.access_token}`;
+        }
+      }
+      const entry: ClaudeHttpServer = { type: "http", url: config.url };
+      if (Object.keys(headers).length > 0) entry.headers = headers;
+      return entry;
+    }
+
+    return null;
+  }
+
+  /**
+   * Maps the approval mode to Claude Code's permission flags:
+   * - `yolo` → `--permission-mode bypassPermissions` (run every tool immediately).
+   * - `ask` / `wait` → `--allowedTools <whitelist>` (only the whitelisted tools may run; anything
+   *   else is denied by Claude rather than hanging on an interactive prompt the headless run can't answer).
+   */
+  public buildArgv(
+    mcpConfigPath: string,
+    approvalMode: ToolApprovalMode,
+    allowedTools: string[],
+  ): string[] {
+    const argv = [
+      "-p",
+      "--mcp-config",
+      mcpConfigPath,
+      "--output-format",
+      "stream-json",
+      "--verbose",
+    ];
+
+    if (approvalMode === "yolo") {
+      argv.push("--permission-mode", "bypassPermissions");
+    } else {
+      // ask & wait: a headless process can't service interactive approvals, so we constrain the
+      // run to the user-approved (whitelisted) tools. An empty whitelist yields no extra tools.
+      if (allowedTools.length > 0) {
+        argv.push("--allowedTools", allowedTools.join(","));
+      }
+    }
+
+    return argv;
+  }
+
+  private async runClaude(
+    argv: string[],
+    systemPrompt: string,
+    videoTranscription: string,
+    options: ManualLoopOptions,
+  ): Promise<MCPLoopResult> {
+    const toolActivity: ToolActivity[] = [];
+
+    const child = this.spawner.spawn(this.claudeCommand, argv);
+
+    // The full prompt = system prompt + the transcript as the user input, passed over stdin so
+    // long transcripts don't bump into argv length limits.
+    const fullPrompt = `${systemPrompt}\n\n---\nvideo transcription: ${videoTranscription}`;
+    child.stdin?.write(fullPrompt);
+    child.stdin?.end();
+
+    const { finalText, terminationReason } = await new Promise<{
+      finalText: string;
+      terminationReason: MCPTerminationReason;
+    }>((resolve, reject) => {
+      let stdoutBuffer = "";
+      let stderr = "";
+      let finalText = "";
+      let terminationReason: MCPTerminationReason = "unknown";
+
+      const handleLine = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        let event: ClaudeStreamEvent;
+        try {
+          event = JSON.parse(trimmed) as ClaudeStreamEvent;
+        } catch {
+          // Non-JSON lines (e.g. stray logs) are ignored — the stream is newline-delimited JSON.
+          return;
+        }
+        const result = this.handleStreamEvent(event, toolActivity, options.onStep);
+        if (result.finalText !== undefined) finalText = result.finalText;
+        if (result.terminationReason) terminationReason = result.terminationReason;
+      };
+
+      child.stdout?.on("data", (data: Buffer) => {
+        stdoutBuffer += data.toString();
+        const lines = stdoutBuffer.split("\n");
+        // Keep the last (possibly partial) line in the buffer.
+        stdoutBuffer = lines.pop() ?? "";
+        for (const line of lines) handleLine(line);
+      });
+
+      child.stderr?.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      child.on("error", (error: Error) => {
+        reject(new Error(`Failed to start Claude Code: ${error.message}`));
+      });
+
+      child.on("close", (code: number | null) => {
+        // Flush any trailing buffered line.
+        if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
+
+        if (code !== 0 && terminationReason === "unknown") {
+          reject(
+            new Error(
+              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}`,
+            ),
+          );
+          return;
+        }
+        resolve({ finalText, terminationReason });
+      });
+    });
+
+    options.onStep?.({ type: "final_result", message: terminationReason });
+
+    const provider = this.judgeProvider ?? (await this.getJudgeProvider());
+    const outcome = await judgeBacklogOutcome(
+      provider,
+      options.desktopAgentProjectPrompt,
+      videoTranscription,
+      toolActivity,
+      finalText,
+    );
+
+    return {
+      text: finalText,
+      backlogActionSucceeded: outcome.achieved,
+      artifacts: outcome.artifacts,
+      terminationReason,
+    };
+  }
+
+  /**
+   * Translates one Claude Code stream-json event into the UI's `MCPStep` progress events (the
+   * same shape the OpenAI loop emits) and records tool calls/results for the outcome judge.
+   */
+  private handleStreamEvent(
+    event: ClaudeStreamEvent,
+    toolActivity: ToolActivity[],
+    onStep?: ManualLoopOptions["onStep"],
+  ): { finalText?: string; terminationReason?: MCPTerminationReason } {
+    // Assistant turn: may carry text and/or tool_use blocks.
+    if (event.type === "assistant" && event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === "text" && block.text) {
+          onStep?.({ type: "reasoning", reasoning: block.text });
+        } else if (block.type === "tool_use") {
+          onStep?.({
+            type: "tool_call",
+            toolName: block.name ?? "unknown",
+            args: block.input,
+          });
+        }
+      }
+      return {};
+    }
+
+    // User turn carries tool_result blocks (Claude reports tool outputs as a user message).
+    if (event.type === "user" && event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === "tool_result") {
+          const resultText = extractToolResultText(block.content);
+          const ok = block.is_error !== true;
+          toolActivity.push({
+            toolName: block.tool_use_id ?? "unknown",
+            ok,
+            resultText: resultText.slice(0, 8000),
+          });
+          onStep?.({ type: "tool_result", result: block.content });
+        }
+      }
+      return {};
+    }
+
+    // Terminal result event: carries the final text + how the run ended.
+    if (event.type === "result") {
+      const finalText = event.result ?? "";
+      const terminationReason: MCPTerminationReason =
+        event.subtype === "success"
+          ? "stop"
+          : event.subtype === "error_max_turns"
+            ? "max-iterations"
+            : "unknown";
+      return { finalText, terminationReason };
+    }
+
+    return {};
+  }
+
+  private async getJudgeProvider(): Promise<OutcomeJudgeProvider | null> {
+    try {
+      return await LanguageModelProvider.getInstance();
+    } catch (error) {
+      console.warn("[LocalClaudeOrchestrator] judge provider unavailable", error);
+      return null;
+    }
+  }
+}
+
+/** A loose view of the Claude Code stream-json events we care about. */
+interface ClaudeStreamEvent {
+  type: "assistant" | "user" | "result" | "system" | string;
+  subtype?: string;
+  result?: string;
+  message?: {
+    content?: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      input?: unknown;
+      tool_use_id?: string;
+      is_error?: boolean;
+      content?: unknown;
+    }>;
+  };
+}
+
+/** Tool results in stream-json may be a string or an array of `{type:"text", text}` blocks. */
+function extractToolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((item) =>
+        item && typeof item === "object" && "text" in item
+          ? String((item as { text?: unknown }).text ?? "")
+          : "",
+      )
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  if (content && typeof content === "object") return JSON.stringify(content);
+  return "";
+}

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -138,8 +138,15 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
       );
     }
 
+    // The serialized config carries live OAuth bearer tokens, so it must not be world-readable on a
+    // shared machine. Write it owner-only (0o600). The default umask would otherwise leave it
+    // readable by other local users in the shared system temp dir. On Windows the POSIX mode is a
+    // no-op, but there the per-user temp dir is already ACL-restricted.
     const tmpConfigPath = join(tmpdir(), `yakshaver-mcp-${randomUUID()}.json`);
-    await fs.writeFile(tmpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf8");
+    await fs.writeFile(tmpConfigPath, JSON.stringify(mcpConfig, null, 2), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
 
     try {
       const argv = this.buildArgv(tmpConfigPath, approvalMode, allowedTools);
@@ -316,6 +323,11 @@ Embed this URL in the task content that you create. Follow user requirements STR
     options: ManualLoopOptions,
   ): Promise<MCPLoopResult> {
     const toolActivity: ToolActivity[] = [];
+    // Correlates a tool_use block's opaque id (e.g. `toolu_01ABC...`) back to its human-readable
+    // tool name (e.g. `mcp__GitHub__create_issue`). Claude Code's stream-json reports the name only
+    // on the assistant `tool_use` block, while the matching `tool_result` references it by id — so we
+    // must remember the mapping to record a meaningful name for the outcome judge.
+    const toolNameById = new Map<string, string>();
 
     const child = this.spawner.spawn(this.claudeCommand, argv);
 
@@ -344,7 +356,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
           // Non-JSON lines (e.g. stray logs) are ignored — the stream is newline-delimited JSON.
           return;
         }
-        const result = this.handleStreamEvent(event, toolActivity, options.onStep);
+        const result = this.handleStreamEvent(event, toolActivity, toolNameById, options.onStep);
         if (result.finalText !== undefined) finalText = result.finalText;
         if (result.terminationReason) terminationReason = result.terminationReason;
       };
@@ -407,6 +419,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
   private handleStreamEvent(
     event: ClaudeStreamEvent,
     toolActivity: ToolActivity[],
+    toolNameById: Map<string, string>,
     onStep?: ManualLoopOptions["onStep"],
   ): { finalText?: string; terminationReason?: MCPTerminationReason } {
     // Assistant turn: may carry text and/or tool_use blocks.
@@ -415,9 +428,13 @@ Embed this URL in the task content that you create. Follow user requirements STR
         if (block.type === "text" && block.text) {
           onStep?.({ type: "reasoning", reasoning: block.text });
         } else if (block.type === "tool_use") {
+          const toolName = block.name ?? "unknown";
+          // Remember id -> name so the matching tool_result (which references this block only by
+          // its opaque `id`) can be recorded against the real tool name, not the id.
+          if (block.id) toolNameById.set(block.id, toolName);
           onStep?.({
             type: "tool_call",
-            toolName: block.name ?? "unknown",
+            toolName,
             args: block.input,
           });
         }
@@ -431,8 +448,14 @@ Embed this URL in the task content that you create. Follow user requirements STR
         if (block.type === "tool_result") {
           const resultText = extractToolResultText(block.content);
           const ok = block.is_error !== true;
+          // `tool_use_id` is the OPAQUE id of the originating tool_use block — resolve it back to the
+          // human-readable tool name so the outcome judge (and diagnostics) see e.g.
+          // `mcp__GitHub__create_issue` rather than `toolu_01ABC...`. Fall back to the id only if the
+          // tool_use block was never seen (out-of-order / dropped event).
+          const id = block.tool_use_id;
+          const toolName = (id ? toolNameById.get(id) : undefined) ?? id ?? "unknown";
           toolActivity.push({
-            toolName: block.tool_use_id ?? "unknown",
+            toolName,
             ok,
             resultText: resultText.slice(0, 8000),
           });
@@ -476,6 +499,9 @@ interface ClaudeStreamEvent {
     content?: Array<{
       type: string;
       text?: string;
+      // The opaque id of a tool_use block (e.g. `toolu_01ABC...`); a tool_result references it via
+      // `tool_use_id`. We map id -> name so results are recorded against the real tool name.
+      id?: string;
       name?: string;
       input?: unknown;
       tool_use_id?: string;

--- a/src/backend/services/mcp/mcp-orchestrator.ts
+++ b/src/backend/services/mcp/mcp-orchestrator.ts
@@ -1,65 +1,33 @@
 import { randomUUID } from "node:crypto";
 import type { ModelMessage, ToolExecutionOptions, ToolModelMessage, UserModelMessage } from "ai";
-import { type ZodType, z } from "zod";
-import type { MCPStep } from "../../../shared/types/mcp";
+import type { ZodType } from "zod";
 import { getDurationParts } from "../../utils/duration-utils";
 import { formatAndReportError } from "../../utils/error-utils";
 import type { VideoUploadResult } from "../auth/types";
 import { TelemetryService } from "../telemetry/telemetry-service";
 import { UserInteractionService } from "../user-interaction/user-interaction-service";
+import {
+  type BacklogArtifact,
+  type IBacklogOrchestrator,
+  judgeBacklogOutcome,
+  type ManualLoopOptions,
+  type MCPLoopResult,
+  type MCPTerminationReason,
+  type ToolActivity,
+} from "./backlog-orchestrator";
 import { LanguageModelProvider } from "./language-model-provider";
 import { MCPServerManager } from "./mcp-server-manager";
 import { orchestratorSystemPrompt } from "./prompts";
 
-export type MCPTerminationReason =
-  | "stop"
-  | "length"
-  | "content-filter"
-  | "cancelled"
-  | "max-iterations"
-  | "unknown";
-
-export interface BacklogArtifact {
-  /** e.g. "issue", "work_item", "ticket", "comment", "pull_request". */
-  type: string;
-  /** The concrete identifier or URL evidencing the created/updated item. */
-  idOrUrl: string;
-}
-
-export interface MCPLoopResult {
-  /** The model's final text output — the drafted work item, or a message explaining why it stopped. */
-  text: string;
-  /**
-   * True only when a backlog item was actually created/updated, decided from the TOOL RESULTS
-   * (not the model's narration). A graceful `stop` with only internal tools, no tools, or an
-   * errored mutation means nothing was filed.
-   */
-  backlogActionSucceeded: boolean;
-  /** The concrete created/updated artifacts the judge found (issue ids/URLs), if any. */
-  artifacts: BacklogArtifact[];
-  /** Why the loop ended — distinguishes a clean finish from hitting a safety cap. */
-  terminationReason: MCPTerminationReason;
-}
-
-/** One executed tool call and (a truncated view of) its result — the ground truth the judge reasons over. */
-interface ToolActivity {
-  toolName: string;
-  ok: boolean;
-  resultText: string;
-}
-
-/**
- * Structured verdict from the outcome judge. Every field is REQUIRED — no `.optional()` / `.default()`.
- * OpenAI strict structured outputs reject a schema whose `required` omits any property, so a
- * `.default()` here makes the field optional and breaks the real `generateObject` call at runtime
- * ("Invalid schema for response_format … Missing 'artifacts'"). That only surfaces against a live
- * model, never in tests that stub generateObject — so keep this schema strict-compatible.
- */
-export const BacklogOutcomeSchema = z.object({
-  achieved: z.boolean(),
-  artifacts: z.array(z.object({ type: z.string(), idOrUrl: z.string() })),
-  reasoning: z.string(),
-});
+// Re-export the shared backlog-orchestrator contract from here so existing importers
+// (and tests) that reference these symbols on the orchestrator module keep working.
+export {
+  type BacklogArtifact,
+  BacklogOutcomeSchema,
+  type IBacklogOrchestrator,
+  type MCPLoopResult,
+  type MCPTerminationReason,
+} from "./backlog-orchestrator";
 
 /**
  * Tool Output Buffer for host-level tool chaining.
@@ -129,7 +97,7 @@ export class ToolOutputBuffer {
   }
 }
 
-export class MCPOrchestrator {
+export class MCPOrchestrator implements IBacklogOrchestrator {
   private static instance: MCPOrchestrator;
 
   private static languageModelProvider: LanguageModelProvider | null = null;
@@ -177,15 +145,7 @@ export class MCPOrchestrator {
   public async manualLoopAsync(
     videoTranscription: string,
     videoUploadResult?: VideoUploadResult,
-    options: {
-      projectMetaData?: string;
-      desktopAgentProjectPrompt?: string;
-      maxToolIterations?: number; // safety cap to avoid infinite loops
-      videoFilePath?: string; // local video file path for screenshot capture
-      serverFilter?: string[]; // if provided, only include tools from these server IDs
-      shaveId?: string; // identifies the current shave for per-shave auto-approve
-      onStep?: (step: MCPStep) => void;
-    } = {},
+    options: ManualLoopOptions = {},
   ): Promise<MCPLoopResult> {
     // Ensure LLM has been initialized
     if (!MCPOrchestrator.languageModelProvider) {
@@ -574,12 +534,9 @@ export class MCPOrchestrator {
   }
 
   /**
-   * Decides whether the run ACTUALLY created/updated a backlog item, judging from the tool
-   * RESULTS (ground truth) rather than a tool-name heuristic or the model's own claims (#833).
-   *
-   * Short-circuits to "not achieved" when no tool call succeeded (the common signed-out case),
-   * so the extra LLM call only happens when something plausibly did get filed. Fails CLOSED
-   * (not achieved) if the judge is unavailable or errors — a false success is the costly mistake.
+   * Decides whether the run ACTUALLY created/updated a backlog item (#833). Delegates to the
+   * shared `judgeBacklogOutcome`, which is also used by the local Claude Code backend so success
+   * is judged identically regardless of who drove the tools.
    */
   private async judgeBacklogOutcome(
     goal: string | undefined,
@@ -587,61 +544,13 @@ export class MCPOrchestrator {
     toolActivity: ToolActivity[],
     finalText: string,
   ): Promise<{ achieved: boolean; artifacts: BacklogArtifact[] }> {
-    const succeeded = toolActivity.filter((t) => t.ok);
-    if (succeeded.length === 0) {
-      console.log("[MCPOrchestrator] outcome: no successful tool calls -> not achieved");
-      return { achieved: false, artifacts: [] };
-    }
-
-    const provider = MCPOrchestrator.languageModelProvider;
-    if (!provider) {
-      console.warn("[MCPOrchestrator] outcome judge unavailable (no LLM) -> not achieved");
-      return { achieved: false, artifacts: [] };
-    }
-
-    const judgeSystemPrompt =
-      "You are a strict verifier deciding whether an automated agent ACTUALLY created or updated " +
-      "a backlog work item (e.g. a GitHub issue, an Azure DevOps work item, or a Jira ticket) as " +
-      "instructed. Judge ONLY from the tool results below (ground truth) — NEVER trust the agent's " +
-      "own final message, which may claim success it did not achieve. Set achieved=true only when a " +
-      "non-errored tool result contains concrete evidence of a created or updated item: an id, a " +
-      "number, or a URL. Put that evidence in artifacts. If no mutating tool produced such evidence — " +
-      "nothing ran, the call errored, or only read/internal tools ran — set achieved=false. When " +
-      "uncertain, set achieved=false.";
-
-    const judgePrompt = [
-      `TASK INSTRUCTIONS GIVEN TO THE AGENT:\n${goal?.slice(0, 4000) || "(create a backlog work item describing the user's request)"}`,
-      `USER REQUEST (video transcript):\n${transcript.slice(0, 2000)}`,
-      `TOOL CALLS AND THEIR RESULTS (ground truth — decide from these):\n${JSON.stringify(toolActivity)}`,
-      `AGENT FINAL MESSAGE (do NOT trust this for success):\n${finalText.slice(0, 2000)}`,
-    ].join("\n\n---\n\n");
-
-    try {
-      const verdict = await provider.generateObject(
-        judgePrompt,
-        BacklogOutcomeSchema,
-        judgeSystemPrompt,
-      );
-      // Enforce the contract in CODE, not just the prompt: a verdict is only trusted as success
-      // if it cites concrete evidence. A model that answers achieved=true but populates no
-      // artifacts is treated as not-achieved (conservative — a false success is the costly error).
-      const achieved = verdict.achieved && verdict.artifacts.length > 0;
-      console.log("[MCPOrchestrator] outcome judged:", {
-        achieved,
-        modelClaimedAchieved: verdict.achieved,
-        artifacts: verdict.artifacts,
-        tools: toolActivity.map((t) => `${t.toolName}${t.ok ? "" : "(errored)"}`),
-      });
-      return { achieved, artifacts: verdict.artifacts };
-    } catch (error) {
-      // Fail CLOSED: if the judge itself errors we cannot confirm a filing, so report
-      // not-achieved rather than risk a false success (the costly direction for #833).
-      console.warn(
-        "[MCPOrchestrator] outcome judge failed -> not achieved (failing closed)",
-        error,
-      );
-      return { achieved: false, artifacts: [] };
-    }
+    return judgeBacklogOutcome(
+      MCPOrchestrator.languageModelProvider,
+      goal,
+      transcript,
+      toolActivity,
+      finalText,
+    );
   }
 
   public async convertToObjectAsync(prompt: string, schema: ZodType): Promise<unknown> {

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -296,11 +296,21 @@ export class MCPServerManager {
 
     const existing = storedConfigs[index];
 
-    const merged: MCPServerConfig = {
-      ...existing,
-      ...(config as unknown as Record<string, unknown>),
-      id: existing.id,
-    } as MCPServerConfig;
+    // When the transport changes, the old config's transport-specific fields
+    // (e.g. url/headers for HTTP, command/args/env for stdio) are NOT valid on
+    // the new discriminated-union member. Overlaying the incoming config onto
+    // `existing` would re-introduce those stale fields, persisting a malformed
+    // config (e.g. a stdio server still carrying a stale url + secret-bearing
+    // headers). On a transport change we therefore REPLACE rather than overlay,
+    // trusting the caller to supply a complete, well-formed target config.
+    const transportChanged = existing.transport !== config.transport;
+    const merged: MCPServerConfig = transportChanged
+      ? ({ ...(config as unknown as Record<string, unknown>), id: existing.id } as MCPServerConfig)
+      : ({
+          ...existing,
+          ...(config as unknown as Record<string, unknown>),
+          id: existing.id,
+        } as MCPServerConfig);
 
     MCPServerManager.validateServerConfig(merged);
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,83 @@
+/**
+ * Minimal, dependency-free arg parser for the `yakshaver` CLI.
+ *
+ * Splits an argv list into positionals and `--flag value` / `--flag=value` /
+ * boolean `--flag` options. Kept tiny and pure so it's trivially unit-testable.
+ */
+
+export interface ParsedArgs {
+  positionals: string[];
+  options: Record<string, string | boolean>;
+}
+
+const BOOLEAN_FLAGS = new Set(["off", "help", "dev", "json"]);
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const options: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      const eq = arg.indexOf("=");
+      if (eq !== -1) {
+        const key = arg.slice(2, eq);
+        options[key] = arg.slice(eq + 1);
+        continue;
+      }
+
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      // Boolean flags, or a flag at the end / followed by another flag.
+      if (BOOLEAN_FLAGS.has(key) || next === undefined || next.startsWith("--")) {
+        options[key] = true;
+      } else {
+        options[key] = next;
+        i++;
+      }
+      continue;
+    }
+
+    positionals.push(arg);
+  }
+
+  return { positionals, options };
+}
+
+/** Read a string option, throwing a clear error when required and missing. */
+export function requireString(options: Record<string, string | boolean>, name: string): string {
+  const value = options[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required --${name} option`);
+  }
+  return value;
+}
+
+/** Read an optional string option. */
+export function optionalString(
+  options: Record<string, string | boolean>,
+  name: string,
+): string | undefined {
+  const value = options[name];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Parse a `key=value,key2=value2` style option into a record. */
+export function parseKeyValueList(value: string | undefined): Record<string, string> | undefined {
+  if (!value) return undefined;
+  const out: Record<string, string> = {};
+  for (const pair of value.split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    const key = pair.slice(0, eq).trim();
+    const val = pair.slice(eq + 1).trim();
+    if (key) out[key] = val;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -8,6 +8,13 @@
 export interface ParsedArgs {
   positionals: string[];
   options: Record<string, string | boolean>;
+  /**
+   * Values for options that were repeated (e.g. `--arg a --arg b`), keyed by
+   * option name, in the order they appeared. A repeatable flag like `--arg`
+   * preserves each value verbatim (spaces included), unlike a space-split
+   * single string. Populated for every option name, even when given once.
+   */
+  repeated: Record<string, string[]>;
 }
 
 const BOOLEAN_FLAGS = new Set(["off", "help", "dev", "json"]);
@@ -15,6 +22,16 @@ const BOOLEAN_FLAGS = new Set(["off", "help", "dev", "json"]);
 export function parseArgs(argv: string[]): ParsedArgs {
   const positionals: string[] = [];
   const options: Record<string, string | boolean> = {};
+  const repeated: Record<string, string[]> = {};
+
+  const recordValue = (key: string, value: string) => {
+    // Last value wins for the flat `options` map (back-compat); the full list of
+    // values is preserved in `repeated` for flags that may be supplied N times.
+    options[key] = value;
+    const list = repeated[key] ?? [];
+    list.push(value);
+    repeated[key] = list;
+  };
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -28,7 +45,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       const eq = arg.indexOf("=");
       if (eq !== -1) {
         const key = arg.slice(2, eq);
-        options[key] = arg.slice(eq + 1);
+        recordValue(key, arg.slice(eq + 1));
         continue;
       }
 
@@ -38,7 +55,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       if (BOOLEAN_FLAGS.has(key) || next === undefined || next.startsWith("--")) {
         options[key] = true;
       } else {
-        options[key] = next;
+        recordValue(key, next);
         i++;
       }
       continue;
@@ -47,7 +64,20 @@ export function parseArgs(argv: string[]): ParsedArgs {
     positionals.push(arg);
   }
 
-  return { positionals, options };
+  return { positionals, options, repeated };
+}
+
+/**
+ * Read all values supplied for a repeatable option (e.g. every `--arg`), in
+ * order, each preserved verbatim. Returns `undefined` when the flag was never
+ * given so callers can distinguish "not provided" from "provided empty".
+ */
+export function repeatedStrings(
+  parsed: Pick<ParsedArgs, "repeated">,
+  name: string,
+): string[] | undefined {
+  const values = parsed.repeated[name];
+  return values && values.length > 0 ? values : undefined;
 }
 
 /** Read a string option, throwing a clear error when required and missing. */

--- a/src/cli/bridge-client.test.ts
+++ b/src/cli/bridge-client.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CliBridgeTokenFile } from "../shared/cli-bridge/protocol";
+import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
+
+const token: CliBridgeTokenFile = {
+  port: 8765,
+  token: "test-token-abc",
+  startedAt: new Date().toISOString(),
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("BridgeClient", () => {
+  it("builds an authorized request against the token's port", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ ok: true, data: [{ id: "a" }] }));
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    const data = await client.get("/mcp/servers");
+
+    expect(data).toEqual([{ id: "a" }]);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8765/mcp/servers");
+    expect(init.method).toBe("GET");
+    expect(init.headers.Authorization).toBe("Bearer test-token-abc");
+  });
+
+  it("serializes the body and sets content-type for writes", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ ok: true, data: { id: "x" } }));
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    await client.post("/mcp/servers", { name: "X", transport: "stdio", command: "node" });
+
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({ name: "X", transport: "stdio", command: "node" });
+  });
+
+  it("caches the token across requests (loads it once)", async () => {
+    const tokenLoader = vi.fn().mockResolvedValue(token);
+    // Fresh Response per call — a Response body stream can only be read once.
+    const fetchFn = vi.fn().mockImplementation(async () => jsonResponse({ ok: true, data: null }));
+    const client = new BridgeClient({ fetchFn, tokenLoader });
+
+    await client.get("/settings");
+    await client.get("/settings");
+
+    expect(tokenLoader).toHaveBeenCalledOnce();
+  });
+
+  it("throws the bridge error message on { ok: false }", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ ok: false, error: "Server with id 'a' already exists" }, 400),
+      );
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    await expect(client.post("/mcp/servers", {})).rejects.toThrow(
+      "Server with id 'a' already exists",
+    );
+  });
+
+  it("maps a connection failure to BridgeUnavailableError", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new BridgeClient({ fetchFn, tokenLoader: async () => token });
+
+    await expect(client.get("/mcp/servers")).rejects.toBeInstanceOf(BridgeUnavailableError);
+  });
+
+  it("surfaces a token-loader failure (app not running)", async () => {
+    const client = new BridgeClient({
+      fetchFn: vi.fn(),
+      tokenLoader: async () => {
+        throw new BridgeUnavailableError("not running");
+      },
+    });
+    await expect(client.get("/mcp/servers")).rejects.toBeInstanceOf(BridgeUnavailableError);
+  });
+});

--- a/src/cli/bridge-client.ts
+++ b/src/cli/bridge-client.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import {
+  type BridgeResponse,
+  CLI_BRIDGE_HOST,
+  CLI_BRIDGE_TOKEN_DIR,
+  CLI_BRIDGE_TOKEN_FILE,
+  type CliBridgeTokenFile,
+  CliBridgeTokenFileSchema,
+} from "../shared/cli-bridge/protocol";
+import { getUserDataDir } from "./user-data-path";
+
+/** Thrown when the app/bridge isn't reachable. The CLI prints a friendly hint. */
+export class BridgeUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BridgeUnavailableError";
+  }
+}
+
+const NOT_RUNNING_HINT =
+  "YakShaver Desktop doesn't appear to be running (or the CLI bridge is disabled). " +
+  "Start the app and retry.";
+
+/** Read + validate the token file the app wrote. */
+export async function readTokenFile(dev?: boolean): Promise<CliBridgeTokenFile> {
+  const filePath = join(getUserDataDir(dev), CLI_BRIDGE_TOKEN_DIR, CLI_BRIDGE_TOKEN_FILE);
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new BridgeUnavailableError(NOT_RUNNING_HINT);
+    }
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new BridgeUnavailableError(
+      `CLI bridge token file is corrupt (${filePath}). ${NOT_RUNNING_HINT}`,
+    );
+  }
+
+  const result = CliBridgeTokenFileSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new BridgeUnavailableError(
+      `CLI bridge token file is invalid (${filePath}). ${NOT_RUNNING_HINT}`,
+    );
+  }
+  return result.data;
+}
+
+export interface BridgeClientOptions {
+  dev?: boolean;
+  /** Injectable for testing. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+  /** Injectable for testing. Defaults to readTokenFile. */
+  tokenLoader?: (dev?: boolean) => Promise<CliBridgeTokenFile>;
+}
+
+/** Tiny typed client over the bridge HTTP API. */
+export class BridgeClient {
+  private readonly fetchFn: typeof fetch;
+  private readonly tokenLoader: (dev?: boolean) => Promise<CliBridgeTokenFile>;
+  private readonly dev?: boolean;
+  private tokenFile: CliBridgeTokenFile | null = null;
+
+  constructor(options: BridgeClientOptions = {}) {
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.tokenLoader = options.tokenLoader ?? readTokenFile;
+    this.dev = options.dev;
+  }
+
+  private async ensureToken(): Promise<CliBridgeTokenFile> {
+    if (!this.tokenFile) {
+      this.tokenFile = await this.tokenLoader(this.dev);
+    }
+    return this.tokenFile;
+  }
+
+  /** Build the absolute URL for a bridge path. */
+  async buildUrl(path: string): Promise<string> {
+    const { port } = await this.ensureToken();
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    return `http://${CLI_BRIDGE_HOST}:${port}${normalized}`;
+  }
+
+  async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+    const token = await this.ensureToken();
+    const url = await this.buildUrl(path);
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token.token}`,
+          ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      // Connection refused etc. → app not actually listening.
+      throw new BridgeUnavailableError(
+        `${NOT_RUNNING_HINT} (${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+
+    let payload: BridgeResponse<T>;
+    try {
+      payload = (await response.json()) as BridgeResponse<T>;
+    } catch {
+      throw new Error(`Bridge returned a non-JSON response (HTTP ${response.status}).`);
+    }
+
+    if (!payload.ok) {
+      throw new Error(payload.error || `Request failed (HTTP ${response.status}).`);
+    }
+    return payload.data;
+  }
+
+  get<T = unknown>(path: string): Promise<T> {
+    return this.request<T>("GET", path);
+  }
+  post<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+  put<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PUT", path, body);
+  }
+  patch<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PATCH", path, body);
+  }
+  del<T = unknown>(path: string): Promise<T> {
+    return this.request<T>("DELETE", path);
+  }
+}

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "./args";
+import { buildRequest, UsageError } from "./commands";
+
+function build(argv: string[]) {
+  return buildRequest(parseArgs(argv));
+}
+
+describe("parseArgs", () => {
+  it("splits positionals and options", () => {
+    const r = parseArgs(["mcp", "add", "--name", "Foo", "--transport", "stdio"]);
+    expect(r.positionals).toEqual(["mcp", "add"]);
+    expect(r.options).toEqual({ name: "Foo", transport: "stdio" });
+  });
+
+  it("supports --key=value", () => {
+    const r = parseArgs(["mcp", "add", "--name=Foo Bar"]);
+    expect(r.options.name).toBe("Foo Bar");
+  });
+
+  it("treats trailing/known flags as boolean", () => {
+    const r = parseArgs(["mcp", "enable", "abc", "--off"]);
+    expect(r.options.off).toBe(true);
+    expect(r.positionals).toEqual(["mcp", "enable", "abc"]);
+  });
+});
+
+describe("buildRequest - mcp", () => {
+  it("mcp list -> GET /mcp/servers", () => {
+    expect(build(["mcp", "list"])).toMatchObject({ method: "GET", path: "/mcp/servers" });
+  });
+
+  it("mcp add stdio builds a POST with command + args + env", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Local",
+      "--transport",
+      "stdio",
+      "--command",
+      "node",
+      "--args",
+      "server.js --port 3000",
+      "--env",
+      "API_KEY=abc,DEBUG=1",
+    ]);
+    expect(req.method).toBe("POST");
+    expect(req.path).toBe("/mcp/servers");
+    expect(req.body).toEqual({
+      name: "Local",
+      description: undefined,
+      transport: "stdio",
+      command: "node",
+      args: ["server.js", "--port", "3000"],
+      env: { API_KEY: "abc", DEBUG: "1" },
+    });
+  });
+
+  it("mcp add http builds a POST with url + headers", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Remote",
+      "--transport",
+      "http",
+      "--url",
+      "https://example.com/mcp",
+      "--header",
+      "Authorization=Bearer xyz",
+    ]);
+    expect(req.body).toMatchObject({
+      transport: "streamableHttp",
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer xyz" },
+    });
+  });
+
+  it("mcp add throws when required option missing", () => {
+    expect(() => build(["mcp", "add", "--transport", "stdio"])).toThrow(/Missing required --name/);
+    expect(() => build(["mcp", "add", "--name", "X", "--transport", "stdio"])).toThrow(
+      /Missing required --command/,
+    );
+  });
+
+  it("mcp add rejects unknown transport", () => {
+    expect(() => build(["mcp", "add", "--name", "X", "--transport", "carrier-pigeon"])).toThrow(
+      UsageError,
+    );
+  });
+
+  it("mcp remove <id> -> DELETE", () => {
+    expect(build(["mcp", "remove", "srv-9"])).toMatchObject({
+      method: "DELETE",
+      path: "/mcp/servers/srv-9",
+    });
+  });
+
+  it("mcp remove without id throws usage error", () => {
+    expect(() => build(["mcp", "remove"])).toThrow(UsageError);
+  });
+
+  it("mcp enable <id> -> POST enabled:true", () => {
+    expect(build(["mcp", "enable", "srv-9"])).toMatchObject({
+      method: "POST",
+      path: "/mcp/servers/srv-9/enabled",
+      body: { enabled: true },
+    });
+  });
+
+  it("mcp enable <id> --off -> POST enabled:false", () => {
+    expect(build(["mcp", "enable", "srv-9", "--off"])).toMatchObject({
+      body: { enabled: false },
+    });
+  });
+
+  it("url-encodes ids with special chars", () => {
+    expect(build(["mcp", "remove", "a/b c"]).path).toBe("/mcp/servers/a%2Fb%20c");
+  });
+});
+
+describe("buildRequest - config", () => {
+  it("config get llm -> GET /llm/config", () => {
+    expect(build(["config", "get", "llm"])).toMatchObject({ method: "GET", path: "/llm/config" });
+  });
+
+  it("config get defaults to settings", () => {
+    expect(build(["config", "get"])).toMatchObject({ method: "GET", path: "/settings" });
+  });
+
+  it("config set settings builds a PATCH patch", () => {
+    const req = build([
+      "config",
+      "set",
+      "settings",
+      "--tool-approval-mode",
+      "yolo",
+      "--open-at-login",
+      "true",
+    ]);
+    expect(req.method).toBe("PATCH");
+    expect(req.path).toBe("/settings");
+    expect(req.body).toEqual({ toolApprovalMode: "yolo", openAtLogin: true });
+  });
+
+  it("config set settings with no fields throws usage error", () => {
+    expect(() => build(["config", "set", "settings"])).toThrow(UsageError);
+  });
+
+  it("config set llm is unsupported", () => {
+    expect(() => build(["config", "set", "llm"])).toThrow(/not supported/);
+  });
+});
+
+describe("buildRequest - errors", () => {
+  it("unknown top-level command throws UsageError", () => {
+    expect(() => build(["frobnicate"])).toThrow(UsageError);
+  });
+  it("unknown mcp subcommand throws UsageError", () => {
+    expect(() => build(["mcp", "wat"])).toThrow(UsageError);
+  });
+});

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -118,6 +118,67 @@ describe("buildRequest - mcp", () => {
   it("url-encodes ids with special chars", () => {
     expect(build(["mcp", "remove", "a/b c"]).path).toBe("/mcp/servers/a%2Fb%20c");
   });
+
+  it("mcp update with only --url PUTs only the provided field", () => {
+    const req = build(["mcp", "update", "srv-9", "--url", "https://new.example.com/mcp"]);
+    expect(req).toMatchObject({ method: "PUT", path: "/mcp/servers/srv-9" });
+    expect(req.body).toEqual({ url: "https://new.example.com/mcp" });
+  });
+
+  it("mcp update sends ONLY provided fields (no transport unless given)", () => {
+    const req = build(["mcp", "update", "srv-9", "--name", "Renamed", "--env", "K=V"]);
+    expect(req.body).toEqual({ name: "Renamed", env: { K: "V" } });
+  });
+
+  it("mcp update normalizes --transport http to streamableHttp", () => {
+    const req = build(["mcp", "update", "srv-9", "--transport", "http"]);
+    expect(req.body).toEqual({ transport: "streamableHttp" });
+  });
+
+  it("mcp update rejects an unknown transport", () => {
+    expect(() => build(["mcp", "update", "srv-9", "--transport", "carrier-pigeon"])).toThrow(
+      UsageError,
+    );
+  });
+
+  it("mcp update with no fields throws a usage error", () => {
+    expect(() => build(["mcp", "update", "srv-9"])).toThrow(/No fields to update/);
+  });
+
+  it("mcp update without id or --name throws a usage error", () => {
+    expect(() => build(["mcp", "update"])).toThrow(UsageError);
+  });
+});
+
+describe("buildRequest - mcp --name selector", () => {
+  it("mcp remove --name sets resolveName and an {id} placeholder path", () => {
+    const req = build(["mcp", "remove", "--name", "My Server"]);
+    expect(req.method).toBe("DELETE");
+    expect(req.path).toBe("/mcp/servers/{id}");
+    expect(req.resolveName).toBe("My Server");
+  });
+
+  it("mcp enable --name sets resolveName", () => {
+    const req = build(["mcp", "enable", "--name", "My Server"]);
+    expect(req.path).toBe("/mcp/servers/{id}/enabled");
+    expect(req.resolveName).toBe("My Server");
+    expect(req.body).toEqual({ enabled: true });
+  });
+
+  it("mcp update --name resolves the target and does NOT treat --name as a rename", () => {
+    const req = build(["mcp", "update", "--name", "My Server", "--url", "https://x.example/mcp"]);
+    expect(req.path).toBe("/mcp/servers/{id}");
+    expect(req.resolveName).toBe("My Server");
+    // --name was consumed as the selector, so it is NOT in the patch body.
+    expect(req.body).toEqual({ url: "https://x.example/mcp" });
+  });
+
+  it("mcp update <id> --name treats --name as a rename (id is the selector)", () => {
+    const req = build(["mcp", "update", "srv-9", "--name", "Renamed"]);
+    expect(req.path).toBe("/mcp/servers/srv-9");
+    expect(req.resolveName).toBeUndefined();
+    expect(req.body).toEqual({ name: "Renamed" });
+  });
 });
 
 describe("buildRequest - config", () => {
@@ -150,6 +211,34 @@ describe("buildRequest - config", () => {
 
   it("config set llm is unsupported", () => {
     expect(() => build(["config", "set", "llm"])).toThrow(/not supported/);
+  });
+
+  it("config get orchestrator -> GET /llm/config", () => {
+    expect(build(["config", "get", "orchestrator"])).toMatchObject({
+      method: "GET",
+      path: "/llm/config",
+    });
+  });
+
+  it("config set orchestrator --backend local-claude -> POST", () => {
+    const req = build(["config", "set", "orchestrator", "--backend", "local-claude"]);
+    expect(req).toMatchObject({ method: "POST", path: "/llm/config/orchestrator" });
+    expect(req.body).toEqual({ orchestrationBackend: "local-claude" });
+  });
+
+  it("config set orchestrator --backend openai -> POST", () => {
+    const req = build(["config", "set", "orchestrator", "--backend", "openai"]);
+    expect(req.body).toEqual({ orchestrationBackend: "openai" });
+  });
+
+  it("config set orchestrator rejects an unknown backend", () => {
+    expect(() => build(["config", "set", "orchestrator", "--backend", "gpt5"])).toThrow(
+      /--backend must be one of/,
+    );
+  });
+
+  it("config set orchestrator requires --backend", () => {
+    expect(() => build(["config", "set", "orchestrator"])).toThrow(/Missing required --backend/);
   });
 });
 

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -57,6 +57,54 @@ describe("buildRequest - mcp", () => {
     });
   });
 
+  it("mcp add stdio with repeatable --arg preserves a value containing spaces", () => {
+    const req = build([
+      "mcp",
+      "add",
+      "--name",
+      "Local",
+      "--transport",
+      "stdio",
+      "--command",
+      "node",
+      "--arg",
+      "/My Documents/server.js",
+      // A flag-like value must use the = form so it is not parsed as a new flag.
+      "--arg=--port",
+      "--arg",
+      "3000",
+    ]);
+    expect(req.body).toMatchObject({
+      command: "node",
+      // Each --arg is one argv entry; the spaced path is NOT shredded.
+      args: ["/My Documents/server.js", "--port", "3000"],
+    });
+  });
+
+  it("mcp add stdio rejects mixing --arg and --args", () => {
+    expect(() =>
+      build([
+        "mcp",
+        "add",
+        "--name",
+        "Local",
+        "--transport",
+        "stdio",
+        "--command",
+        "node",
+        "--args",
+        "a b",
+        "--arg",
+        "c",
+      ]),
+    ).toThrow(/either repeatable --arg/);
+  });
+
+  it("mcp update with repeatable --arg sets the args array verbatim", () => {
+    const req = build(["mcp", "update", "srv-9", "--arg", "/path with space/x.js", "--arg=--flag"]);
+    expect(req.body).toEqual({ args: ["/path with space/x.js", "--flag"] });
+  });
+
   it("mcp add http builds a POST with url + headers", () => {
     const req = build([
       "mcp",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,167 @@
+import { optionalString, type ParsedArgs, parseKeyValueList, requireString } from "./args";
+
+/** A resolved request the CLI should issue against the bridge. */
+export interface CommandRequest {
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  path: string;
+  body?: unknown;
+  /** Short human label used when pretty-printing the result. */
+  label: string;
+}
+
+/**
+ * Translate parsed CLI args into a bridge request.
+ *
+ * Pure and side-effect free (no fetch, no fs) so the routing/validation logic is
+ * unit-testable in isolation. Throws on bad usage with a clear message.
+ */
+export function buildRequest(parsed: ParsedArgs): CommandRequest {
+  const [group, action, ...rest] = parsed.positionals;
+  const { options } = parsed;
+
+  if (group === "mcp") {
+    return buildMcpRequest(action, rest, options);
+  }
+  if (group === "config") {
+    return buildConfigRequest(action, rest, options);
+  }
+
+  throw new UsageError(`Unknown command: ${[group, action].filter(Boolean).join(" ")}`);
+}
+
+function buildMcpRequest(
+  action: string | undefined,
+  rest: string[],
+  options: Record<string, string | boolean>,
+): CommandRequest {
+  switch (action) {
+    case "list":
+      return { method: "GET", path: "/mcp/servers", label: "MCP servers" };
+
+    case "add": {
+      const transport = requireString(options, "transport");
+      if (transport !== "stdio" && transport !== "streamableHttp" && transport !== "http") {
+        throw new UsageError(`--transport must be one of: stdio, http (streamableHttp)`);
+      }
+      const name = requireString(options, "name");
+      const description = optionalString(options, "description");
+
+      if (transport === "stdio") {
+        const command = requireString(options, "command");
+        const argsValue = optionalString(options, "args");
+        const body = {
+          name,
+          description,
+          transport: "stdio" as const,
+          command,
+          args: argsValue ? argsValue.split(" ").filter(Boolean) : undefined,
+          env: parseKeyValueList(optionalString(options, "env")),
+        };
+        return { method: "POST", path: "/mcp/servers", body, label: "Added MCP server" };
+      }
+
+      // http / streamableHttp
+      const url = requireString(options, "url");
+      const body = {
+        name,
+        description,
+        transport: "streamableHttp" as const,
+        url,
+        headers: parseKeyValueList(optionalString(options, "header")),
+      };
+      return { method: "POST", path: "/mcp/servers", body, label: "Added MCP server" };
+    }
+
+    case "remove": {
+      const id = rest[0];
+      if (!id) throw new UsageError("Usage: yakshaver mcp remove <id>");
+      return {
+        method: "DELETE",
+        path: `/mcp/servers/${encodeURIComponent(id)}`,
+        label: "Removed MCP server",
+      };
+    }
+
+    case "enable": {
+      const id = rest[0];
+      if (!id) throw new UsageError("Usage: yakshaver mcp enable <id> [--off]");
+      const enabled = options.off !== true;
+      return {
+        method: "POST",
+        path: `/mcp/servers/${encodeURIComponent(id)}/enabled`,
+        body: { enabled },
+        label: enabled ? "Enabled MCP server" : "Disabled MCP server",
+      };
+    }
+
+    default:
+      throw new UsageError(`Unknown mcp subcommand: ${action ?? "(none)"}`);
+  }
+}
+
+function buildConfigRequest(
+  action: string | undefined,
+  rest: string[],
+  options: Record<string, string | boolean>,
+): CommandRequest {
+  const target = rest[0] ?? "settings"; // default to settings
+
+  if (action === "get") {
+    if (target === "llm") {
+      return { method: "GET", path: "/llm/config", label: "LLM config" };
+    }
+    if (target === "settings") {
+      return { method: "GET", path: "/settings", label: "User settings" };
+    }
+    throw new UsageError("Usage: yakshaver config get [llm|settings]");
+  }
+
+  if (action === "set") {
+    if (target === "settings") {
+      const body = buildSettingsPatch(options);
+      return { method: "PATCH", path: "/settings", body, label: "Updated settings" };
+    }
+    if (target === "llm") {
+      throw new UsageError(
+        "Setting the full LLM config via the CLI is not supported (it requires secrets). " +
+          "Configure providers in the app UI.",
+      );
+    }
+    throw new UsageError("Usage: yakshaver config set settings --<key> <value>");
+  }
+
+  throw new UsageError(`Unknown config subcommand: ${action ?? "(none)"}`);
+}
+
+function buildSettingsPatch(options: Record<string, string | boolean>): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+
+  const toolApprovalMode = optionalString(options, "tool-approval-mode");
+  if (toolApprovalMode !== undefined) {
+    patch.toolApprovalMode = toolApprovalMode;
+  }
+
+  if (options["open-at-login"] !== undefined) {
+    patch.openAtLogin = coerceBoolean(options["open-at-login"]);
+  }
+
+  if (Object.keys(patch).length === 0) {
+    throw new UsageError(
+      "No settings provided. Try --tool-approval-mode <yolo|wait|ask> or --open-at-login <true|false>",
+    );
+  }
+  return patch;
+}
+
+function coerceBoolean(value: string | boolean): boolean {
+  if (typeof value === "boolean") return value;
+  return value === "true" || value === "1" || value === "yes";
+}
+
+/** A usage/validation error (distinct from runtime/bridge errors). */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,4 +1,10 @@
-import { optionalString, type ParsedArgs, parseKeyValueList, requireString } from "./args";
+import {
+  optionalString,
+  type ParsedArgs,
+  parseKeyValueList,
+  repeatedStrings,
+  requireString,
+} from "./args";
 
 /** A resolved request the CLI should issue against the bridge. */
 export interface CommandRequest {
@@ -30,7 +36,7 @@ export function buildRequest(parsed: ParsedArgs): CommandRequest {
   const { options } = parsed;
 
   if (group === "mcp") {
-    return buildMcpRequest(action, rest, options);
+    return buildMcpRequest(action, rest, options, parsed);
   }
   if (group === "config") {
     return buildConfigRequest(action, rest, options);
@@ -39,10 +45,41 @@ export function buildRequest(parsed: ParsedArgs): CommandRequest {
   throw new UsageError(`Unknown command: ${[group, action].filter(Boolean).join(" ")}`);
 }
 
+/**
+ * Resolve the stdio `args` array from the CLI flags.
+ *
+ * Prefers the repeatable `--arg <value>` form (one value per flag, each
+ * preserved VERBATIM so a single argument may contain spaces, e.g. a path like
+ * `/My Documents/server.js`). Falls back to the legacy single `--args "a b c"`
+ * form, which splits on whitespace and therefore CANNOT express an argument
+ * containing a space. The two forms are mutually exclusive.
+ *
+ * Returns `undefined` when neither flag is given (so the field is omitted and
+ * any existing value is preserved on update).
+ */
+function resolveStdioArgs(
+  options: Record<string, string | boolean>,
+  parsed: Pick<ParsedArgs, "repeated">,
+): string[] | undefined {
+  const repeated = repeatedStrings(parsed, "arg");
+  const argsValue = optionalString(options, "args");
+
+  if (repeated && argsValue !== undefined) {
+    throw new UsageError(
+      'Use either repeatable --arg <value> (preserves spaces) or a single --args "a b c", not both.',
+    );
+  }
+
+  if (repeated) return repeated;
+  if (argsValue !== undefined) return argsValue.split(" ").filter(Boolean);
+  return undefined;
+}
+
 function buildMcpRequest(
   action: string | undefined,
   rest: string[],
   options: Record<string, string | boolean>,
+  parsed: Pick<ParsedArgs, "repeated">,
 ): CommandRequest {
   switch (action) {
     case "list":
@@ -58,13 +95,12 @@ function buildMcpRequest(
 
       if (transport === "stdio") {
         const command = requireString(options, "command");
-        const argsValue = optionalString(options, "args");
         const body = {
           name,
           description,
           transport: "stdio" as const,
           command,
-          args: argsValue ? argsValue.split(" ").filter(Boolean) : undefined,
+          args: resolveStdioArgs(options, parsed),
           env: parseKeyValueList(optionalString(options, "env")),
         };
         return { method: "POST", path: "/mcp/servers", body, label: "Added MCP server" };
@@ -110,7 +146,7 @@ function buildMcpRequest(
         options,
         "update <id> | --name <name> [--url ... | --command ... | --args ... | --env ... | --header ... | --transport ...]",
       );
-      const body = buildMcpPatch(options, target.usedNameForLookup);
+      const body = buildMcpPatch(options, target.usedNameForLookup, parsed);
       return {
         ...target,
         method: "PUT",
@@ -160,6 +196,7 @@ function resolveTarget(
 function buildMcpPatch(
   options: Record<string, string | boolean>,
   nameUsedForLookup: boolean,
+  parsed: Pick<ParsedArgs, "repeated">,
 ): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
 
@@ -186,8 +223,8 @@ function buildMcpPatch(
   const command = optionalString(options, "command");
   if (command !== undefined) patch.command = command;
 
-  const argsValue = optionalString(options, "args");
-  if (argsValue !== undefined) patch.args = argsValue.split(" ").filter(Boolean);
+  const args = resolveStdioArgs(options, parsed);
+  if (args !== undefined) patch.args = args;
 
   const env = parseKeyValueList(optionalString(options, "env"));
   if (env !== undefined) patch.env = env;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -7,7 +7,17 @@ export interface CommandRequest {
   body?: unknown;
   /** Short human label used when pretty-printing the result. */
   label: string;
+  /**
+   * When set, the CLI must first resolve this MCP server NAME to an id (via
+   * `GET /mcp/servers`) and substitute it for the `{id}` placeholder in `path`
+   * before issuing the request. Kept out of {@link buildRequest} so that
+   * function stays pure (no fetch); the runtime resolution lives in index.ts.
+   */
+  resolveName?: string;
 }
+
+/** Placeholder substituted with a resolved server id when `resolveName` is set. */
+export const ID_PLACEHOLDER = "{id}";
 
 /**
  * Translate parsed CLI args into a bridge request.
@@ -73,30 +83,124 @@ function buildMcpRequest(
     }
 
     case "remove": {
-      const id = rest[0];
-      if (!id) throw new UsageError("Usage: yakshaver mcp remove <id>");
+      const target = resolveTarget(rest[0], options, "remove <id> | --name <name>");
       return {
+        ...target,
         method: "DELETE",
-        path: `/mcp/servers/${encodeURIComponent(id)}`,
+        path: `/mcp/servers/${target.idSegment}`,
         label: "Removed MCP server",
       };
     }
 
     case "enable": {
-      const id = rest[0];
-      if (!id) throw new UsageError("Usage: yakshaver mcp enable <id> [--off]");
+      const target = resolveTarget(rest[0], options, "enable <id> | --name <name> [--off]");
       const enabled = options.off !== true;
       return {
+        ...target,
         method: "POST",
-        path: `/mcp/servers/${encodeURIComponent(id)}/enabled`,
+        path: `/mcp/servers/${target.idSegment}/enabled`,
         body: { enabled },
         label: enabled ? "Enabled MCP server" : "Disabled MCP server",
+      };
+    }
+
+    case "update": {
+      const target = resolveTarget(
+        rest[0],
+        options,
+        "update <id> | --name <name> [--url ... | --command ... | --args ... | --env ... | --header ... | --transport ...]",
+      );
+      const body = buildMcpPatch(options, target.usedNameForLookup);
+      return {
+        ...target,
+        method: "PUT",
+        path: `/mcp/servers/${target.idSegment}`,
+        body,
+        label: "Updated MCP server",
       };
     }
 
     default:
       throw new UsageError(`Unknown mcp subcommand: ${action ?? "(none)"}`);
   }
+}
+
+/**
+ * Resolve the server target for `remove`/`enable`/`update`.
+ *
+ * The selector is EITHER a positional id OR `--name <name>` (resolved to an id
+ * at runtime via the bridge). When a positional id is given, `--name` is free to
+ * act as a rename field on `update` (see {@link buildMcpPatch}); when no
+ * positional id is given, `--name` IS the selector and is consumed for lookup.
+ */
+function resolveTarget(
+  positionalId: string | undefined,
+  options: Record<string, string | boolean>,
+  usage: string,
+): { idSegment: string; resolveName?: string; usedNameForLookup: boolean } {
+  const name = optionalString(options, "name");
+
+  if (positionalId) {
+    // id is the selector; --name (if any) is a value to apply, not a lookup.
+    return { idSegment: encodeURIComponent(positionalId), usedNameForLookup: false };
+  }
+  if (name) {
+    return { idSegment: ID_PLACEHOLDER, resolveName: name, usedNameForLookup: true };
+  }
+  throw new UsageError(`Usage: yakshaver mcp ${usage}`);
+}
+
+/**
+ * Build the merge-update body for `mcp update`. Includes ONLY the fields the
+ * user actually provided so unspecified fields are preserved server-side.
+ *
+ * `--name` is reserved for server lookup when used as a selector, so we only
+ * treat `--name` as a rename when it was NOT consumed to resolve the target.
+ */
+function buildMcpPatch(
+  options: Record<string, string | boolean>,
+  nameUsedForLookup: boolean,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+
+  if (!nameUsedForLookup) {
+    const name = optionalString(options, "name");
+    if (name !== undefined) patch.name = name;
+  }
+
+  const description = optionalString(options, "description");
+  if (description !== undefined) patch.description = description;
+
+  const transport = optionalString(options, "transport");
+  if (transport !== undefined) {
+    const normalized = transport === "http" ? "streamableHttp" : transport;
+    if (normalized !== "stdio" && normalized !== "streamableHttp") {
+      throw new UsageError("--transport must be one of: stdio, http (streamableHttp)");
+    }
+    patch.transport = normalized;
+  }
+
+  const url = optionalString(options, "url");
+  if (url !== undefined) patch.url = url;
+
+  const command = optionalString(options, "command");
+  if (command !== undefined) patch.command = command;
+
+  const argsValue = optionalString(options, "args");
+  if (argsValue !== undefined) patch.args = argsValue.split(" ").filter(Boolean);
+
+  const env = parseKeyValueList(optionalString(options, "env"));
+  if (env !== undefined) patch.env = env;
+
+  const headers = parseKeyValueList(optionalString(options, "header"));
+  if (headers !== undefined) patch.headers = headers;
+
+  if (Object.keys(patch).length === 0) {
+    throw new UsageError(
+      "No fields to update. Provide at least one of --name/--description/--url/--command/--args/--env/--header/--transport",
+    );
+  }
+  return patch;
 }
 
 function buildConfigRequest(
@@ -107,16 +211,30 @@ function buildConfigRequest(
   const target = rest[0] ?? "settings"; // default to settings
 
   if (action === "get") {
-    if (target === "llm") {
+    if (target === "llm" || target === "orchestrator") {
+      // The LLM config carries `orchestrationBackend`; `get orchestrator` is an
+      // alias that surfaces the same payload.
       return { method: "GET", path: "/llm/config", label: "LLM config" };
     }
     if (target === "settings") {
       return { method: "GET", path: "/settings", label: "User settings" };
     }
-    throw new UsageError("Usage: yakshaver config get [llm|settings]");
+    throw new UsageError("Usage: yakshaver config get [llm|orchestrator|settings]");
   }
 
   if (action === "set") {
+    if (target === "orchestrator") {
+      const backend = requireString(options, "backend");
+      if (backend !== "openai" && backend !== "local-claude") {
+        throw new UsageError("--backend must be one of: openai, local-claude");
+      }
+      return {
+        method: "POST",
+        path: "/llm/config/orchestrator",
+        body: { orchestrationBackend: backend },
+        label: "Updated orchestration backend",
+      };
+    }
     if (target === "settings") {
       const body = buildSettingsPatch(options);
       return { method: "PATCH", path: "/settings", body, label: "Updated settings" };
@@ -124,10 +242,13 @@ function buildConfigRequest(
     if (target === "llm") {
       throw new UsageError(
         "Setting the full LLM config via the CLI is not supported (it requires secrets). " +
-          "Configure providers in the app UI.",
+          "Configure providers in the app UI, or set the orchestrator with " +
+          "`config set orchestrator --backend <openai|local-claude>`.",
       );
     }
-    throw new UsageError("Usage: yakshaver config set settings --<key> <value>");
+    throw new UsageError(
+      "Usage: yakshaver config set [settings --<key> <value> | orchestrator --backend <openai|local-claude>]",
+    );
   }
 
   throw new UsageError(`Unknown config subcommand: ${action ?? "(none)"}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { parseArgs } from "./args";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
-import { buildRequest, type CommandRequest, UsageError } from "./commands";
+import { buildRequest, type CommandRequest, ID_PLACEHOLDER, UsageError } from "./commands";
+import { resolveServerIdByName } from "./resolve-name";
 
 const HELP = `yakshaver — configure YakShaver Desktop from the terminal
 
@@ -15,13 +16,18 @@ MCP
   yakshaver mcp list
   yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b"] [--env "K=V,K2=V2"]
   yakshaver mcp add --name <name> --transport http  --url <url> [--header "K=V"]
+  yakshaver mcp update <id> [--name ... --url ... --command ... --args ... --env ... --header ... --transport ...]
   yakshaver mcp remove <id>
   yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
 
+  remove/enable/update also accept --name <name> instead of a positional <id>
+  (resolved against the server list; errors if the name is missing or ambiguous).
+
 CONFIG
-  yakshaver config get [llm|settings]      # defaults to settings
+  yakshaver config get [llm|orchestrator|settings]   # defaults to settings
   yakshaver config set settings --tool-approval-mode <yolo|wait|ask>
   yakshaver config set settings --open-at-login <true|false>
+  yakshaver config set orchestrator --backend <openai|local-claude>
 
 GLOBAL
   --dev      Target the dev build (YakShaverDev) userData
@@ -53,10 +59,15 @@ async function main(argv: string[]): Promise<number> {
   const client = new BridgeClient({ dev: parsed.options.dev === true });
 
   try {
-    const data = await client.request(request.method, request.path, request.body);
+    const path = await resolvePath(client, request);
+    const data = await client.request(request.method, path, request.body);
     printResult(request.label, data, parsed.options.json === true);
     return 0;
   } catch (err) {
+    if (err instanceof UsageError) {
+      console.error(`Error: ${err.message}`);
+      return 2;
+    }
     if (err instanceof BridgeUnavailableError) {
       console.error(err.message);
       return 3;
@@ -64,6 +75,18 @@ async function main(argv: string[]): Promise<number> {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
   }
+}
+
+/**
+ * If the request targets an MCP server by name, resolve the name to a concrete
+ * id via `GET /mcp/servers` and substitute it into the path. Otherwise return
+ * the path unchanged. Throws a {@link UsageError} on 0 or >1 matches.
+ */
+async function resolvePath(client: BridgeClient, request: CommandRequest): Promise<string> {
+  if (!request.resolveName) return request.path;
+  const servers = await client.get<unknown[]>("/mcp/servers");
+  const id = resolveServerIdByName(servers, request.resolveName);
+  return request.path.replace(ID_PLACEHOLDER, encodeURIComponent(id));
 }
 
 function printResult(label: string, data: unknown, asJson: boolean): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,14 +14,20 @@ token-authenticated bridge.
 
 MCP
   yakshaver mcp list
-  yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b"] [--env "K=V,K2=V2"]
+  yakshaver mcp add --name <name> --transport stdio --command <cmd> [--arg <a> --arg <b>] [--env "K=V,K2=V2"]
   yakshaver mcp add --name <name> --transport http  --url <url> [--header "K=V"]
-  yakshaver mcp update <id> [--name ... --url ... --command ... --args ... --env ... --header ... --transport ...]
+  yakshaver mcp update <id> [--name ... --url ... --command ... --arg ... --env ... --header ... --transport ...]
   yakshaver mcp remove <id>
   yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
 
   remove/enable/update also accept --name <name> instead of a positional <id>
   (resolved against the server list; errors if the name is missing or ambiguous).
+
+  stdio args: pass --arg once per argument (repeatable) to preserve spaces,
+  e.g. --arg "/My Documents/server.js". For an argument that itself starts with
+  "--", use the = form (--arg=--port). The legacy --args "a b c" form splits on
+  whitespace and cannot express an argument that contains a space; the two forms
+  are mutually exclusive. Built-in servers cannot be modified or removed.
 
 CONFIG
   yakshaver config get [llm|orchestrator|settings]   # defaults to settings

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { parseArgs } from "./args";
+import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
+import { buildRequest, type CommandRequest, UsageError } from "./commands";
+
+const HELP = `yakshaver — configure YakShaver Desktop from the terminal
+
+USAGE
+  yakshaver <command> [options]
+
+The desktop app must be running; the CLI talks to it over a localhost-only,
+token-authenticated bridge.
+
+MCP
+  yakshaver mcp list
+  yakshaver mcp add --name <name> --transport stdio --command <cmd> [--args "a b"] [--env "K=V,K2=V2"]
+  yakshaver mcp add --name <name> --transport http  --url <url> [--header "K=V"]
+  yakshaver mcp remove <id>
+  yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
+
+CONFIG
+  yakshaver config get [llm|settings]      # defaults to settings
+  yakshaver config set settings --tool-approval-mode <yolo|wait|ask>
+  yakshaver config set settings --open-at-login <true|false>
+
+GLOBAL
+  --dev      Target the dev build (YakShaverDev) userData
+  --json     Print raw JSON instead of pretty output
+  -h, --help Show this help
+
+Secrets (api keys, header/env values) are always redacted in output.`;
+
+async function main(argv: string[]): Promise<number> {
+  const parsed = parseArgs(argv);
+
+  if (parsed.options.help || parsed.positionals.length === 0) {
+    console.log(HELP);
+    return parsed.positionals.length === 0 && !parsed.options.help ? 1 : 0;
+  }
+
+  let request: CommandRequest;
+  try {
+    request = buildRequest(parsed);
+  } catch (err) {
+    if (err instanceof UsageError) {
+      console.error(`Error: ${err.message}\n`);
+      console.error(HELP);
+      return 2;
+    }
+    throw err;
+  }
+
+  const client = new BridgeClient({ dev: parsed.options.dev === true });
+
+  try {
+    const data = await client.request(request.method, request.path, request.body);
+    printResult(request.label, data, parsed.options.json === true);
+    return 0;
+  } catch (err) {
+    if (err instanceof BridgeUnavailableError) {
+      console.error(err.message);
+      return 3;
+    }
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+function printResult(label: string, data: unknown, asJson: boolean): void {
+  if (asJson) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  // Pretty-print MCP server lists as a compact table-ish summary.
+  if (Array.isArray(data)) {
+    console.log(`${label} (${data.length}):`);
+    for (const item of data) {
+      printServerLine(item);
+    }
+    return;
+  }
+
+  if (label.startsWith("Added") || label.startsWith("Removed") || label.includes("MCP server")) {
+    console.log(`${label}:`);
+    printServerLine(data);
+    return;
+  }
+
+  console.log(`${label}:`);
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function printServerLine(item: unknown): void {
+  if (!item || typeof item !== "object") {
+    console.log(`  ${JSON.stringify(item)}`);
+    return;
+  }
+  const s = item as Record<string, unknown>;
+  const enabled = s.enabled === false ? "disabled" : "enabled";
+  const target = s.url ?? s.command ?? "";
+  const builtin = s.builtin ? " [builtin]" : "";
+  console.log(
+    `  - ${String(s.name ?? "(unnamed)")} [${String(s.transport ?? "?")}] (${enabled})${builtin}` +
+      `\n      id: ${String(s.id ?? "?")}` +
+      (target ? `\n      ${s.url ? "url" : "command"}: ${String(target)}` : ""),
+  );
+}
+
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    console.error(`Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  });

--- a/src/cli/resolve-name.test.ts
+++ b/src/cli/resolve-name.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { UsageError } from "./commands";
+import { resolveServerIdByName } from "./resolve-name";
+
+describe("resolveServerIdByName", () => {
+  const servers = [
+    { id: "srv-1", name: "Alpha" },
+    { id: "srv-2", name: "Beta" },
+    { id: "srv-3", name: "Beta" }, // duplicate name -> ambiguous
+  ];
+
+  it("resolves a unique name to its id", () => {
+    expect(resolveServerIdByName(servers, "Alpha")).toBe("srv-1");
+  });
+
+  it("throws a UsageError when no server matches", () => {
+    expect(() => resolveServerIdByName(servers, "Gamma")).toThrow(UsageError);
+    expect(() => resolveServerIdByName(servers, "Gamma")).toThrow(/No MCP server found/);
+  });
+
+  it("throws a UsageError listing ids when the name is ambiguous", () => {
+    expect(() => resolveServerIdByName(servers, "Beta")).toThrow(/Multiple MCP servers match/);
+    expect(() => resolveServerIdByName(servers, "Beta")).toThrow(/srv-2, srv-3/);
+  });
+
+  it("treats a non-array input as empty (no match)", () => {
+    expect(() => resolveServerIdByName(null, "Alpha")).toThrow(/No MCP server found/);
+  });
+
+  it("rejects a matched server that has no usable id", () => {
+    expect(() => resolveServerIdByName([{ name: "Alpha" }], "Alpha")).toThrow(/no usable id/);
+  });
+});

--- a/src/cli/resolve-name.ts
+++ b/src/cli/resolve-name.ts
@@ -1,0 +1,34 @@
+import { UsageError } from "./commands";
+
+/**
+ * Resolve a unique MCP server id from a list of servers (as returned by
+ * `GET /mcp/servers`) given a server name.
+ *
+ * Pure and side-effect free so the matching + ambiguity rules are unit-testable
+ * in isolation. Matching is case-sensitive and exact on `name`.
+ *
+ * @throws {UsageError} when zero or more than one server matches the name.
+ */
+export function resolveServerIdByName(servers: unknown, name: string): string {
+  const list = Array.isArray(servers) ? servers : [];
+  const matches = list.filter(
+    (s): s is { id?: unknown; name?: unknown } =>
+      !!s && typeof s === "object" && (s as { name?: unknown }).name === name,
+  );
+
+  if (matches.length === 0) {
+    throw new UsageError(`No MCP server found with name '${name}'`);
+  }
+  if (matches.length > 1) {
+    const ids = matches.map((m) => String(m.id ?? "?")).join(", ");
+    throw new UsageError(
+      `Multiple MCP servers match name '${name}' (ids: ${ids}). Use the positional <id> instead.`,
+    );
+  }
+
+  const id = matches[0].id;
+  if (typeof id !== "string" || id.length === 0) {
+    throw new UsageError(`MCP server '${name}' has no usable id`);
+  }
+  return id;
+}

--- a/src/cli/user-data-path.ts
+++ b/src/cli/user-data-path.ts
@@ -1,0 +1,41 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Replicate Electron's `app.getPath('userData')` for a plain Node process.
+ *
+ * The desktop app stores config under `<appData>/YakShaver` (or
+ * `<appData>/YakShaverDev` in development — see src/backend/index.ts). The CLI
+ * is NOT Electron, so we recompute the per-OS appData location here.
+ *
+ * Electron's appData maps to:
+ *   - Windows: %APPDATA%            (C:\Users\<user>\AppData\Roaming)
+ *   - macOS:   ~/Library/Application Support
+ *   - Linux:   $XDG_CONFIG_HOME or ~/.config
+ *
+ * The userData folder name is the Electron app name ("YakShaver"), overridden to
+ * "YakShaverDev" when running against a dev build.
+ */
+export function getAppDataDir(): string {
+  if (process.platform === "win32") {
+    return process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+  }
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Application Support");
+  }
+  return process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+}
+
+/** Resolve the YakShaver userData directory. Pass `dev: true` for a dev build. */
+export function getUserDataDir(dev = isDevEnv()): string {
+  const appName = dev ? "YakShaverDev" : "YakShaver";
+  return join(getAppDataDir(), appName);
+}
+
+/**
+ * Whether to target the dev build's userData. Controlled by the
+ * YAKSHAVER_ENV=development env var or a `--dev` flag handled by the caller.
+ */
+export function isDevEnv(): boolean {
+  return process.env.YAKSHAVER_ENV === "development" || process.env.NODE_ENV === "development";
+}

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+
+/**
+ * Shared protocol definitions for the YakShaver CLI bridge.
+ *
+ * The bridge is a localhost-only HTTP server started by the desktop app's main
+ * process. The `yakshaver` CLI talks to it. Both sides import the constants and
+ * Zod schemas here so the wire format stays in lockstep.
+ */
+
+/** Name of the token file written under `userData/yakshaver-tokens/`. */
+export const CLI_BRIDGE_TOKEN_FILE = "cli-bridge.json";
+
+/** Directory (relative to userData) where secure tokens live. */
+export const CLI_BRIDGE_TOKEN_DIR = "yakshaver-tokens";
+
+/** Host the bridge binds to. Localhost ONLY — never expose to the network. */
+export const CLI_BRIDGE_HOST = "127.0.0.1";
+
+/** Default port the bridge attempts to bind. May fall back to an ephemeral port. */
+export const CLI_BRIDGE_DEFAULT_PORT = 8765;
+
+/** Env var that, when truthy, disables the bridge entirely. */
+export const CLI_BRIDGE_DISABLE_ENV = "YAKSHAVER_DISABLE_CLI_BRIDGE";
+
+/** Placeholder shown instead of any secret value. */
+export const REDACTED = "***redacted***";
+
+/** Shape of the token file the app writes and the CLI reads. */
+export interface CliBridgeTokenFile {
+  port: number;
+  token: string;
+  /** ISO timestamp the bridge last (re)started. Informational only. */
+  startedAt: string;
+  /** App version, for diagnostics. */
+  version?: string;
+}
+
+export const CliBridgeTokenFileSchema = z.object({
+  port: z.number().int().positive(),
+  token: z.string().min(1),
+  startedAt: z.string(),
+  version: z.string().optional(),
+});
+
+/** Envelope every endpoint returns. */
+export type BridgeResponse<T = unknown> = { ok: true; data: T } | { ok: false; error: string };
+
+// ---------------------------------------------------------------------------
+// MCP server payload schemas (subset of MCPServerConfig the CLI can set).
+// Mirrors the validation the MCPServerManager performs internally, but lets us
+// reject bad input early at the bridge boundary.
+// ---------------------------------------------------------------------------
+
+const stringRecord = z.record(z.string(), z.string());
+
+const baseFields = {
+  name: z.string().min(1, "name is required"),
+  description: z.string().optional(),
+  enabled: z.boolean().optional(),
+  toolWhitelist: z.array(z.string()).optional(),
+};
+
+export const HttpServerInputSchema = z.object({
+  ...baseFields,
+  transport: z.literal("streamableHttp"),
+  url: z.string().url("url must be a valid URL"),
+  headers: stringRecord.optional(),
+  version: z.string().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+});
+
+export const StdioServerInputSchema = z.object({
+  ...baseFields,
+  transport: z.literal("stdio"),
+  command: z.string().min(1, "command is required"),
+  args: z.array(z.string()).optional(),
+  env: stringRecord.optional(),
+  cwd: z.string().optional(),
+  stderr: z.enum(["inherit", "ignore", "pipe"]).optional(),
+});
+
+/** Input accepted by POST /mcp/servers and PUT /mcp/servers/:id. */
+export const McpServerInputSchema = z.discriminatedUnion("transport", [
+  HttpServerInputSchema,
+  StdioServerInputSchema,
+]);
+export type McpServerInput = z.infer<typeof McpServerInputSchema>;
+
+/** Input accepted by POST /mcp/servers/:id/enabled. */
+export const McpEnabledInputSchema = z.object({
+  enabled: z.boolean(),
+});
+
+/**
+ * Keys on an MCP server config considered secret. Redacted in any response.
+ * `headers` and `env` often carry tokens/api keys so we redact their values.
+ */
+export const MCP_SECRET_KEYS = ["headers", "env"] as const;

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -87,9 +87,47 @@ export const McpServerInputSchema = z.discriminatedUnion("transport", [
 ]);
 export type McpServerInput = z.infer<typeof McpServerInputSchema>;
 
+/**
+ * Input accepted by PUT /mcp/servers/:id (merge-update).
+ *
+ * Unlike {@link McpServerInputSchema}, every field is optional so callers can
+ * send ONLY the fields they want to change. The router merges the provided
+ * fields onto the existing server config. `transport` is optional here; when
+ * omitted the existing transport is preserved.
+ */
+export const McpServerPatchSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    enabled: z.boolean().optional(),
+    toolWhitelist: z.array(z.string()).optional(),
+    transport: z.enum(["stdio", "streamableHttp"]).optional(),
+    // http
+    url: z.string().url("url must be a valid URL").optional(),
+    headers: stringRecord.optional(),
+    timeoutMs: z.number().int().positive().optional(),
+    // stdio
+    command: z.string().min(1).optional(),
+    args: z.array(z.string()).optional(),
+    env: stringRecord.optional(),
+    cwd: z.string().optional(),
+    stderr: z.enum(["inherit", "ignore", "pipe"]).optional(),
+    version: z.string().optional(),
+  })
+  .strict();
+export type McpServerPatch = z.infer<typeof McpServerPatchSchema>;
+
 /** Input accepted by POST /mcp/servers/:id/enabled. */
 export const McpEnabledInputSchema = z.object({
   enabled: z.boolean(),
+});
+
+/** Orchestration backends the CLI may set. Mirrors `OrchestrationBackend`. */
+export const OrchestrationBackendSchema = z.enum(["openai", "local-claude"]);
+
+/** Input accepted by POST /llm/config/orchestrator. */
+export const OrchestratorInputSchema = z.object({
+  orchestrationBackend: OrchestrationBackendSchema,
 });
 
 /**

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -130,6 +130,46 @@ export const OrchestratorInputSchema = z.object({
   orchestrationBackend: OrchestrationBackendSchema,
 });
 
+// ---------------------------------------------------------------------------
+// Full LLM config payload (POST /llm/config). Mirrors `LLMConfigV2` in
+// src/shared/types/llm.ts so the bridge validates the body BEFORE it is
+// encrypted and persisted (storeLLMConfig performs no validation of its own).
+// ---------------------------------------------------------------------------
+
+const ProviderNameSchema = z.enum(["openai", "azure", "deepseek"]);
+
+/** A single model config (discriminated on `provider`). Mirrors `ModelConfig`. */
+const ModelConfigSchema = z.discriminatedUnion("provider", [
+  z.object({
+    provider: z.literal("openai"),
+    model: z.string().nullable(),
+    apiKey: z.string(),
+  }),
+  z.object({
+    provider: z.literal("deepseek"),
+    model: z.string().nullable(),
+    apiKey: z.string(),
+  }),
+  z.object({
+    provider: z.literal("azure"),
+    model: z.string().nullable(),
+    apiKey: z.string(),
+    resourceName: z.string(),
+  }),
+]);
+
+/** Input accepted by POST /llm/config. Mirrors `LLMConfigV2`. */
+export const LLMConfigV2Schema = z
+  .object({
+    version: z.literal(2),
+    languageModel: ModelConfigSchema.nullable(),
+    transcriptionModel: ModelConfigSchema.nullable(),
+    providerApiKeys: z.record(ProviderNameSchema, z.string()).optional(),
+    orchestrationBackend: OrchestrationBackendSchema.optional(),
+  })
+  .strict();
+export type LLMConfigV2Input = z.infer<typeof LLMConfigV2Schema>;
+
 /**
  * Keys on an MCP server config considered secret. Redacted in any response.
  * `headers` and `env` often carry tokens/api keys so we redact their values.

--- a/src/shared/cli-bridge/redact.ts
+++ b/src/shared/cli-bridge/redact.ts
@@ -1,0 +1,69 @@
+import type { MCPServerConfig } from "../types/mcp";
+import { REDACTED } from "./protocol";
+
+/**
+ * Redaction helpers shared by the bridge (so secrets never leave the app) and
+ * importable by the CLI/tests. We never echo full secret values back over the
+ * wire — api keys, bearer tokens, and arbitrary header/env values are masked.
+ */
+
+function redactStringMap(
+  map: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!map) return map;
+  const out: Record<string, string> = {};
+  for (const key of Object.keys(map)) {
+    out[key] = REDACTED;
+  }
+  return out;
+}
+
+/** Redact secret-bearing fields on a single MCP server config. */
+export function redactMcpServer(server: MCPServerConfig): MCPServerConfig {
+  const clone = { ...(server as unknown as Record<string, unknown>) };
+
+  if ("headers" in clone) {
+    clone.headers = redactStringMap(clone.headers as Record<string, string> | undefined);
+  }
+  if ("env" in clone) {
+    clone.env = redactStringMap(clone.env as Record<string, string> | undefined);
+  }
+
+  return clone as unknown as MCPServerConfig;
+}
+
+/** Redact a list of MCP server configs. */
+export function redactMcpServers(servers: MCPServerConfig[]): MCPServerConfig[] {
+  return servers.map(redactMcpServer);
+}
+
+/**
+ * Redact an LLM config (V2 shape). Replaces every `apiKey` with the placeholder
+ * but keeps `hasApiKey` booleans so callers can tell whether a key is set.
+ */
+export function redactLlmConfig(config: unknown): unknown {
+  if (!config || typeof config !== "object") return config;
+
+  const redactModel = (model: unknown): unknown => {
+    if (!model || typeof model !== "object") return model;
+    const m = model as Record<string, unknown>;
+    const hasApiKey = typeof m.apiKey === "string" && m.apiKey.length > 0;
+    return { ...m, apiKey: hasApiKey ? REDACTED : m.apiKey, hasApiKey };
+  };
+
+  const c = config as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...c };
+
+  if ("languageModel" in c) out.languageModel = redactModel(c.languageModel);
+  if ("transcriptionModel" in c) out.transcriptionModel = redactModel(c.transcriptionModel);
+
+  if (c.providerApiKeys && typeof c.providerApiKeys === "object") {
+    const masked: Record<string, string> = {};
+    for (const key of Object.keys(c.providerApiKeys as Record<string, unknown>)) {
+      masked[key] = REDACTED;
+    }
+    out.providerApiKeys = masked;
+  }
+
+  return out;
+}

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -23,6 +23,15 @@ export type ModelConfig = OpenAIConfig | AzureOpenAIConfig | DeepSeekConfig;
 
 export type ProviderApiKeys = Readonly<Partial<Record<ProviderName, string>>>;
 
+/**
+ * Which backend drives the backlog-creation (EXECUTING_TASK) step.
+ * - `openai`: the in-process MCPOrchestrator loop (default, original behaviour).
+ * - `local-claude`: drive the step with a local `claude -p` (headless) process.
+ */
+export type OrchestrationBackend = "openai" | "local-claude";
+
+export const DEFAULT_ORCHESTRATION_BACKEND: OrchestrationBackend = "openai";
+
 export type LLMConfigV1 = ModelConfig & {
   version?: 1;
 };
@@ -33,6 +42,11 @@ export interface LLMConfigV2 {
   transcriptionModel: ModelConfig | null;
   /** Persisted API keys per provider, enabling restoration when switching providers */
   providerApiKeys?: ProviderApiKeys;
+  /**
+   * Opt-in orchestration backend for the backlog-creation step.
+   * Absent/undefined behaves exactly as `openai` — existing configs are unaffected.
+   */
+  orchestrationBackend?: OrchestrationBackend;
 }
 
 export type LLMConfig = LLMConfigV1 | LLMConfigV2;

--- a/src/ui/src/components/settings/llm/LLMSettingsPanel.tsx
+++ b/src/ui/src/components/settings/llm/LLMSettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { LanguageModelSetting } from "./LanguageModelSetting";
+import { OrchestratorBackendSetting } from "./OrchestratorBackendSetting";
 import { TranscriptionModelSetting } from "./TranscriptionModelSetting";
 
 interface LLMSettingsPanelProps {
@@ -17,6 +18,7 @@ export function LLMSettingsPanel({ isActive }: LLMSettingsPanelProps) {
 
       <LanguageModelSetting isActive={isActive} />
       <TranscriptionModelSetting isActive={isActive} />
+      <OrchestratorBackendSetting isActive={isActive} />
     </div>
   );
 }

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -1,0 +1,150 @@
+import type { LLMConfigV2, OrchestrationBackend } from "@shared/types/llm";
+import { DEFAULT_ORCHESTRATION_BACKEND } from "@shared/types/llm";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { ipcClient } from "@/services/ipc-client";
+import { formatErrorMessage } from "@/utils";
+
+interface OrchestratorBackendSettingProps {
+  isActive: boolean;
+}
+
+interface BackendOption {
+  id: OrchestrationBackend;
+  title: string;
+  description: string;
+}
+
+const BACKEND_OPTIONS: readonly BackendOption[] = [
+  {
+    id: "openai",
+    title: "OpenAI",
+    description: "Drive backlog creation with the built-in language model loop. (Default)",
+  },
+  {
+    id: "local-claude",
+    title: "Claude Code (local)",
+    description:
+      "Drive backlog creation with a local headless `claude` process. Requires the `claude` CLI installed and on PATH.",
+  },
+];
+
+const BACKEND_LABELS: Record<OrchestrationBackend, string> = {
+  openai: "OpenAI",
+  "local-claude": "Claude Code (local)",
+};
+
+export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSettingProps) {
+  const [currentBackend, setCurrentBackend] = useState<OrchestrationBackend>(
+    DEFAULT_ORCHESTRATION_BACKEND,
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [pendingBackend, setPendingBackend] = useState<OrchestrationBackend | null>(null);
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const cfg = await ipcClient.llm.getConfig();
+        if (!cancelled) {
+          setCurrentBackend(cfg?.orchestrationBackend ?? DEFAULT_ORCHESTRATION_BACKEND);
+        }
+      } catch (error) {
+        console.error("Failed to load orchestrator backend setting", error);
+        toast.error(`Failed to load orchestrator setting: ${formatErrorMessage(error)}`);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isActive]);
+
+  const handleSelect = useCallback(
+    async (backend: OrchestrationBackend) => {
+      if (backend === currentBackend) {
+        return;
+      }
+
+      setPendingBackend(backend);
+      try {
+        // Preserve every other field on the V2 config; only flip the backend.
+        const existing = await ipcClient.llm.getConfig();
+        const next: LLMConfigV2 = {
+          version: 2,
+          languageModel: existing?.languageModel ?? null,
+          transcriptionModel: existing?.transcriptionModel ?? null,
+          providerApiKeys: existing?.providerApiKeys,
+          orchestrationBackend: backend,
+        };
+        const result = await ipcClient.llm.setConfig(next);
+        if (!result.success) {
+          throw new Error("Failed to update orchestrator backend");
+        }
+        setCurrentBackend(backend);
+        toast.success(`Orchestrator set to ${BACKEND_LABELS[backend]}`);
+      } catch (error) {
+        console.error("Failed to update orchestrator backend", error);
+        toast.error(`Failed to update orchestrator: ${formatErrorMessage(error)}`);
+      } finally {
+        setPendingBackend(null);
+      }
+    },
+    [currentBackend],
+  );
+
+  return (
+    <Card className="w-full gap-4 border-white/10 py-4">
+      <CardHeader className="px-4">
+        <CardTitle>Orchestrator</CardTitle>
+        <CardDescription>
+          Choose which backend drives backlog creation. Claude Code (local) requires the{" "}
+          <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="px-4">
+        <div className="grid gap-2 md:grid-cols-2">
+          {BACKEND_OPTIONS.map((option) => {
+            const isSelected = option.id === currentBackend;
+            const isDisabled = isLoading || (!!pendingBackend && pendingBackend !== option.id);
+
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => void handleSelect(option.id)}
+                disabled={isDisabled}
+                aria-pressed={isSelected}
+                className={cn(
+                  "flex h-full flex-col gap-1.5 rounded-md border px-3 py-2 text-left transition-colors",
+                  "disabled:cursor-not-allowed disabled:opacity-60",
+                  isSelected
+                    ? "border-white/50 bg-white/10"
+                    : "border-white/10 hover:border-white/30 hover:bg-white/5",
+                )}
+              >
+                <span className="text-sm font-medium">{option.title}</span>
+                <span className="text-xs leading-relaxed text-muted-foreground">
+                  {option.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/backend/**/*", "src/shared/**/*"],
+  "include": ["src/backend/**/*", "src/shared/**/*", "src/cli/**/*"],
   "exclude": ["node_modules", "dist", "src/ui"]
 }


### PR DESCRIPTION
## Problem

The `yakshaver` CLI could read but not fully configure the desktop app. This PR adds a localhost-only, token-authenticated bridge surface so the CLI can set the orchestration backend, update/enable/remove MCP servers (including by `--name`), and read/write user settings — without ever handling or echoing secrets.

## What changed

- **Orchestration backend**: `config get|set orchestrator` reads/sets `LLMConfigV2.orchestrationBackend` (`openai` | `local-claude`). `config get` always surfaces a concrete value, defaulting to `openai` — including on a fresh install where no LLM config exists yet.
- **MCP management**: `mcp add|update|remove|enable`, with `--name <name>` selectors resolved against the server list. `update` is a merge-patch (only provided fields change). A transport switch (HTTP <-> stdio) normalizes to the target discriminated-union member and strips the old transport's fields so no stale `url`/`headers` or `command`/`args`/`env` survive — both at the bridge and in the manager's own persistence merge.
- **Built-in servers** (always-on, in-memory) cannot be modified or removed via the CLI; such requests are rejected with a clear error instead of silently no-op'ing.
- **stdio args**: a repeatable `--arg <value>` flag preserves each argument verbatim (so a value may contain spaces, e.g. `--arg "/My Documents/server.js"`). The legacy whitespace-split `--args "a b c"` is kept for back-compat; the two are mutually exclusive.
- **Settings**: `config get|set settings` for `--tool-approval-mode` and `--open-at-login`.

## Security model

- The bridge binds to `127.0.0.1` only (never `0.0.0.0`).
- A random 256-bit bearer token is generated at startup and written to `userData/yakshaver-tokens/cli-bridge.json` (owner-readable where the OS honours it); every request must present `Authorization: Bearer <token>`.
- All secrets (api keys, header/env values) are redacted in every response.
- All write payloads are validated with strict zod schemas (`LLMConfigV2Schema`, MCP input/patch schemas) before persistence.

## Test plan

- `npm run build` (tsc) — passes.
- `npx vitest run` over `src/cli`, `src/backend/services/cli-bridge`, `src/backend/services/mcp` — 120 tests pass, including:
  - repeatable `--arg` preserving spaces + rejecting `--arg`/`--args` mixing;
  - built-in server enable/update/remove rejection;
  - fresh-install (null config) `config get orchestrator` -> `openai`;
  - an integration test driving the transport switch through the REAL `MCPServerManager.updateServerAsync` (storage mocked) asserting no stale secret-bearing fields persist.
- `npx biome check` — clean on all touched files.

(DB and ffmpeg suites are skipped here due to native-binding/platform limitations in the CI worktree, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
