### PR TITLE
L⚠️ ◾ feat(#915): single yakshaver MCP front-door proxying the app's aggregated toolset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,6 +539,33 @@ Button variants: `default`, `destructive`, `outline`, `secondary`, `ghost`, `lin
 - **External**: Configure via Settings UI (persisted to `mcp-servers.json`)
 - **Internal**: Add to `src/backend/services/mcp/internal/` and register in MCP orchestrator
 
+Both external and internal/in-memory servers are aggregated by `MCPServerManager`
+(`collectToolsWithServerPrefixAsync()` → a single server-prefixed `ToolSet`) and are
+reachable by every orchestration backend through the **MCP front-door** (see below) —
+there is no longer any server kind that the Claude Code orchestrator cannot reach.
+
+### The MCP Front-Door (single `yakshaver` proxy)
+
+The app exposes its **entire aggregated toolset** — external AND internal/in-memory
+servers, server-prefixed — to the Claude Code orchestrator through one proxy MCP
+server instead of re-declaring each upstream server to Claude:
+
+- **CLI subcommand**: `yakshaver mcp-serve` (`src/cli/mcp-serve.ts`) runs a stdio MCP
+  server named `yakshaver`. The orchestrator spawns it via a one-entry `--mcp-config`;
+  to Claude the tools appear as `mcp__yakshaver__<Server__tool>`. It owns no tools of
+  its own — every `tools/list` / `tools/call` is proxied to the running desktop app
+  over the localhost CLI bridge.
+- **Bridge endpoints** (`src/backend/services/cli-bridge/bridge-router.ts`):
+  - `GET /tools` → the full server-prefixed tool list (names + descriptions + JSON
+    Schema). Returns `[]` (never an error) when no enabled servers are healthy.
+  - `POST /tools/call` → executes one tool by name through the app's tool-approval
+    policy SERVER-SIDE, so a headless run never hangs on an interactive prompt
+    (`yolo` runs everything; `ask`/`wait` run only whitelisted tools, otherwise return
+    a structured "not approved" envelope, never a transport error).
+- **Wiring**: `McpToolBridge` (`src/backend/services/mcp/mcp-tool-bridge.ts`) flattens
+  the AI-SDK `ToolSet` into wire summaries and enforces the approval policy; the front
+  door (`mcp-serve.ts`) maps a `{ok:false}` envelope to an MCP `isError` result.
+
 ### Updating Release Workflows
 
 - macOS arm64 and x64 builds generate separate ZIPs but must publish a single update manifest

--- a/src/backend/ipc/channels.ts
+++ b/src/backend/ipc/channels.ts
@@ -41,6 +41,7 @@ export const IPC_CHANNELS = {
   LLM_GET_CONFIG: "llm:get-config",
   LLM_CLEAR_CONFIG: "llm:clear-config",
   LLM_CHECK_HEALTH: "llm:check-health",
+  LLM_CHECK_ORCHESTRATOR_READINESS: "llm:check-orchestrator-readiness",
 
   // MCP
   MCP_PROCESS_MESSAGE: "mcp:process-message",

--- a/src/backend/ipc/llm-settings-handlers.ts
+++ b/src/backend/ipc/llm-settings-handlers.ts
@@ -1,5 +1,6 @@
 import type { LLMConfigV2 } from "@shared/types/llm";
 import { type IpcMainInvokeEvent, ipcMain } from "electron";
+import { checkClaudeReadiness } from "../services/mcp/claude-readiness";
 import { LanguageModelProvider } from "../services/mcp/language-model-provider";
 import { LlmStorage } from "../services/storage/llm-storage";
 import { IPC_CHANNELS } from "./channels";
@@ -34,6 +35,12 @@ export class LLMSettingsIPCHandlers {
     ipcMain.handle(IPC_CHANNELS.LLM_CHECK_HEALTH, async () => {
       const provider = await LanguageModelProvider.getInstance();
       return await provider.checkHealth();
+    });
+
+    // Readiness of the Claude Code (local-claude) orchestration backend — installed + (best-effort)
+    // authenticated — so the UI can warn BEFORE a run that Claude Code can't be driven.
+    ipcMain.handle(IPC_CHANNELS.LLM_CHECK_ORCHESTRATOR_READINESS, async () => {
+      return await checkClaudeReadiness();
     });
   }
 }

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -8,6 +8,7 @@ import {
   ProgressStage as WorkflowProgressStage,
   type WorkflowState,
 } from "../../shared/types/workflow";
+import type { OrchestratorBackend } from "../../shared/types/workflow-payloads";
 import { INITIAL_SUMMARY_PROMPT, TASK_EXECUTION_PROMPT } from "../constants/prompts";
 import { IdentityServerAuthService } from "../services/auth/identity-server-auth";
 import type { VideoUploadResult } from "../services/auth/types";
@@ -40,7 +41,7 @@ import { WorkflowStateManager } from "../services/workflow/workflow-state-manage
 import { formatAndReportError } from "../utils/error-utils";
 import { IPC_CHANNELS } from "./channels";
 
-export type { VideoProcessingContext, RetryResult };
+export type { RetryResult, VideoProcessingContext };
 
 export const TranscriptSummarySchema = z.object({
   taskType: z.string(),
@@ -137,9 +138,12 @@ export class ProcessVideoIPCHandlers {
               ? this.lastVideoFilePath
               : undefined;
 
-          const mcpAdapter = new McpWorkflowAdapter(workflowManager);
+          const { orchestrator, backend } = await this.getBacklogOrchestrator();
 
-          const orchestrator = await this.getBacklogOrchestrator();
+          const mcpAdapter = new McpWorkflowAdapter(workflowManager, {
+            orchestrator: backend,
+          });
+
           const loopResult = await orchestrator.manualLoopAsync(
             intermediateOutput,
             videoUploadResult,
@@ -562,12 +566,13 @@ export class ProcessVideoIPCHandlers {
 
         const serverFilter = projectDetails?.selectedMcpServerIds;
 
+        const { orchestrator, backend } = await this.getBacklogOrchestrator();
+
         const mcpAdapter = new McpWorkflowAdapter(workflowManager, {
           transcriptText,
           intermediateOutput,
+          orchestrator: backend,
         });
-
-        const orchestrator = await this.getBacklogOrchestrator();
 
         // transcriptText guaranteed by: normal flow sets it in TRANSCRIBING; retry validated at entry
         const loopResult = await orchestrator.manualLoopAsync(
@@ -735,11 +740,17 @@ export class ProcessVideoIPCHandlers {
    * `local-claude` drives the step with a headless `claude -p`; anything else (including a config
    * with no `orchestrationBackend` field) uses the in-process OpenAI loop. Falls back to OpenAI if
    * the config can't be read so the stage never hard-fails on a config hiccup.
+   *
+   * Returns the chosen orchestrator alongside a UI-facing `backend` label (stamped into the
+   * Executing Task payload so the stage card can badge which orchestrator is active).
    */
-  private async getBacklogOrchestrator(): Promise<IBacklogOrchestrator> {
-    let backend: string | undefined;
+  private async getBacklogOrchestrator(): Promise<{
+    orchestrator: IBacklogOrchestrator;
+    backend: OrchestratorBackend;
+  }> {
+    let configuredBackend: string | undefined;
     try {
-      backend = (await LlmStorage.getInstance().getLLMConfig())?.orchestrationBackend;
+      configuredBackend = (await LlmStorage.getInstance().getLLMConfig())?.orchestrationBackend;
     } catch (error) {
       console.warn(
         "[ProcessVideo] Failed to read orchestration backend, defaulting to OpenAI",
@@ -747,12 +758,12 @@ export class ProcessVideoIPCHandlers {
       );
     }
 
-    if (backend === "local-claude") {
+    if (configuredBackend === "local-claude") {
       console.log("[ProcessVideo] Using local Claude Code orchestrator");
-      return new LocalClaudeOrchestrator();
+      return { orchestrator: new LocalClaudeOrchestrator(), backend: "claude-code" };
     }
 
-    return await MCPOrchestrator.getInstanceAsync();
+    return { orchestrator: await MCPOrchestrator.getInstanceAsync(), backend: "openai" };
   }
 
   private async formatFinalResult(mcpResult: string | undefined): Promise<string | undefined> {

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -60,6 +60,7 @@ const IPC_CHANNELS = {
   LLM_GET_CONFIG: "llm:get-config",
   LLM_CLEAR_CONFIG: "llm:clear-config",
   LLM_CHECK_HEALTH: "llm:check-health",
+  LLM_CHECK_ORCHESTRATOR_READINESS: "llm:check-orchestrator-readiness",
 
   // MCP
   MCP_PROCESS_MESSAGE: "mcp:process-message",
@@ -249,6 +250,8 @@ const electronAPI = {
     getConfig: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_GET_CONFIG),
     clearConfig: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_CLEAR_CONFIG),
     checkHealth: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_CHECK_HEALTH),
+    checkOrchestratorReadiness: () =>
+      ipcRenderer.invoke(IPC_CHANNELS.LLM_CHECK_ORCHESTRATOR_READINESS),
   },
   mcp: {
     processMessage: (

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -44,6 +44,17 @@ function makeServices(overrides: Partial<BridgeServices> = {}): BridgeServices {
       updateSettingsAsync: vi.fn().mockResolvedValue(undefined),
       ...overrides.settings,
     },
+    tools: {
+      listTools: vi.fn().mockResolvedValue([
+        {
+          name: "GitHub__create_issue",
+          description: "Create a GitHub issue",
+          inputSchema: { type: "object", properties: { title: { type: "string" } } },
+        },
+      ]),
+      callTool: vi.fn().mockResolvedValue({ ok: true, result: "Created #5" }),
+      ...overrides.tools,
+    },
   };
 }
 
@@ -383,6 +394,74 @@ describe("routeRequest - settings", () => {
     });
     expect(res.status).toBe(400);
     expect(services.settings.updateSettingsAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe("routeRequest - tools (#915 aggregated front-door)", () => {
+  it("GET /tools returns the aggregated tool list", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/tools" });
+    expect(res.status).toBe(200);
+    expect(services.tools.listTools).toHaveBeenCalledOnce();
+    if (!res.body.ok) throw new Error("expected ok");
+    const tools = res.body.data as Array<{ name: string }>;
+    expect(tools.map((t) => t.name)).toEqual(["GitHub__create_issue"]);
+  });
+
+  it("GET /tools rejects non-GET methods", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "POST", path: "/tools" });
+    expect(res.status).toBe(405);
+  });
+
+  it("POST /tools/call validates the body via zod", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/tools/call",
+      body: { arguments: {} }, // missing required `name`
+    });
+    expect(res.status).toBe(400);
+    expect(services.tools.callTool).not.toHaveBeenCalled();
+  });
+
+  it("POST /tools/call proxies name+arguments and returns the result envelope", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/tools/call",
+      body: { name: "GitHub__create_issue", arguments: { title: "Bug" } },
+    });
+    expect(res.status).toBe(200);
+    expect(services.tools.callTool).toHaveBeenCalledWith("GitHub__create_issue", { title: "Bug" });
+    if (!res.body.ok) throw new Error("expected ok envelope");
+    expect(res.body.data).toEqual({ ok: true, result: "Created #5" });
+  });
+
+  it("POST /tools/call surfaces a structured not-approved result as a 200 envelope (no hang)", async () => {
+    const services = makeServices({
+      tools: {
+        listTools: vi.fn(),
+        callTool: vi
+          .fn()
+          .mockResolvedValue({ ok: false, notApproved: true, error: "not approved" }),
+      },
+    });
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/tools/call",
+      body: { name: "GitHub__create_issue" },
+    });
+    // Tool-level refusal is still a successful BRIDGE response.
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok envelope");
+    expect(res.body.data).toEqual({ ok: false, notApproved: true, error: "not approved" });
+  });
+
+  it("POST /tools/call rejects non-POST methods", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/tools/call" });
+    expect(res.status).toBe(405);
   });
 });
 

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,9 +1,12 @@
 import {
   type BridgeResponse,
+  type BridgeToolSummary,
   McpEnabledInputSchema,
   McpServerInputSchema,
   McpServerPatchSchema,
   OrchestratorInputSchema,
+  ToolCallInputSchema,
+  type ToolCallResult,
 } from "../../../shared/cli-bridge/protocol";
 import {
   redactLlmConfig,
@@ -35,6 +38,15 @@ export interface BridgeServices {
   settings: {
     getSettingsAsync(): Promise<UserSettings>;
     updateSettingsAsync(patch: PartialUserSettings): Promise<void>;
+  };
+  /**
+   * Aggregated MCP toolset front-door (#915). Exposes the app's full,
+   * server-prefixed toolset (incl. internal/in-memory servers) and proxies
+   * tool execution through the app's approval policy.
+   */
+  tools: {
+    listTools(): Promise<BridgeToolSummary[]>;
+    callTool(name: string, args?: Record<string, unknown>): Promise<ToolCallResult>;
   };
 }
 
@@ -86,6 +98,11 @@ export async function routeRequest(
     // /settings
     if (segments[0] === "settings" && segments.length === 1) {
       return await routeSettings(services, req);
+    }
+
+    // /tools and /tools/call
+    if (segments[0] === "tools") {
+      return await routeTools(services, req, segments.slice(1));
     }
 
     return fail(`Unknown route: ${req.method} ${req.path}`, 404);
@@ -243,6 +260,49 @@ async function routeSettings(services: BridgeServices, req: BridgeRequest): Prom
     return ok(await services.settings.getSettingsAsync());
   }
   return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+/**
+ * Aggregated toolset front-door (#915).
+ *
+ *  - `GET  /tools`       → the full server-prefixed tool list (incl. internal/
+ *    in-memory servers), names + descriptions + JSON-Schema only.
+ *  - `POST /tools/call`  → execute one tool by name; the approval policy is
+ *    enforced inside the tools service so a refusal is a structured result, not
+ *    an HTTP error (the caller must surface it, not retry).
+ */
+async function routeTools(
+  services: BridgeServices,
+  req: BridgeRequest,
+  rest: string[],
+): Promise<BridgeResult> {
+  // /tools
+  if (rest.length === 0) {
+    if (req.method !== "GET") {
+      return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+    }
+    const tools = await services.tools.listTools();
+    return ok(tools);
+  }
+
+  // /tools/call
+  if (rest.length === 1 && rest[0] === "call") {
+    if (req.method !== "POST") {
+      return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+    }
+    const parsed = ToolCallInputSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid tool call: ${formatZodError(parsed.error)}`);
+    }
+    const result = await services.tools.callTool(parsed.data.name, parsed.data.arguments ?? {});
+    // A tool-level failure (incl. a structured "not approved") is still a
+    // successful BRIDGE response — the envelope carries {ok:false,...} so the
+    // MCP front-door can relay it to the model verbatim. Only transport/route
+    // problems use a non-200 status.
+    return ok(result);
+  }
+
+  return fail(`Unknown route: ${req.method} ${req.path}`, 404);
 }
 
 function formatZodError(error: {

--- a/src/backend/services/cli-bridge/cli-bridge-server.test.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.test.ts
@@ -44,6 +44,10 @@ function makeServices(): BridgeServices {
       getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: "ask" }),
       updateSettingsAsync: vi.fn(),
     },
+    tools: {
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ ok: true, result: null }),
+    },
   };
 }
 

--- a/src/backend/services/cli-bridge/cli-bridge-server.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.ts
@@ -12,6 +12,7 @@ import {
   type CliBridgeTokenFile,
 } from "../../../shared/cli-bridge/protocol";
 import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { McpToolBridge } from "../mcp/mcp-tool-bridge";
 import { LlmStorage } from "../storage/llm-storage";
 import { UserSettingsStorage } from "../storage/user-settings-storage";
 import { type BridgeServices, routeRequest } from "./bridge-router";
@@ -240,6 +241,15 @@ export class CliBridgeServer {
   getPort(): number | null {
     return this.port;
   }
+
+  /**
+   * The current bearer token, or null if not started. Used by the orchestrator to
+   * hand the `yakshaver mcp-serve` front-door a deterministic token (rather than
+   * relying on the token-file read racing app startup). NOT exposed over HTTP.
+   */
+  getToken(): string | null {
+    return this.token;
+  }
 }
 
 function safeStringEquals(a: string, b: string): boolean {
@@ -289,5 +299,21 @@ function createDefaultServices(): BridgeServices {
       getSettingsAsync: () => UserSettingsStorage.getInstance().getSettingsAsync(),
       updateSettingsAsync: (patch) => UserSettingsStorage.getInstance().updateSettingsAsync(patch),
     },
+    tools: {
+      async listTools() {
+        return (await getToolBridge()).listTools();
+      },
+      async callTool(name, args) {
+        return (await getToolBridge()).callTool(name, args);
+      },
+    },
   };
+}
+
+/** Build a {@link McpToolBridge} wired to the live singletons. */
+async function getToolBridge(): Promise<McpToolBridge> {
+  const manager = await MCPServerManager.getInstanceAsync();
+  return new McpToolBridge(manager, {
+    getSettingsAsync: () => UserSettingsStorage.getInstance().getSettingsAsync(),
+  });
 }

--- a/src/backend/services/cli-bridge/front-door.integration.test.ts
+++ b/src/backend/services/cli-bridge/front-door.integration.test.ts
@@ -1,0 +1,223 @@
+import { createServer, type Server as HttpServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { ToolSet } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { BridgeClient } from "../../../cli/bridge-client";
+import { callToolViaBridge, listToolsViaBridge } from "../../../cli/mcp-serve";
+import { McpToolBridge, type ToolBridgeManager } from "../mcp/mcp-tool-bridge";
+import { type BridgeServices, routeRequest } from "./bridge-router";
+
+/**
+ * CONNECTED-PATH integration test for the single `yakshaver` MCP front-door (#915).
+ *
+ * The unit suites each mock ONE side of a boundary. This one wires the WHOLE
+ * server-side chain end-to-end with NO mocks on the path under test, and drives it
+ * through the REAL `mcp-serve` proxy + REAL `BridgeClient` over a REAL localhost
+ * HTTP socket — exactly the bytes the spawned front-door exchanges with the app:
+ *
+ *   mcp-serve (listToolsViaBridge / callToolViaBridge)
+ *     → real BridgeClient (real fetch, real Bearer auth)
+ *       → real node:http server (real token check)
+ *         → real routeRequest (real Zod validation + envelope)
+ *           → real McpToolBridge (real flatten + approval policy + execute)
+ *             → in-memory ToolSet (a real internal/in-memory tool — the #915 win)
+ *
+ * The ONLY fake is the leaf `ToolBridgeManager`, standing in for the live
+ * `MCPServerManager` so the test needs neither Electron nor a real provider. It
+ * returns genuine AI-SDK-shaped tools (description + Zod inputSchema + execute),
+ * including an `Internal__*` in-memory tool and a tool that resolves to a native
+ * MCP `CallToolResult` with `isError:true` (an auth-denied call that does NOT
+ * throw) — the failure class that must not reach Claude as a success.
+ *
+ * No Claude/LLM is involved: this proves spawn→bridge→execute, the part the PR's
+ * deferred live e2e leaves unverified.
+ */
+
+const TOKEN = "integration-test-token";
+
+/** A real ToolSet: a GitHub tool, an INTERNAL in-memory tool, and a failing tool. */
+function makeToolSet(): ToolSet {
+  return {
+    GitHub__create_issue: {
+      description: "Create a GitHub issue",
+      inputSchema: z.object({ title: z.string() }),
+      execute: async (input: unknown) => {
+        const { title } = input as { title: string };
+        return { content: [{ type: "text", text: `Created issue: ${title}` }] };
+      },
+    },
+    // The #915 win: an internal/in-memory server tool, reachable here even though
+    // Claude Code can't reach it over its own transports.
+    Internal__fill_template: {
+      description: "Fill the internal template",
+      inputSchema: z.object({ name: z.string() }),
+      execute: async (input: unknown) => {
+        const { name } = input as { name: string };
+        return `Hello ${name}`;
+      },
+    },
+    // A tool whose underlying MCP call FAILS without throwing (auth-denied):
+    // resolves to a CallToolResult with isError:true.
+    GitHub__delete_repo: {
+      description: "Delete a repo (will be denied)",
+      inputSchema: z.object({ repo: z.string() }),
+      execute: async () => ({
+        isError: true,
+        content: [{ type: "text", text: "403 Forbidden: insufficient scopes" }],
+      }),
+    },
+  } as unknown as ToolSet;
+}
+
+function makeManager(whitelist: string[]): ToolBridgeManager {
+  const tools = makeToolSet();
+  return {
+    collectToolsWithServerPrefixAsync: async () => tools,
+    getWhitelistWithServerPrefixAsync: async () => whitelist,
+  };
+}
+
+/** Build the real BridgeServices, with only the tools front-door wired to a real bridge. */
+function makeServices(approvalMode: "yolo" | "ask" | "wait", whitelist: string[]): BridgeServices {
+  const bridge = new McpToolBridge(makeManager(whitelist), {
+    getSettingsAsync: async () => ({ toolApprovalMode: approvalMode }),
+  });
+  // Only the routes this test exercises need real backing; the rest can throw.
+  const notUsed = () => {
+    throw new Error("not part of the front-door path");
+  };
+  return {
+    mcp: {
+      listAvailableServers: notUsed,
+      addServerAsync: notUsed,
+      updateServerAsync: notUsed,
+      removeServerAsync: notUsed,
+      getServerByIdAsync: notUsed,
+    },
+    llm: { getLLMConfig: notUsed, storeLLMConfig: notUsed },
+    settings: { getSettingsAsync: notUsed, updateSettingsAsync: notUsed },
+    tools: {
+      listTools: () => bridge.listTools(),
+      callTool: (name: string, args?: Record<string, unknown>) => bridge.callTool(name, args),
+    },
+  } as unknown as BridgeServices;
+}
+
+/** Stand up a real localhost HTTP server running the real router with Bearer auth. */
+function startBridge(services: BridgeServices): Promise<{ server: HttpServer; port: number }> {
+  const server = createServer((req, res) => {
+    if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Unauthorized" }));
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", async () => {
+      const raw = Buffer.concat(chunks).toString("utf8").trim();
+      const body = raw ? JSON.parse(raw) : undefined;
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const result = await routeRequest(services, {
+        method: req.method ?? "GET",
+        path: url.pathname,
+        body,
+      });
+      const payload = JSON.stringify(result.body);
+      res.writeHead(result.status, { "Content-Type": "application/json" });
+      res.end(payload);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, port });
+    });
+  });
+}
+
+function makeClient(port: number): BridgeClient {
+  return new BridgeClient({
+    tokenLoader: async () => ({ port, token: TOKEN, startedAt: new Date().toISOString() }),
+  });
+}
+
+describe("front-door integration — mcp-serve → BridgeClient → router → McpToolBridge", () => {
+  let server: HttpServer;
+  let port: number;
+
+  afterEach(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function boot(mode: "yolo" | "ask" | "wait", whitelist: string[] = []) {
+    ({ server, port } = await startBridge(makeServices(mode, whitelist)));
+    return makeClient(port);
+  }
+
+  it("lists the full aggregated toolset INCLUDING the internal in-memory tool", async () => {
+    const client = await boot("yolo");
+    const { tools } = await listToolsViaBridge(client);
+
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toContain("GitHub__create_issue");
+    // The #915 headline win, proven over the real HTTP path (not a mock).
+    expect(names).toContain("Internal__fill_template");
+
+    const gh = tools.find((t) => t.name === "GitHub__create_issue");
+    expect(gh?.inputSchema).toMatchObject({ type: "object" });
+    expect((gh?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty(
+      "title",
+    );
+  });
+
+  it("calls a provider tool end-to-end and returns its content (yolo)", async () => {
+    const client = await boot("yolo");
+    const result = await callToolViaBridge(client, "GitHub__create_issue", { title: "Bug" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "Created issue: Bug" }]);
+  });
+
+  it("calls the INTERNAL in-memory tool end-to-end (#915)", async () => {
+    const client = await boot("yolo");
+    const result = await callToolViaBridge(client, "Internal__fill_template", { name: "Ada" });
+    // A plain-string tool result is wrapped as text content with no error flag.
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toEqual([{ type: "text", text: "Hello Ada" }]);
+  });
+
+  it("surfaces an MCP-level isError (auth-denied) as a FAILURE, not a successful call", async () => {
+    const client = await boot("yolo");
+    const result = await callToolViaBridge(client, "GitHub__delete_repo", { repo: "x" });
+    // The execute() resolved (no throw) with isError:true — it must reach Claude as an error.
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: "403 Forbidden: insufficient scopes" }]);
+  });
+
+  it("refuses a non-whitelisted tool under 'ask' with a structured MCP isError (no hang)", async () => {
+    const client = await boot("ask", /* whitelist */ []);
+    const result = await callToolViaBridge(client, "GitHub__create_issue", { title: "Bug" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({ type: "text" });
+    expect((result.content[0] as { text?: string }).text).toMatch(/not approved/i);
+  });
+
+  it("runs a WHITELISTED tool under 'ask'", async () => {
+    const client = await boot("ask", ["GitHub__create_issue"]);
+    const result = await callToolViaBridge(client, "GitHub__create_issue", { title: "OK" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "Created issue: OK" }]);
+  });
+
+  it("rejects an unauthenticated request at the HTTP boundary", async () => {
+    await boot("yolo");
+    const badClient = new BridgeClient({
+      tokenLoader: async () => ({
+        port,
+        token: "wrong-token",
+        startedAt: new Date().toISOString(),
+      }),
+    });
+    await expect(listToolsViaBridge(badClient)).rejects.toThrow(/unauthorized/i);
+  });
+});

--- a/src/backend/services/mcp/claude-readiness.test.ts
+++ b/src/backend/services/mcp/claude-readiness.test.ts
@@ -1,0 +1,128 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClaudeReadinessDeps,
+  checkClaudeReadiness,
+  detectClaudeAuth,
+  resolveCredentialsPath,
+} from "./claude-readiness";
+
+/** A spawner whose `claude --version` child closes with the given exit code (or emits an error). */
+function makeSpawner(opts: {
+  versionExitCode?: number;
+  spawnError?: boolean;
+  emitError?: boolean;
+}) {
+  const spawn = vi.fn((_cmd: string, _args: string[]) => {
+    if (opts.spawnError) throw new Error("spawn failed");
+    const child = new EventEmitter() as unknown as ChildProcess;
+    setImmediate(() => {
+      if (opts.emitError) child.emit("error", new Error("ENOENT"));
+      else child.emit("close", opts.versionExitCode ?? 0);
+    });
+    return child;
+  });
+  return { spawn };
+}
+
+function makeDeps(overrides: Partial<ClaudeReadinessDeps> = {}): ClaudeReadinessDeps {
+  return {
+    spawner: makeSpawner({ versionExitCode: 0 }),
+    env: {},
+    fileExists: () => false,
+    homeDir: () => "/home/test",
+    claudeCommand: "claude",
+    ...overrides,
+  };
+}
+
+describe("resolveCredentialsPath", () => {
+  it("uses CLAUDE_CONFIG_DIR when set", () => {
+    expect(resolveCredentialsPath({ CLAUDE_CONFIG_DIR: "/custom/dir" }, () => "/home/test")).toBe(
+      join("/custom/dir", ".credentials.json"),
+    );
+  });
+
+  it("falls back to <home>/.claude when CLAUDE_CONFIG_DIR is unset/blank", () => {
+    expect(resolveCredentialsPath({ CLAUDE_CONFIG_DIR: "  " }, () => "/home/test")).toBe(
+      join("/home/test", ".claude", ".credentials.json"),
+    );
+  });
+});
+
+describe("detectClaudeAuth", () => {
+  it("is true when an auth env var is set", () => {
+    const deps = makeDeps();
+    expect(detectClaudeAuth({ ANTHROPIC_API_KEY: "sk-123" }, deps)).toBe(true);
+    expect(detectClaudeAuth({ CLAUDE_CODE_OAUTH_TOKEN: "tok" }, deps)).toBe(true);
+  });
+
+  it("ignores blank/whitespace env values", () => {
+    expect(detectClaudeAuth({ ANTHROPIC_API_KEY: "   " }, makeDeps())).toBe(false);
+  });
+
+  it("is true when the credentials file exists", () => {
+    const credsPath = join("/home/test", ".claude", ".credentials.json");
+    const deps = makeDeps({ fileExists: (p) => p === credsPath });
+    expect(detectClaudeAuth({}, deps)).toBe(true);
+  });
+
+  it("is false with no env and no credentials file", () => {
+    expect(detectClaudeAuth({}, makeDeps())).toBe(false);
+  });
+});
+
+describe("checkClaudeReadiness", () => {
+  it("reports not-installed when `claude --version` exits non-zero", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 127 }) }),
+    );
+    expect(r).toMatchObject({ installed: false, ready: false, state: "not-installed" });
+    expect(r.message).toMatch(/not found on PATH/i);
+  });
+
+  it("reports not-installed when spawning errors (ENOENT)", async () => {
+    const r = await checkClaudeReadiness(makeDeps({ spawner: makeSpawner({ emitError: true }) }));
+    expect(r.state).toBe("not-installed");
+  });
+
+  it("reports not-installed when spawn throws synchronously", async () => {
+    const r = await checkClaudeReadiness(makeDeps({ spawner: makeSpawner({ spawnError: true }) }));
+    expect(r.state).toBe("not-installed");
+  });
+
+  it("reports not-authenticated when installed but no credentials", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 0 }) }),
+    );
+    expect(r).toMatchObject({ installed: true, authenticated: false, ready: false });
+    expect(r.state).toBe("not-authenticated");
+    expect(r.message).toMatch(/not signed in/i);
+  });
+
+  it("reports ready when installed and an auth env var is present", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 0 }), env: { ANTHROPIC_API_KEY: "sk" } }),
+    );
+    expect(r).toEqual({
+      installed: true,
+      authenticated: true,
+      ready: true,
+      state: "ready",
+      message: "",
+    });
+  });
+
+  it("reports ready when installed and a credentials file exists", async () => {
+    const credsPath = join("/home/test", ".claude", ".credentials.json");
+    const r = await checkClaudeReadiness(
+      makeDeps({
+        spawner: makeSpawner({ versionExitCode: 0 }),
+        fileExists: (p) => p === credsPath,
+      }),
+    );
+    expect(r.ready).toBe(true);
+  });
+});

--- a/src/backend/services/mcp/claude-readiness.ts
+++ b/src/backend/services/mcp/claude-readiness.ts
@@ -1,0 +1,123 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { OrchestratorReadiness } from "../../../shared/types/llm";
+import type { IClaudeProcessSpawner } from "./local-claude-orchestrator";
+
+export type { OrchestratorReadiness } from "../../../shared/types/llm";
+
+/** Dependencies, injected so the unit tests stay pure (no real `claude`, no real FS/env). */
+export interface ClaudeReadinessDeps {
+  spawner: IClaudeProcessSpawner;
+  /** Process environment to inspect for auth env vars. */
+  env: NodeJS.ProcessEnv;
+  /** Existence check for the credentials file (injectable for tests). */
+  fileExists: (path: string) => boolean;
+  /** Resolver for the user's home directory (injectable for tests). */
+  homeDir: () => string;
+  /** Command used to invoke the CLI. */
+  claudeCommand: string;
+}
+
+const INSTALL_MESSAGE =
+  "Claude Code CLI not found on PATH. Install it (npm i -g @anthropic-ai/claude-code), or switch the Orchestrator to OpenAI.";
+
+const SIGN_IN_MESSAGE =
+  "Claude Code is installed but not signed in. Run `claude` in a terminal and complete the login, then re-check — or switch the Orchestrator to OpenAI.";
+
+/**
+ * Auth env vars that let `claude -p` run without an interactive login. Mirrors Claude Code's
+ * documented credential-precedence chain (cloud providers, bearer/API tokens, long-lived OAuth).
+ */
+const AUTH_ENV_VARS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "CLAUDE_CODE_USE_FOUNDRY",
+] as const;
+
+export const defaultClaudeReadinessDeps: Omit<ClaudeReadinessDeps, "claudeCommand"> = {
+  spawner: { spawn: (command, args) => spawn(command, args) },
+  env: process.env,
+  fileExists: (path) => existsSync(path),
+  homeDir: () => homedir(),
+};
+
+/**
+ * Resolve the path to Claude Code's credentials file, honouring `CLAUDE_CONFIG_DIR`
+ * and otherwise falling back to `<home>/.claude/.credentials.json`.
+ */
+export function resolveCredentialsPath(env: NodeJS.ProcessEnv, homeDir: () => string): string {
+  const baseDir = env.CLAUDE_CONFIG_DIR?.trim() || join(homeDir(), ".claude");
+  return join(baseDir, ".credentials.json");
+}
+
+/**
+ * Best-effort, NON-BILLING authentication signal: an auth env var is set, OR a credentials file
+ * exists at the resolved config dir.
+ *
+ * Known limitation: a macOS login that stores its token ONLY in the Keychain leaves no
+ * credentials file, so this can report `false` for an actually-signed-in mac user. That is a
+ * false "not ready" warning, never a false "ready" — and the run-time error path (which surfaces
+ * Claude's own auth error) remains the authoritative check. A Keychain probe / `claude -p` probe
+ * can be layered on later without changing this contract.
+ */
+export function detectClaudeAuth(env: NodeJS.ProcessEnv, deps: ClaudeReadinessDeps): boolean {
+  const hasAuthEnv = AUTH_ENV_VARS.some((name) => {
+    const value = env[name];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+  if (hasAuthEnv) return true;
+
+  return deps.fileExists(resolveCredentialsPath(env, deps.homeDir));
+}
+
+/** Spawn `claude --version` and resolve true iff it exits 0. Never rejects. */
+function detectClaudeInstalled(deps: ClaudeReadinessDeps): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = deps.spawner.spawn(deps.claudeCommand, ["--version"]);
+    } catch {
+      resolve(false);
+      return;
+    }
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}
+
+/**
+ * Compute the readiness of the Claude Code orchestration backend: is the CLI installed, and
+ * does it appear authenticated? Pure given its injected deps; never throws.
+ */
+export async function checkClaudeReadiness(
+  deps: ClaudeReadinessDeps = { ...defaultClaudeReadinessDeps, claudeCommand: "claude" },
+): Promise<OrchestratorReadiness> {
+  const installed = await detectClaudeInstalled(deps);
+  if (!installed) {
+    return {
+      installed: false,
+      authenticated: false,
+      ready: false,
+      state: "not-installed",
+      message: INSTALL_MESSAGE,
+    };
+  }
+
+  const authenticated = detectClaudeAuth(deps.env, deps);
+  if (!authenticated) {
+    return {
+      installed: true,
+      authenticated: false,
+      ready: false,
+      state: "not-authenticated",
+      message: SIGN_IN_MESSAGE,
+    };
+  }
+
+  return { installed: true, authenticated: true, ready: true, state: "ready", message: "" };
+}

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -18,6 +18,7 @@ import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 import {
   LocalClaudeOrchestrator,
   type OrchestratorServerManager,
+  stripFrontDoorPrefix,
   YAKSHAVER_MCP_SERVER_KEY,
   type YakshaverFrontDoorConfig,
 } from "./local-claude-orchestrator";
@@ -297,10 +298,25 @@ describe("LocalClaudeOrchestrator", () => {
       expect(written).toContain("video transcription: a bug report");
 
       const types = steps.map((s) => s.type);
+      // A `start` step is always emitted first so the Executing Task box is never empty.
+      expect(types[0]).toBe("start");
       expect(types).toContain("reasoning");
       expect(types).toContain("tool_call");
       expect(types).toContain("tool_result");
       expect(types).toContain("final_result");
+
+      // Reasoning is wrapped so the UI's <ReasoningStep> (which JSON.parses + renders .text) shows
+      // the text instead of a blank box.
+      const reasoningStep = steps.find((s) => s.type === "reasoning");
+      expect(reasoningStep?.reasoning).toBeDefined();
+      expect(JSON.parse(reasoningStep?.reasoning as string)).toMatchObject({
+        text: "I'll create an issue.",
+      });
+
+      // The single-front-door prefix is stripped from the displayed tool name so it reads as the
+      // real `Server__tool` rather than mis-parsing the server as `mcp`.
+      const toolCallStep = steps.find((s) => s.type === "tool_call");
+      expect(toolCallStep?.toolName).toBe("GitHub__create_issue");
 
       expect(generateObject).toHaveBeenCalledTimes(1);
       expect(result.backlogActionSucceeded).toBe(true);
@@ -378,6 +394,19 @@ describe("LocalClaudeOrchestrator", () => {
       await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
         /Claude Code process exited with code 1/,
       );
+    });
+  });
+
+  describe("stripFrontDoorPrefix", () => {
+    it("strips the mcp__yakshaver__ front-door prefix so the real Server__tool remains", () => {
+      expect(stripFrontDoorPrefix(`mcp__${YAKSHAVER_MCP_SERVER_KEY}__GitHub__issue_write`)).toBe(
+        "GitHub__issue_write",
+      );
+    });
+
+    it("leaves non-front-door (Claude built-in) tool names unchanged", () => {
+      expect(stripFrontDoorPrefix("Read")).toBe("Read");
+      expect(stripFrontDoorPrefix("mcp__other__Foo__bar")).toBe("mcp__other__Foo__bar");
     });
   });
 });

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -15,8 +15,12 @@ vi.mock("../../utils/error-utils", () => ({
 import type { MCPStep } from "../../../shared/types/mcp";
 import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 // vi.mock calls above are hoisted, so this static import sees the stubbed modules.
-import { LocalClaudeOrchestrator } from "./local-claude-orchestrator";
-import type { MCPServerConfig } from "./types";
+import {
+  LocalClaudeOrchestrator,
+  type OrchestratorServerManager,
+  YAKSHAVER_MCP_SERVER_KEY,
+  type YakshaverFrontDoorConfig,
+} from "./local-claude-orchestrator";
 
 type MockChild = ChildProcess & {
   stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
@@ -52,40 +56,22 @@ function makeSpawner(versionExitCode: number, runChild: MockChild, runScript?: (
   return { spawn };
 }
 
-function makeManager(servers: MCPServerConfig[]) {
-  return { listAvailableServers: vi.fn().mockResolvedValue(servers) };
+/** A manager mock exposing the new orchestrator surface: the prefixed whitelist + a warm hook. */
+function makeManager(whitelist: string[] = []): OrchestratorServerManager {
+  return {
+    getWhitelistWithServerPrefixAsync: vi.fn().mockResolvedValue(whitelist),
+    collectToolsWithServerPrefixAsync: vi.fn().mockResolvedValue({}),
+  };
 }
 
 function makeSettings(mode: ToolApprovalMode) {
   return { getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: mode }) };
 }
 
-function makeTokenStorage(tokenByServer: Record<string, string> = {}) {
-  return {
-    getTokensAsync: vi.fn(async (serverId: string) =>
-      tokenByServer[serverId] ? { access_token: tokenByServer[serverId] } : undefined,
-    ),
-  };
-}
-
-const httpServer: MCPServerConfig = {
-  id: "gh-1",
-  name: "GitHub",
-  transport: "streamableHttp",
-  url: "https://mcp.github.test/",
-  toolWhitelist: ["create_issue"],
-  enabled: true,
-};
-
-const stdioServer: MCPServerConfig = {
-  id: "fs-1",
-  name: "Local FS",
-  transport: "stdio",
-  command: "npx",
-  args: ["-y", "fs-mcp"],
-  env: { FOO: "bar" },
-  toolWhitelist: ["read_file"],
-  enabled: true,
+const frontDoor: YakshaverFrontDoorConfig = {
+  command: "/path/to/node",
+  cliEntryPath: "/app/dist/cli/index.js",
+  env: { ELECTRON_RUN_AS_NODE: "1", YAKSHAVER_BRIDGE_PORT: "8765", YAKSHAVER_BRIDGE_TOKEN: "tok" },
 };
 
 describe("LocalClaudeOrchestrator", () => {
@@ -101,8 +87,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("ask"),
         { generateObject: vi.fn() },
       );
@@ -124,8 +110,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("ask"),
         { generateObject: vi.fn() },
       );
@@ -136,87 +122,67 @@ describe("LocalClaudeOrchestrator", () => {
     });
   });
 
-  describe("MCP config serialization", () => {
-    it("serializes stdio (command/args/env) and http (url + injected bearer token)", async () => {
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn: vi.fn() },
-        makeManager([stdioServer, httpServer]),
-        makeTokenStorage({ "gh-1": "tok-123" }),
-        makeSettings("ask"),
-        { generateObject: vi.fn() },
-      );
+  describe("single-entry yakshaver MCP config (#915 front-door)", () => {
+    it("writes ONE mcp server entry: yakshaver -> the mcp-serve front-door", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const config = orch.buildMcpConfig(frontDoor);
 
-      const { mcpConfig, allowedTools } = await orch.serializeMcpServers(
-        makeManager([stdioServer, httpServer]),
-        undefined,
-      );
-
-      expect(mcpConfig.mcpServers).toEqual({
-        Local_FS: {
-          type: "stdio",
-          command: "npx",
-          args: ["-y", "fs-mcp"],
-          env: { FOO: "bar" },
-        },
-        GitHub: {
-          type: "http",
-          url: "https://mcp.github.test/",
-          headers: { Authorization: "Bearer tok-123" },
+      expect(Object.keys(config.mcpServers)).toEqual([YAKSHAVER_MCP_SERVER_KEY]);
+      expect(config.mcpServers.yakshaver).toEqual({
+        type: "stdio",
+        command: "/path/to/node",
+        args: ["/app/dist/cli/index.js", "mcp-serve"],
+        env: {
+          ELECTRON_RUN_AS_NODE: "1",
+          YAKSHAVER_BRIDGE_PORT: "8765",
+          YAKSHAVER_BRIDGE_TOKEN: "tok",
         },
       });
-      expect(allowedTools).toEqual(["mcp__Local_FS__read_file", "mcp__GitHub__create_issue"]);
     });
 
-    it("respects the serverFilter and skips disabled + inMemory servers", async () => {
-      const disabled: MCPServerConfig = { ...stdioServer, id: "off", name: "Off", enabled: false };
-      const internal: MCPServerConfig = {
-        id: "in",
-        name: "Internal",
-        transport: "inMemory",
-        enabled: true,
+    it("omits env when the front-door has none", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const config = orch.buildMcpConfig({
+        command: "node",
+        cliEntryPath: "/app/dist/cli/index.js",
+      });
+      expect(config.mcpServers.yakshaver).not.toHaveProperty("env");
+    });
+
+    it("re-prefixes the app's whitelist as mcp__yakshaver__<Server__tool>", async () => {
+      const orch = new LocalClaudeOrchestrator();
+      const manager = makeManager(["GitHub__create_issue", "Internal__fill_template"]);
+
+      const allowed = await orch.buildAllowedTools(manager);
+
+      expect(manager.collectToolsWithServerPrefixAsync).toHaveBeenCalledOnce();
+      expect(allowed).toEqual([
+        "mcp__yakshaver__GitHub__create_issue",
+        "mcp__yakshaver__Internal__fill_template",
+      ]);
+    });
+
+    it("warming failure is non-fatal; the stored whitelist still applies", async () => {
+      const orch = new LocalClaudeOrchestrator();
+      const manager: OrchestratorServerManager = {
+        getWhitelistWithServerPrefixAsync: vi.fn().mockResolvedValue(["GitHub__create_issue"]),
+        collectToolsWithServerPrefixAsync: vi.fn().mockRejectedValue(new Error("no servers")),
       };
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn: vi.fn() },
-        null,
-        makeTokenStorage(),
-      );
-      const mgr = makeManager([stdioServer, httpServer, disabled, internal]);
-
-      const { mcpConfig } = await orch.serializeMcpServers(mgr, ["gh-1"]);
-      expect(Object.keys(mcpConfig.mcpServers)).toEqual(["GitHub"]);
-    });
-
-    it("flags servers with no whitelist (under ask/wait) instead of hanging", async () => {
-      const noWhitelist: MCPServerConfig = { ...httpServer, toolWhitelist: [] };
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn: vi.fn() },
-        null,
-        makeTokenStorage(),
-      );
-      const { skippedNonWhitelistedServers, allowedTools } = await orch.serializeMcpServers(
-        makeManager([noWhitelist]),
-        undefined,
-      );
-      expect(skippedNonWhitelistedServers).toEqual(["GitHub"]);
-      expect(allowedTools).toEqual([]);
+      const allowed = await orch.buildAllowedTools(manager);
+      expect(allowed).toEqual(["mcp__yakshaver__GitHub__create_issue"]);
     });
   });
 
   describe("argv building per approval mode", () => {
-    it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {
+    it("always passes --strict-mcp-config + the single --mcp-config", () => {
       const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "yolo", ["mcp__GitHub__create_issue"]);
-      expect(argv).toContain("--permission-mode");
-      expect(argv).toContain("bypassPermissions");
-      expect(argv).not.toContain("--allowedTools");
+      const argv = orch.buildArgv("/tmp/cfg.json", "yolo", []);
       expect(argv).toEqual(
         expect.arrayContaining([
           "-p",
           "--mcp-config",
           "/tmp/cfg.json",
+          "--strict-mcp-config",
           "--output-format",
           "stream-json",
           "--verbose",
@@ -224,15 +190,27 @@ describe("LocalClaudeOrchestrator", () => {
       );
     });
 
-    it("ask -> --allowedTools built from the whitelist", () => {
+    it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const argv = orch.buildArgv("/tmp/cfg.json", "yolo", [
+        "mcp__yakshaver__GitHub__create_issue",
+      ]);
+      expect(argv).toContain("--permission-mode");
+      expect(argv).toContain("bypassPermissions");
+      expect(argv).not.toContain("--allowedTools");
+    });
+
+    it("ask -> --allowedTools built from the yakshaver-prefixed whitelist", () => {
       const orch = new LocalClaudeOrchestrator();
       const argv = orch.buildArgv("/tmp/cfg.json", "ask", [
-        "mcp__GitHub__create_issue",
-        "mcp__Local_FS__read_file",
+        "mcp__yakshaver__GitHub__create_issue",
+        "mcp__yakshaver__Local_FS__read_file",
       ]);
       const idx = argv.indexOf("--allowedTools");
       expect(idx).toBeGreaterThan(-1);
-      expect(argv[idx + 1]).toBe("mcp__GitHub__create_issue,mcp__Local_FS__read_file");
+      expect(argv[idx + 1]).toBe(
+        "mcp__yakshaver__GitHub__create_issue,mcp__yakshaver__Local_FS__read_file",
+      );
       expect(argv).not.toContain("bypassPermissions");
     });
 
@@ -272,7 +250,11 @@ describe("LocalClaudeOrchestrator", () => {
           type: "assistant",
           message: {
             content: [
-              { type: "tool_use", name: "mcp__GitHub__create_issue", input: { title: "Bug" } },
+              {
+                type: "tool_use",
+                name: "mcp__yakshaver__GitHub__create_issue",
+                input: { title: "Bug" },
+              },
             ],
           },
         }),
@@ -282,7 +264,7 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_result",
-                tool_use_id: "mcp__GitHub__create_issue",
+                tool_use_id: "mcp__yakshaver__GitHub__create_issue",
                 content: "Created issue #5: https://github.com/o/r/issues/5",
               },
             ],
@@ -299,8 +281,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([httpServer]),
-        makeTokenStorage({ "gh-1": "tok" }),
+        makeManager(["GitHub__create_issue"]),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject },
       );
@@ -338,7 +320,7 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_result",
-                tool_use_id: "mcp__GitHub__create_issue",
+                tool_use_id: "mcp__yakshaver__GitHub__create_issue",
                 is_error: true,
                 content: "401 Unauthorized",
               },
@@ -351,8 +333,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([httpServer]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject },
       );
@@ -368,8 +350,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject: vi.fn() },
       );
@@ -387,8 +369,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject: vi.fn() },
       );

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -6,7 +6,6 @@ import { join } from "node:path";
 import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 import { getDurationParts } from "../../utils/duration-utils";
 import type { VideoUploadResult } from "../auth/types";
-import { McpOAuthTokenStorage } from "../storage/mcp-oauth-token-storage";
 import { UserSettingsStorage } from "../storage/user-settings-storage";
 import {
   type IBacklogOrchestrator,
@@ -20,7 +19,6 @@ import {
 import { LanguageModelProvider } from "./language-model-provider";
 import { MCPServerManager } from "./mcp-server-manager";
 import { orchestratorSystemPrompt } from "./prompts";
-import type { MCPServerConfig } from "./types";
 
 /**
  * Spawner abstraction mirroring ffmpeg-service's `IProcessSpawner`, kept here so the unit tests
@@ -55,21 +53,46 @@ export interface ClaudeMcpConfigFile {
   mcpServers: Record<string, ClaudeMcpServer>;
 }
 
-/** Minimal token lookup the orchestrator needs — narrower than the full storage so tests stub it easily. */
-export interface TokenLookup {
-  getTokensAsync(serverId: string): Promise<{ access_token?: string } | undefined>;
-}
+/** Fixed MCP server key for the single front-door. Tools appear as `mcp__yakshaver__<Server__tool>`. */
+export const YAKSHAVER_MCP_SERVER_KEY = "yakshaver";
 
-/** Claude Code's tool name format is `mcp__<server>__<tool>`. Server names are sanitized to match. */
-function sanitizeServerName(name: string): string {
-  return name.replace(/\s+/g, "_");
+/**
+ * How to spawn the single `yakshaver mcp-serve` front-door (#915), and how the
+ * spawned process reaches the running app's bridge.
+ *
+ * Injectable so the argv/config unit tests stay pure (no Electron `app`, no
+ * `process.execPath`, no live bridge). The real value is resolved from the
+ * Electron app + the running {@link CliBridgeServer} at call time.
+ */
+export interface YakshaverFrontDoorConfig {
+  /** Executable that runs the CLI (Electron-as-node in prod, or `node` in tests). */
+  command: string;
+  /** Path to the built CLI entry (`dist/cli/index.js`). The `mcp-serve` arg is appended. */
+  cliEntryPath: string;
+  /** Extra env to pass to the front-door process (bridge port/token, ELECTRON_RUN_AS_NODE). */
+  env?: Record<string, string>;
 }
 
 /**
+ * The MCPServerManager surface the orchestrator now needs: the prefixed whitelist (authoritative
+ * client-side gate) plus an optional tool-collection call to warm the internal clients so built-in
+ * tools are reflected in the whitelist.
+ */
+export type OrchestratorServerManager = Pick<
+  MCPServerManager,
+  "getWhitelistWithServerPrefixAsync"
+> &
+  Partial<Pick<MCPServerManager, "collectToolsWithServerPrefixAsync">>;
+
+/**
  * Drives the backlog-creation step with a local headless `claude -p` process instead of the
- * in-process OpenAI loop. Serializes the enabled MCP servers to a temp `--mcp-config`, maps the
- * tool-approval mode to Claude's permission flags, streams `stream-json` events to `onStep`, and
- * reuses the shared `judgeBacklogOutcome` on the collected tool results.
+ * in-process OpenAI loop.
+ *
+ * As of #915 it no longer serializes each MCP server (and skips internal ones); instead it writes
+ * a SINGLE `--mcp-config` entry — the `yakshaver` MCP front-door — which proxies the app's full
+ * aggregated toolset (including internal/in-memory servers) over the localhost bridge. It still
+ * maps the tool-approval mode to Claude's permission flags, streams `stream-json` events to
+ * `onStep`, and reuses the shared `judgeBacklogOutcome` on the collected tool results.
  */
 export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
   // Storage deps are resolved lazily — only when actually needed — so constructing the orchestrator
@@ -77,15 +100,11 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
   constructor(
     private readonly claudeCommand: string = "claude",
     private readonly spawner: IClaudeProcessSpawner = defaultClaudeSpawner,
-    private readonly serverManager: Pick<MCPServerManager, "listAvailableServers"> | null = null,
-    private readonly tokenStorage: TokenLookup | null = null,
+    private readonly serverManager: OrchestratorServerManager | null = null,
+    private readonly frontDoor: YakshaverFrontDoorConfig | null = null,
     private readonly settingsStorage: Pick<UserSettingsStorage, "getSettingsAsync"> | null = null,
     private readonly judgeProvider: OutcomeJudgeProvider | null = null,
   ) {}
-
-  private getTokenStorage(): TokenLookup {
-    return this.tokenStorage ?? McpOAuthTokenStorage.getInstance();
-  }
 
   private getSettingsStorage(): Pick<UserSettingsStorage, "getSettingsAsync"> {
     return this.settingsStorage ?? UserSettingsStorage.getInstance();
@@ -120,6 +139,7 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
     await this.ensureClaudeAvailable();
 
     const manager = this.serverManager ?? (await MCPServerManager.getInstanceAsync());
+    const frontDoor = this.frontDoor ?? (await resolveFrontDoorConfig());
     const approvalMode = (await this.getSettingsStorage().getSettingsAsync()).toolApprovalMode;
 
     const systemPrompt = this.buildSystemPrompt(
@@ -129,12 +149,12 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
       options.videoFilePath,
     );
 
-    const { mcpConfig, allowedTools, skippedNonWhitelistedServers } =
-      await this.serializeMcpServers(manager, options.serverFilter);
+    const mcpConfig = this.buildMcpConfig(frontDoor);
+    const allowedTools = await this.buildAllowedTools(manager);
 
-    if (skippedNonWhitelistedServers.length > 0) {
+    if (approvalMode !== "yolo" && allowedTools.length === 0) {
       console.warn(
-        `[LocalClaudeOrchestrator] No whitelisted tools for server(s): ${skippedNonWhitelistedServers.join(", ")} under "${approvalMode}" approval mode — proceeding with whatever is whitelisted; non-whitelisted tools were skipped.`,
+        `[LocalClaudeOrchestrator] No whitelisted tools under "${approvalMode}" approval mode — Claude will be constrained to the built-in tools the app always permits. Whitelist tools or use "yolo" to allow more.`,
       );
     }
 
@@ -195,85 +215,40 @@ Embed this URL in the task content that you create. Follow user requirements STR
   }
 
   /**
-   * Serializes the enabled MCP servers (respecting `serverFilter`) into Claude Code's
-   * `--mcp-config` format. stdio → {command,args,env}; streamableHttp → {url, headers} with the
-   * OAuth bearer token injected from token storage when present. Also returns the `--allowedTools`
-   * derived from each server's whitelist (used under ask/wait approval modes).
+   * Builds the SINGLE-entry `--mcp-config` (#915): one `yakshaver` MCP server that proxies the
+   * app's full aggregated toolset over the localhost bridge. No per-server serialization and no
+   * OAuth-token injection here — the front-door reaches the app, which applies its own auth.
+   *
+   * The resulting tools appear to Claude as `mcp__yakshaver__<Server__tool>`.
    */
-  public async serializeMcpServers(
-    manager: Pick<MCPServerManager, "listAvailableServers">,
-    serverFilter?: string[],
-  ): Promise<{
-    mcpConfig: ClaudeMcpConfigFile;
-    allowedTools: string[];
-    skippedNonWhitelistedServers: string[];
-  }> {
-    const all = await manager.listAvailableServers();
-    const filterSet = serverFilter && serverFilter.length > 0 ? new Set(serverFilter) : null;
-
-    const selected = all.filter((c) => {
-      if (c.enabled === false) return false;
-      if (!filterSet) return true;
-      return filterSet.has(c.id) || filterSet.has(c.name);
-    });
-
-    const mcpServers: Record<string, ClaudeMcpServer> = {};
-    const allowedTools: string[] = [];
-    const skippedNonWhitelistedServers: string[] = [];
-
-    for (const config of selected) {
-      // inMemory servers are YakShaver-internal; Claude Code can't reach them over its own
-      // transports, so they're skipped for the local backend.
-      if (config.transport === "inMemory") continue;
-
-      const serverKey = sanitizeServerName(config.name);
-      const entry = await this.toClaudeServerEntry(config);
-      if (!entry) continue;
-      mcpServers[serverKey] = entry;
-
-      const whitelist = config.toolWhitelist ?? [];
-      if (whitelist.length === 0) {
-        skippedNonWhitelistedServers.push(config.name);
-      }
-      for (const toolName of whitelist) {
-        allowedTools.push(`mcp__${serverKey}__${toolName}`);
-      }
-    }
-
-    return {
-      mcpConfig: { mcpServers },
-      allowedTools,
-      skippedNonWhitelistedServers,
+  public buildMcpConfig(frontDoor: YakshaverFrontDoorConfig): ClaudeMcpConfigFile {
+    const entry: ClaudeStdioServer = {
+      type: "stdio",
+      command: frontDoor.command,
+      args: [frontDoor.cliEntryPath, "mcp-serve"],
     };
+    if (frontDoor.env && Object.keys(frontDoor.env).length > 0) {
+      entry.env = frontDoor.env;
+    }
+    return { mcpServers: { [YAKSHAVER_MCP_SERVER_KEY]: entry } };
   }
 
-  private async toClaudeServerEntry(config: MCPServerConfig): Promise<ClaudeMcpServer | null> {
-    if (config.transport === "stdio") {
-      const entry: ClaudeStdioServer = {
-        type: "stdio",
-        command: config.command,
-      };
-      if (config.args && config.args.length > 0) entry.args = config.args;
-      if (config.env && Object.keys(config.env).length > 0) entry.env = config.env;
-      return entry;
+  /**
+   * Builds the `--allowedTools` list for ask/wait modes: the app's whitelisted, server-prefixed
+   * tool names (`Server__tool`), each re-prefixed for the single front-door so Claude sees them as
+   * `mcp__yakshaver__<Server__tool>`. (Built-in/internal tools are always whitelisted by the
+   * manager, so they flow through here too.) Under yolo this is unused.
+   */
+  public async buildAllowedTools(manager: OrchestratorServerManager): Promise<string[]> {
+    // Warm the MCP clients first (best-effort) so built-in/internal tools — which are only
+    // reflected in the whitelist once their client is connected — are included.
+    if (manager.collectToolsWithServerPrefixAsync) {
+      await manager.collectToolsWithServerPrefixAsync().catch(() => {
+        /* no enabled servers / nothing to warm — the stored whitelist still applies */
+      });
     }
-
-    if (config.transport === "streamableHttp") {
-      const headers: Record<string, string> = { ...config.headers };
-      // Inject the OAuth bearer token so Claude Code authenticates the same way the in-process
-      // client does (built-in servers don't use OAuth).
-      if (!config.builtin) {
-        const tokens = await this.getTokenStorage().getTokensAsync(config.id);
-        if (tokens?.access_token) {
-          headers.Authorization = `Bearer ${tokens.access_token}`;
-        }
-      }
-      const entry: ClaudeHttpServer = { type: "http", url: config.url };
-      if (Object.keys(headers).length > 0) entry.headers = headers;
-      return entry;
-    }
-
-    return null;
+    const prefixedWhitelist = await manager.getWhitelistWithServerPrefixAsync();
+    return prefixedWhitelist.map((name) => `mcp__${YAKSHAVER_MCP_SERVER_KEY}__${name}`);
   }
 
   /**
@@ -281,6 +256,9 @@ Embed this URL in the task content that you create. Follow user requirements STR
    * - `yolo` → `--permission-mode bypassPermissions` (run every tool immediately).
    * - `ask` / `wait` → `--allowedTools <whitelist>` (only the whitelisted tools may run; anything
    *   else is denied by Claude rather than hanging on an interactive prompt the headless run can't answer).
+   *
+   * Always passes `--strict-mcp-config` so Claude loads ONLY our single front-door config and
+   * ignores any ambient user/project `.mcp.json`.
    */
   public buildArgv(
     mcpConfigPath: string,
@@ -291,6 +269,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
       "-p",
       "--mcp-config",
       mcpConfigPath,
+      "--strict-mcp-config",
       "--output-format",
       "stream-json",
       "--verbose",
@@ -465,6 +444,35 @@ Embed this URL in the task content that you create. Follow user requirements STR
       return null;
     }
   }
+}
+
+/**
+ * Resolve how to spawn the `yakshaver mcp-serve` front-door from the live Electron app + bridge.
+ *
+ * - command: the current binary run as plain Node (`ELECTRON_RUN_AS_NODE=1` + `process.execPath`),
+ *   so we don't depend on a separately-installed node.
+ * - cliEntryPath: the packaged CLI entry, `<appPath>/dist/cli/index.js`.
+ * - env: bridge port + token (so the front-door connects without racing the token file) plus
+ *   `ELECTRON_RUN_AS_NODE`.
+ *
+ * Lazily imports electron + the bridge server so the pure argv/config unit tests (which always
+ * inject a `frontDoor`) never touch these singletons.
+ */
+async function resolveFrontDoorConfig(): Promise<YakshaverFrontDoorConfig> {
+  const { app } = await import("electron");
+  const { CliBridgeServer } = await import("../cli-bridge/cli-bridge-server");
+
+  const cliEntryPath = join(app.getAppPath(), "dist", "cli", "index.js");
+  const env: Record<string, string> = { ELECTRON_RUN_AS_NODE: "1" };
+
+  // Hand the front-door the live bridge port+token so it connects deterministically.
+  const bridge = CliBridgeServer.getInstance();
+  const port = bridge.getPort();
+  const token = bridge.getToken();
+  if (port != null) env.YAKSHAVER_BRIDGE_PORT = String(port);
+  if (token) env.YAKSHAVER_BRIDGE_TOKEN = token;
+
+  return { command: process.execPath, cliEntryPath, env };
 }
 
 /** A loose view of the Claude Code stream-json events we care about. */

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -299,6 +299,13 @@ Embed this URL in the task content that you create. Follow user requirements STR
 
     const child = this.spawner.spawn(this.claudeCommand, argv);
 
+    // Always emit a first line so the Executing Task box is never empty, even before Claude
+    // streams anything (and even when its narration ends up terse).
+    options.onStep?.({
+      type: "start",
+      message: "Orchestrating with Claude Code…",
+    });
+
     // The full prompt = system prompt + the transcript as the user input, passed over stdin so
     // long transcripts don't bump into argv length limits.
     const fullPrompt = `${systemPrompt}\n\n---\nvideo transcription: ${videoTranscription}`;
@@ -350,9 +357,14 @@ Embed this URL in the task content that you create. Follow user requirements STR
         if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
 
         if (code !== 0 && terminationReason === "unknown") {
+          // A non-zero exit with no result event is most commonly an auth failure (the headless
+          // `claude -p` can't prompt for login, so it exits with an auth error on stderr). Append
+          // actionable guidance so the user isn't left with a bare exit code.
+          const guidance =
+            " Claude Code may not be signed in — run `claude` in a terminal to log in, or switch the Orchestrator to OpenAI in Settings.";
           reject(
             new Error(
-              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}`,
+              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}${guidance}`,
             ),
           );
           return;
@@ -393,11 +405,18 @@ Embed this URL in the task content that you create. Follow user requirements STR
     if (event.type === "assistant" && event.message?.content) {
       for (const block of event.message.content) {
         if (block.type === "text" && block.text) {
-          onStep?.({ type: "reasoning", reasoning: block.text });
+          // The UI's <ReasoningStep> JSON.parses `reasoning` and renders `parsed.text` — matching
+          // how the OpenAI loop emits it. Wrap Claude's raw text the same way; emitting a bare
+          // string would fail that parse and render a BLANK reasoning box (the root cause of the
+          // sparse Executing Task box under the local-claude backend).
+          onStep?.({
+            type: "reasoning",
+            reasoning: JSON.stringify({ type: "text", text: block.text }),
+          });
         } else if (block.type === "tool_use") {
           onStep?.({
             type: "tool_call",
-            toolName: block.name ?? "unknown",
+            toolName: stripFrontDoorPrefix(block.name ?? "unknown"),
             args: block.input,
           });
         }
@@ -492,6 +511,21 @@ interface ClaudeStreamEvent {
       content?: unknown;
     }>;
   };
+}
+
+/** The prefix Claude prepends to every front-door tool: `mcp__yakshaver__<Server__tool>`. */
+const FRONT_DOOR_TOOL_PREFIX = `mcp__${YAKSHAVER_MCP_SERVER_KEY}__`;
+
+/**
+ * Strips the single-front-door prefix from a tool name so the UI shows the real `Server__tool`
+ * (e.g. `mcp__yakshaver__GitHub__issue_write` -> `GitHub__issue_write`). The UI's `formatToolName`
+ * splits on the FIRST `__`, so without this it would mis-parse the server as `mcp` and render a
+ * messy/blank tool label. Non-front-door tools (Claude built-ins) are returned unchanged.
+ */
+export function stripFrontDoorPrefix(toolName: string): string {
+  return toolName.startsWith(FRONT_DOOR_TOOL_PREFIX)
+    ? toolName.slice(FRONT_DOOR_TOOL_PREFIX.length)
+    : toolName;
 }
 
 /** Tool results in stream-json may be a string or an array of `{type:"text", text}` blocks. */

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { CLI_BRIDGE_PORT_ENV, CLI_BRIDGE_TOKEN_ENV } from "../../../shared/cli-bridge/protocol";
 import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 import { getDurationParts } from "../../utils/duration-utils";
 import type { VideoUploadResult } from "../auth/types";
@@ -469,8 +470,8 @@ async function resolveFrontDoorConfig(): Promise<YakshaverFrontDoorConfig> {
   const bridge = CliBridgeServer.getInstance();
   const port = bridge.getPort();
   const token = bridge.getToken();
-  if (port != null) env.YAKSHAVER_BRIDGE_PORT = String(port);
-  if (token) env.YAKSHAVER_BRIDGE_TOKEN = token;
+  if (port != null) env[CLI_BRIDGE_PORT_ENV] = String(port);
+  if (token) env[CLI_BRIDGE_TOKEN_ENV] = token;
 
   return { command: process.execPath, cliEntryPath, env };
 }

--- a/src/backend/services/mcp/mcp-tool-bridge.test.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.test.ts
@@ -1,0 +1,133 @@
+import type { ToolSet } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { McpToolBridge, type ToolBridgeManager, type ToolBridgeSettings } from "./mcp-tool-bridge";
+
+/**
+ * Build a ToolSet where each tool carries an AI-SDK-shaped {description, inputSchema, execute}.
+ * `Internal__*` stands in for an internal/in-memory server's tool — the #915 win is that these
+ * are present here even though Claude Code can't reach them over its own transports.
+ */
+function makeToolSet(executeSpies: Record<string, ReturnType<typeof vi.fn>> = {}): ToolSet {
+  const mk = (name: string, description: string) =>
+    ({
+      description,
+      inputSchema: z.object({ title: z.string() }),
+      execute: executeSpies[name] ?? vi.fn().mockResolvedValue(`ran ${name}`),
+    }) as unknown as ToolSet[string];
+
+  return {
+    GitHub__create_issue: mk("GitHub__create_issue", "Create a GitHub issue"),
+    Internal__fill_template: mk("Internal__fill_template", "Fill the internal template"),
+  };
+}
+
+function makeManager(
+  tools: ToolSet,
+  whitelist: string[] = [],
+): ToolBridgeManager & {
+  collectToolsWithServerPrefixAsync: ReturnType<typeof vi.fn>;
+} {
+  return {
+    collectToolsWithServerPrefixAsync: vi.fn().mockResolvedValue(tools),
+    getWhitelistWithServerPrefixAsync: vi.fn().mockResolvedValue(whitelist),
+  };
+}
+
+function makeSettings(mode: "yolo" | "ask" | "wait"): ToolBridgeSettings {
+  return { getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: mode }) };
+}
+
+describe("McpToolBridge.listTools", () => {
+  it("flattens the aggregated toolset INCLUDING internal servers, with JSON-Schema input", async () => {
+    const bridge = new McpToolBridge(makeManager(makeToolSet()), makeSettings("ask"));
+    const tools = await bridge.listTools();
+
+    const names = tools.map((t) => t.name).sort();
+    // Internal/in-memory server tool is present — the key #915 win.
+    expect(names).toEqual(["GitHub__create_issue", "Internal__fill_template"]);
+
+    const gh = tools.find((t) => t.name === "GitHub__create_issue");
+    expect(gh?.description).toBe("Create a GitHub issue");
+    // Zod inputSchema is resolved to a JSON Schema object.
+    expect(gh?.inputSchema).toMatchObject({ type: "object" });
+    expect((gh?.inputSchema as { properties?: unknown }).properties).toHaveProperty("title");
+  });
+
+  it("falls back to a permissive object schema when a tool has no inputSchema", async () => {
+    const tools = {
+      Bare__tool: { description: "no schema", execute: vi.fn() },
+    } as unknown as ToolSet;
+    const bridge = new McpToolBridge(makeManager(tools), makeSettings("yolo"));
+    const [summary] = await bridge.listTools();
+    expect(summary.inputSchema).toEqual({ type: "object", properties: {} });
+  });
+});
+
+describe("McpToolBridge.callTool - approval policy enforcement", () => {
+  let executeSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executeSpy = vi.fn().mockResolvedValue("Created #5");
+  });
+
+  it("yolo: runs ANY tool immediately (no whitelist needed)", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), /* whitelist */ []),
+      makeSettings("yolo"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(executeSpy).toHaveBeenCalledOnce();
+    expect(res).toEqual({ ok: true, result: "Created #5" });
+  });
+
+  it("ask: runs a whitelisted tool", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), ["GitHub__create_issue"]),
+      makeSettings("ask"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(executeSpy).toHaveBeenCalledOnce();
+    expect(res.ok).toBe(true);
+  });
+
+  it("ask/wait: a NON-whitelisted tool returns a structured not-approved result and does NOT run (no hang)", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), /* whitelist */ []),
+      makeSettings("wait"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(executeSpy).not.toHaveBeenCalled();
+    expect(res.ok).toBe(false);
+    expect(res.notApproved).toBe(true);
+    expect(res.error).toMatch(/not approved/i);
+  });
+
+  it("returns a clear error for an unknown tool", async () => {
+    const bridge = new McpToolBridge(makeManager(makeToolSet()), makeSettings("yolo"));
+    const res = await bridge.callTool("Nope__missing", {});
+    expect(res).toEqual({ ok: false, error: "Unknown tool: Nope__missing" });
+  });
+
+  it("captures an execute() throw as a structured failure (does not reject)", async () => {
+    const boom = vi.fn().mockRejectedValue(new Error("boom"));
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: boom }), ["GitHub__create_issue"]),
+      makeSettings("ask"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(res).toEqual({ ok: false, error: "boom" });
+  });
+
+  it("defaults arguments to {} and passes them to execute()", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), []),
+      makeSettings("yolo"),
+    );
+    await bridge.callTool("GitHub__create_issue");
+    expect(executeSpy).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ toolCallId: expect.any(String) }),
+    );
+  });
+});

--- a/src/backend/services/mcp/mcp-tool-bridge.test.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.test.ts
@@ -62,6 +62,20 @@ describe("McpToolBridge.listTools", () => {
     const [summary] = await bridge.listTools();
     expect(summary.inputSchema).toEqual({ type: "object", properties: {} });
   });
+
+  it("resolves to an EMPTY list (never rejects) when no enabled servers are healthy", async () => {
+    // collectToolsWithServerPrefixAsync throws ("No MCP clients available" /
+    // "No tools available...") whenever zero enabled servers are healthy — e.g.
+    // the first-run "no MCP servers configured" state. The bridge must collapse
+    // that to [] so the front-door's tools/list returns an empty list rather
+    // than a JSON-RPC transport error mid-run.
+    const manager = makeManager(makeToolSet());
+    manager.collectToolsWithServerPrefixAsync.mockRejectedValue(
+      new Error("[MCPServerManager]: No MCP clients available"),
+    );
+    const bridge = new McpToolBridge(manager, makeSettings("ask"));
+    await expect(bridge.listTools()).resolves.toEqual([]);
+  });
 });
 
 describe("McpToolBridge.callTool - approval policy enforcement", () => {
@@ -118,6 +132,22 @@ describe("McpToolBridge.callTool - approval policy enforcement", () => {
     );
     const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
     expect(res).toEqual({ ok: false, error: "boom" });
+  });
+
+  it("returns a structured failure (never rejects) when no enabled servers are healthy", async () => {
+    // Same degenerate state as the listTools case: collecting the toolset throws.
+    // callTool must collapse it to an empty toolset, so the existing "Unknown
+    // tool" structured refusal is returned and the front-door can relay it as an
+    // MCP isError result instead of rejecting with a transport error mid-run.
+    const manager = makeManager(makeToolSet(), ["GitHub__create_issue"]);
+    manager.collectToolsWithServerPrefixAsync.mockRejectedValue(
+      new Error("[MCPServerManager]: No tools available from selected/healthy servers"),
+    );
+    const bridge = new McpToolBridge(manager, makeSettings("yolo"));
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected a structured failure");
+    expect(res.error).toMatch(/unknown tool/i);
   });
 
   it("defaults arguments to {} and passes them to execute()", async () => {

--- a/src/backend/services/mcp/mcp-tool-bridge.test.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.test.ts
@@ -99,6 +99,7 @@ describe("McpToolBridge.callTool - approval policy enforcement", () => {
     const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
     expect(executeSpy).not.toHaveBeenCalled();
     expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected a not-approved failure");
     expect(res.notApproved).toBe(true);
     expect(res.error).toMatch(/not approved/i);
   });

--- a/src/backend/services/mcp/mcp-tool-bridge.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.ts
@@ -44,7 +44,7 @@ export class McpToolBridge {
 
   /** Aggregated tool list for `GET /tools`. Names/descriptions/schemas only. */
   async listTools(): Promise<BridgeToolSummary[]> {
-    const tools = await this.manager.collectToolsWithServerPrefixAsync();
+    const tools = await this.collectToolsOrEmpty();
     const summaries: BridgeToolSummary[] = [];
     for (const [name, tool] of Object.entries(tools)) {
       summaries.push({
@@ -65,7 +65,7 @@ export class McpToolBridge {
    * route these to the in-app approval UI; for v1 it's a clean refusal.)
    */
   async callTool(name: string, args: Record<string, unknown> = {}): Promise<ToolCallResult> {
-    const tools = await this.manager.collectToolsWithServerPrefixAsync();
+    const tools = await this.collectToolsOrEmpty();
     const tool = tools[name];
     if (!tool) {
       return { ok: false, error: `Unknown tool: ${name}` };
@@ -98,6 +98,28 @@ export class McpToolBridge {
       return { ok: true, result };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Resolve the aggregated toolset, treating the "no healthy/enabled servers"
+   * degenerate state as an EMPTY toolset rather than an error.
+   *
+   * {@link ToolBridgeManager.collectToolsWithServerPrefixAsync} throws when zero
+   * enabled servers are healthy (e.g. the first-run "no MCP servers configured"
+   * state, or every configured server failing to connect). That throw must NOT
+   * propagate to the bridge router (which would relay it as an HTTP 500 and make
+   * the front-door reject mid-run). Honouring the bridge's "never hang, always
+   * return a structured envelope" contract, we collapse it to `{}`:
+   *  - `listTools()` then returns an empty list (tools/list ⇒ []), and
+   *  - `callTool()` then returns the existing structured `{ok:false, "Unknown
+   *    tool"}` refusal, which the front-door relays as an MCP `isError` result.
+   */
+  private async collectToolsOrEmpty(): Promise<ToolSet> {
+    try {
+      return await this.manager.collectToolsWithServerPrefixAsync();
+    } catch {
+      return {} as ToolSet;
     }
   }
 }

--- a/src/backend/services/mcp/mcp-tool-bridge.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.ts
@@ -1,0 +1,139 @@
+import { asSchema, type ToolSet } from "ai";
+import type { BridgeToolSummary, ToolCallResult } from "../../../shared/cli-bridge/protocol";
+import type { ToolApprovalMode } from "../../../shared/types/user-settings";
+
+/**
+ * The slice of {@link MCPServerManager} the tool bridge needs. Kept narrow so the
+ * router (and its unit tests) can inject a mock without dragging in Electron, the
+ * MCP clients, or the storage singletons.
+ */
+export interface ToolBridgeManager {
+  /**
+   * The aggregated, server-prefixed toolset across ALL enabled servers —
+   * INCLUDING internal/in-memory ones (the #915 win: these are reachable here
+   * even though Claude Code cannot reach them over its own transports).
+   */
+  collectToolsWithServerPrefixAsync(): Promise<ToolSet>;
+  /** Prefixed tool names that may run without interactive approval. */
+  getWhitelistWithServerPrefixAsync(): Promise<string[]>;
+}
+
+/** The settings slice the bridge needs to read the current approval mode. */
+export interface ToolBridgeSettings {
+  getSettingsAsync(): Promise<{ toolApprovalMode: ToolApprovalMode }>;
+}
+
+/**
+ * Bridges the app's aggregated MCP toolset to the localhost bridge endpoints
+ * (`GET /tools`, `POST /tools/call`) consumed by the single `yakshaver` MCP
+ * front-door (#915).
+ *
+ * Two responsibilities:
+ *  1. Flatten the AI-SDK `ToolSet` (server-prefixed keys → `description` +
+ *     JSON-Schema `inputSchema`) into wire-friendly summaries.
+ *  2. Apply the app's tool-approval policy SERVER-SIDE on every call so a
+ *     headless run never hangs on an interactive prompt: `yolo` runs everything;
+ *     `ask`/`wait` run only whitelisted tools, otherwise return a STRUCTURED
+ *     "not approved" result.
+ */
+export class McpToolBridge {
+  constructor(
+    private readonly manager: ToolBridgeManager,
+    private readonly settings: ToolBridgeSettings,
+  ) {}
+
+  /** Aggregated tool list for `GET /tools`. Names/descriptions/schemas only. */
+  async listTools(): Promise<BridgeToolSummary[]> {
+    const tools = await this.manager.collectToolsWithServerPrefixAsync();
+    const summaries: BridgeToolSummary[] = [];
+    for (const [name, tool] of Object.entries(tools)) {
+      summaries.push({
+        name,
+        description: extractDescription(tool),
+        inputSchema: await extractInputSchema(tool),
+      });
+    }
+    return summaries;
+  }
+
+  /**
+   * Execute a single tool by its server-prefixed name for `POST /tools/call`.
+   *
+   * Enforces the approval policy first, NEVER hanging: under `ask`/`wait` a
+   * non-whitelisted tool returns `{ok:false, notApproved:true}` rather than
+   * waiting on a UI prompt the headless caller can't answer. (Phase 4.1 will
+   * route these to the in-app approval UI; for v1 it's a clean refusal.)
+   */
+  async callTool(name: string, args: Record<string, unknown> = {}): Promise<ToolCallResult> {
+    const tools = await this.manager.collectToolsWithServerPrefixAsync();
+    const tool = tools[name];
+    if (!tool) {
+      return { ok: false, error: `Unknown tool: ${name}` };
+    }
+
+    const approvalMode = (await this.settings.getSettingsAsync()).toolApprovalMode;
+    if (approvalMode !== "yolo") {
+      const whitelist = new Set(await this.manager.getWhitelistWithServerPrefixAsync());
+      if (!whitelist.has(name)) {
+        return {
+          ok: false,
+          notApproved: true,
+          error: `Tool '${name}' is not approved under the '${approvalMode}' approval mode. Whitelist it in YakShaver, or switch the approval mode to 'yolo'.`,
+        };
+      }
+    }
+
+    const execute = (tool as { execute?: unknown }).execute;
+    if (typeof execute !== "function") {
+      return { ok: false, error: `Tool '${name}' is not executable` };
+    }
+
+    try {
+      // The AI-SDK execute signature is execute(input, options). The bridge has
+      // no streaming context, so we pass a minimal options object.
+      const result = await (execute as ToolExecute)(args, {
+        toolCallId: `bridge-${Date.now()}`,
+        messages: [],
+      });
+      return { ok: true, result };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+type ToolExecute = (
+  input: unknown,
+  options: { toolCallId: string; messages: unknown[] },
+) => Promise<unknown> | unknown;
+
+function extractDescription(tool: unknown): string | undefined {
+  if (tool && typeof tool === "object" && "description" in tool) {
+    const desc = (tool as { description?: unknown }).description;
+    return typeof desc === "string" ? desc : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a tool's `inputSchema` (an AI-SDK FlexibleSchema — Zod, JSON-Schema, or
+ * Standard Schema) to a plain JSON Schema object the MCP front-door can hand to
+ * Claude. Falls back to a permissive empty-object schema if resolution fails.
+ */
+async function extractInputSchema(tool: unknown): Promise<Record<string, unknown>> {
+  const fallback: Record<string, unknown> = { type: "object", properties: {} };
+  if (!tool || typeof tool !== "object" || !("inputSchema" in tool)) {
+    return fallback;
+  }
+  const raw = (tool as { inputSchema?: unknown }).inputSchema;
+  if (raw === undefined || raw === null) return fallback;
+  try {
+    const schema = asSchema(raw as never);
+    const json = await schema.jsonSchema;
+    return (json as Record<string, unknown>) ?? fallback;
+  } catch {
+    // Some tools may already expose a plain JSON-Schema object directly.
+    if (typeof raw === "object") return raw as Record<string, unknown>;
+    return fallback;
+  }
+}

--- a/src/backend/services/workflow/mcp-workflow-adapter.test.ts
+++ b/src/backend/services/workflow/mcp-workflow-adapter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { MCPStep } from "../../../shared/types/mcp";
+import { ProgressStage as WorkflowProgressStage } from "../../../shared/types/workflow";
+import type { ExecutingTaskPayload } from "../../../shared/types/workflow-payloads";
+import { McpWorkflowAdapter } from "./mcp-workflow-adapter";
+import type { WorkflowStateManager } from "./workflow-state-manager";
+
+/**
+ * Minimal in-memory stand-in for {@link WorkflowStateManager} that records the EXECUTING_TASK
+ * payload/status the way the real manager would, without pulling in electron/telemetry singletons.
+ */
+function makeStubManager() {
+  const store: { payload?: string; status: string } = { status: "not_started" };
+  const manager = {
+    getStepState: () => ({ payload: store.payload, status: store.status }),
+    updateStagePayload: (_stage: unknown, payload: unknown, status?: string) => {
+      store.payload = JSON.stringify(payload);
+      if (status) store.status = status;
+    },
+    completeStage: (_stage: unknown, payload?: unknown) => {
+      store.payload = payload ? JSON.stringify(payload) : undefined;
+      store.status = "completed";
+    },
+    failStage: (_stage: unknown, _error: string) => {
+      store.payload = JSON.stringify({ error: _error });
+      store.status = "failed";
+    },
+  } as unknown as WorkflowStateManager;
+
+  const readPayload = (): ExecutingTaskPayload =>
+    store.payload ? (JSON.parse(store.payload) as ExecutingTaskPayload) : { steps: [] };
+
+  return { manager, readPayload, getStatus: () => store.status };
+}
+
+describe("McpWorkflowAdapter", () => {
+  it("seeds the orchestrator backend into the EXECUTING_TASK payload at construction", () => {
+    const { manager, readPayload } = makeStubManager();
+
+    new McpWorkflowAdapter(manager, { orchestrator: "claude-code" });
+
+    expect(readPayload().orchestrator).toBe("claude-code");
+    expect(readPayload().steps).toEqual([]);
+  });
+
+  it("defaults to the openai backend label when seeded as such", () => {
+    const { manager, readPayload } = makeStubManager();
+
+    new McpWorkflowAdapter(manager, { transcriptText: "hi", orchestrator: "openai" });
+
+    expect(readPayload().orchestrator).toBe("openai");
+    expect(readPayload().transcriptText).toBe("hi");
+  });
+
+  it("preserves the orchestrator field as steps stream in and the stage completes", () => {
+    const { manager, readPayload } = makeStubManager();
+    const adapter = new McpWorkflowAdapter(manager, { orchestrator: "claude-code" });
+
+    const start: MCPStep = { type: "start", message: "Orchestrating with Claude Code (local)…" };
+    adapter.onStep(start);
+
+    expect(readPayload().orchestrator).toBe("claude-code");
+    expect(readPayload().steps).toHaveLength(1);
+
+    adapter.complete("done", "final");
+
+    const final = readPayload();
+    expect(final.orchestrator).toBe("claude-code");
+    expect(final.steps).toHaveLength(1);
+    expect(final.mcpResult).toBe("done");
+  });
+
+  it("preserves the streamed steps and orchestrator badge on the failed path (#833)", () => {
+    const { manager, readPayload, getStatus } = makeStubManager();
+    const adapter = new McpWorkflowAdapter(manager, { orchestrator: "claude-code" });
+
+    adapter.onStep({ type: "start", message: "Orchestrating with Claude Code…" });
+    adapter.onStep({ type: "tool_call", toolName: "create_backlog_item" });
+
+    adapter.fail("drafted result", "final output", "No work item was created");
+
+    const final = readPayload();
+    expect(getStatus()).toBe("failed");
+    // failStage clobbers the slot to { error } — fail() must restore the snapshot taken first.
+    expect(final.orchestrator).toBe("claude-code");
+    expect(final.steps).toHaveLength(2);
+    expect(final.error).toBe("No work item was created");
+    expect(final.mcpResult).toBe("drafted result");
+    expect(final.finalOutput).toBe("final output");
+  });
+
+  it("does not stamp an orchestrator when none is provided", () => {
+    const { manager, readPayload } = makeStubManager();
+
+    // No initialContext at all — payload is only seeded once a step arrives.
+    const adapter = new McpWorkflowAdapter(manager);
+    adapter.onStep({ type: "start" });
+
+    expect(readPayload().orchestrator).toBeUndefined();
+  });
+
+  it("targets the EXECUTING_TASK stage", () => {
+    expect(WorkflowProgressStage.EXECUTING_TASK).toBe("executing_task");
+  });
+});

--- a/src/backend/services/workflow/mcp-workflow-adapter.ts
+++ b/src/backend/services/workflow/mcp-workflow-adapter.ts
@@ -1,6 +1,9 @@
 import type { MCPStep } from "../../../shared/types/mcp";
 import { ProgressStage as WorkflowProgressStage } from "../../../shared/types/workflow";
-import type { ExecutingTaskPayload } from "../../../shared/types/workflow-payloads";
+import type {
+  ExecutingTaskPayload,
+  OrchestratorBackend,
+} from "../../../shared/types/workflow-payloads";
 import type { WorkflowStateManager } from "./workflow-state-manager";
 
 export class McpWorkflowAdapter {
@@ -9,7 +12,11 @@ export class McpWorkflowAdapter {
 
   constructor(
     workflowManager: WorkflowStateManager,
-    initialContext?: { transcriptText?: string; intermediateOutput?: unknown },
+    initialContext?: {
+      transcriptText?: string;
+      intermediateOutput?: unknown;
+      orchestrator?: OrchestratorBackend;
+    },
   ) {
     this.workflowManager = workflowManager;
 
@@ -66,12 +73,15 @@ export class McpWorkflowAdapter {
    * created a backlog item (#833).
    */
   public fail(finalResult: unknown, finalOutput: string | undefined, errorMessage: string) {
+    // Snapshot the streamed steps + orchestrator badge BEFORE failStage() clobbers the payload:
     // failStage records the error + telemetry but REPLACES the stage payload with just { error }.
+    const existing = this.getPayload();
     this.workflowManager.failStage(WorkflowProgressStage.EXECUTING_TASK, errorMessage);
-    // Re-attach the drafted result afterwards (keeping the failed status and the error) so the
-    // user can still see what the model produced.
+    // Re-attach the snapshotted result afterwards (keeping the failed status and the error) so the
+    // user can still see the streamed steps, the orchestrator badge, and what the model produced.
     const payload = {
-      ...this.getPayload(),
+      ...existing,
+      error: errorMessage,
       mcpResult: typeof finalResult === "string" ? finalResult : JSON.stringify(finalResult),
       finalOutput,
     };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from "./args";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
 import { buildRequest, type CommandRequest, ID_PLACEHOLDER, UsageError } from "./commands";
+import { runMcpServe } from "./mcp-serve";
 import { resolveServerIdByName } from "./resolve-name";
 
 const HELP = `yakshaver — configure YakShaver Desktop from the terminal
@@ -23,6 +24,10 @@ MCP
   remove/enable/update also accept --name <name> instead of a positional <id>
   (resolved against the server list; errors if the name is missing or ambiguous).
 
+MCP FRONT-DOOR (internal — used by the Claude Code orchestrator)
+  yakshaver mcp-serve                       # run the stdio MCP server that proxies
+                                            # the app's aggregated toolset to Claude
+
 CONFIG
   yakshaver config get [llm|orchestrator|settings]   # defaults to settings
   yakshaver config set settings --tool-approval-mode <yolo|wait|ask>
@@ -42,6 +47,14 @@ async function main(argv: string[]): Promise<number> {
   if (parsed.options.help || parsed.positionals.length === 0) {
     console.log(HELP);
     return parsed.positionals.length === 0 && !parsed.options.help ? 1 : 0;
+  }
+
+  // `mcp-serve` is special: it RUNS the stdio MCP front-door (proxying to the
+  // bridge) rather than issuing a single bridge request. The Claude orchestrator
+  // spawns this as its one MCP server.
+  if (parsed.positionals[0] === "mcp-serve") {
+    await runMcpServe({ dev: parsed.options.dev === true });
+    return typeof process.exitCode === "number" ? process.exitCode : 0;
   }
 
   let request: CommandRequest;

--- a/src/cli/mcp-serve.test.ts
+++ b/src/cli/mcp-serve.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BridgeToolSummary, ToolCallResult } from "../shared/cli-bridge/protocol";
+import { callToolViaBridge, listToolsViaBridge } from "./mcp-serve";
+
+describe("mcp-serve front-door — tools/list proxy", () => {
+  it("maps GET /tools summaries to MCP tool descriptors", async () => {
+    const summaries: BridgeToolSummary[] = [
+      {
+        name: "GitHub__create_issue",
+        description: "Create a GitHub issue",
+        inputSchema: { type: "object", properties: { title: { type: "string" } } },
+      },
+      {
+        name: "Internal__fill_template",
+        description: "internal",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+    const get = vi.fn().mockResolvedValue(summaries);
+
+    const result = await listToolsViaBridge({ get });
+
+    expect(get).toHaveBeenCalledWith("/tools");
+    expect(result.tools.map((t) => t.name)).toEqual([
+      "GitHub__create_issue",
+      "Internal__fill_template",
+    ]);
+    expect(result.tools[0].inputSchema).toMatchObject({ type: "object" });
+  });
+
+  it("normalizes a non-object inputSchema to a permissive object schema", async () => {
+    const get = vi.fn().mockResolvedValue([
+      {
+        name: "Weird__tool",
+        inputSchema: { type: "string" } as unknown as Record<string, unknown>,
+      },
+    ]);
+    const result = await listToolsViaBridge({ get });
+    expect(result.tools[0].inputSchema).toEqual({ type: "object", properties: {} });
+  });
+});
+
+describe("mcp-serve front-door — tools/call proxy", () => {
+  it("forwards name + arguments to POST /tools/call and returns the result as text content", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, result: "Created #5" } as ToolCallResult);
+
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", { title: "Bug" });
+
+    expect(post).toHaveBeenCalledWith("/tools/call", {
+      name: "GitHub__create_issue",
+      arguments: { title: "Bug" },
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toEqual([{ type: "text", text: "Created #5" }]);
+  });
+
+  it("stringifies a non-string tool result", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, result: { id: 5 } } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "X__y", {});
+    expect(result.content[0].text).toBe(JSON.stringify({ id: 5 }));
+  });
+
+  it("defaults missing arguments to {}", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, result: "ok" } as ToolCallResult);
+    await callToolViaBridge({ post }, "X__y", undefined);
+    expect(post).toHaveBeenCalledWith("/tools/call", { name: "X__y", arguments: {} });
+  });
+
+  it("surfaces a structured not-approved result as an MCP isError tool result", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValue({ ok: false, notApproved: true, error: "not approved" } as ToolCallResult);
+
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Tool not approved: not approved/);
+  });
+
+  it("surfaces an execution failure as an MCP isError tool result", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: false, error: "boom" } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Tool failed: boom/);
+  });
+});

--- a/src/cli/mcp-serve.test.ts
+++ b/src/cli/mcp-serve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { BridgeToolSummary, ToolCallResult } from "../shared/cli-bridge/protocol";
+import { BridgeUnavailableError } from "./bridge-client";
 import { callToolViaBridge, listToolsViaBridge } from "./mcp-serve";
 
 /** Read the `text` off the first content item (MCP content is a typed union). */
@@ -43,6 +44,22 @@ describe("mcp-serve front-door — tools/list proxy", () => {
     ]);
     const result = await listToolsViaBridge({ get });
     expect(result.tools[0].inputSchema).toEqual({ type: "object", properties: {} });
+  });
+
+  it("collapses a mid-run bridge UNAVAILABILITY to an empty toolset (not a protocol error)", async () => {
+    // The app quit/restarted after the front-door was up: the GET throws
+    // BridgeUnavailableError. Discovery must not abort the session — it degrades
+    // to [] like the bridge router's own never-throw-on-empty contract.
+    const get = vi.fn().mockRejectedValue(new BridgeUnavailableError("app not running"));
+    const result = await listToolsViaBridge({ get });
+    expect(result.tools).toEqual([]);
+  });
+
+  it("propagates a non-availability failure (e.g. 401/malformed) rather than masking it as []", async () => {
+    // A stale-token 401 or malformed response is a persistent misconfiguration, not
+    // a transient dropout — silently returning [] would hide it, so it must surface.
+    const get = vi.fn().mockRejectedValue(new Error("unauthorized"));
+    await expect(listToolsViaBridge({ get })).rejects.toThrow(/unauthorized/i);
   });
 });
 
@@ -114,5 +131,19 @@ describe("mcp-serve front-door — tools/call proxy", () => {
     const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
     expect(result.isError).toBe(true);
     expect(firstText(result.content)).toMatch(/Tool failed: boom/);
+  });
+
+  it("maps a mid-run bridge transport throw to an isError tool result (not a protocol error)", async () => {
+    // The bridge became unreachable mid-shave (app quit/socket drop): post() throws.
+    // Per MCP, that must reach Claude as a recoverable isError result so it can
+    // self-correct — never escape as a JSON-RPC protocol error.
+    const post = vi
+      .fn()
+      .mockRejectedValue(new Error("YakShaver Desktop doesn't appear to be running"));
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(true);
+    expect(firstText(result.content)).toMatch(
+      /Tool failed: YakShaver Desktop doesn't appear to be running/,
+    );
   });
 });

--- a/src/cli/mcp-serve.test.ts
+++ b/src/cli/mcp-serve.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import type { BridgeToolSummary, ToolCallResult } from "../shared/cli-bridge/protocol";
 import { callToolViaBridge, listToolsViaBridge } from "./mcp-serve";
 
+/** Read the `text` off the first content item (MCP content is a typed union). */
+function firstText(content: Array<{ type: string }>): string | undefined {
+  const item = content[0] as { text?: string };
+  return item.text;
+}
+
 describe("mcp-serve front-door — tools/list proxy", () => {
   it("maps GET /tools summaries to MCP tool descriptors", async () => {
     const summaries: BridgeToolSummary[] = [
@@ -57,7 +63,33 @@ describe("mcp-serve front-door — tools/call proxy", () => {
   it("stringifies a non-string tool result", async () => {
     const post = vi.fn().mockResolvedValue({ ok: true, result: { id: 5 } } as ToolCallResult);
     const result = await callToolViaBridge({ post }, "X__y", {});
-    expect(result.content[0].text).toBe(JSON.stringify({ id: 5 }));
+    expect(firstText(result.content)).toBe(JSON.stringify({ id: 5 }));
+  });
+
+  it("relays a native MCP CallToolResult's content verbatim (no double-stringify)", async () => {
+    const post = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { content: [{ type: "text", text: "Created #5" }] },
+    } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "Created #5" }]);
+  });
+
+  it("surfaces an MCP-level isError (auth-denied/rate-limit) as isError, NOT a successful call", async () => {
+    // A failed MCP tool resolves WITHOUT throwing, returning { isError: true, content }.
+    // The bridge envelope is still ok:true (transport succeeded), so this case is the
+    // one that previously leaked an underlying failure to Claude as success.
+    const post = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        isError: true,
+        content: [{ type: "text", text: "401 Unauthorized: token expired" }],
+      },
+    } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: "401 Unauthorized: token expired" }]);
   });
 
   it("defaults missing arguments to {}", async () => {
@@ -74,13 +106,13 @@ describe("mcp-serve front-door — tools/call proxy", () => {
     const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/Tool not approved: not approved/);
+    expect(firstText(result.content)).toMatch(/Tool not approved: not approved/);
   });
 
   it("surfaces an execution failure as an MCP isError tool result", async () => {
     const post = vi.fn().mockResolvedValue({ ok: false, error: "boom" } as ToolCallResult);
     const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/Tool failed: boom/);
+    expect(firstText(result.content)).toMatch(/Tool failed: boom/);
   });
 });

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -1,0 +1,158 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { BridgeToolSummary, ToolCallResult } from "../shared/cli-bridge/protocol";
+import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
+
+/**
+ * The single `yakshaver` MCP front-door (#915).
+ *
+ * Runs a stdio MCP SERVER that the Claude Code orchestrator spawns (via a
+ * one-entry `--mcp-config`). It owns NO tools itself — every `tools/list` and
+ * `tools/call` is proxied to the running desktop app over the localhost CLI
+ * bridge:
+ *
+ *   tools/list → GET  /tools        (the app's full aggregated, server-prefixed
+ *                                    toolset, INCLUDING internal/in-memory
+ *                                    servers Claude Code can't reach directly)
+ *   tools/call → POST /tools/call   (executes through the app's approval policy)
+ *
+ * To Claude the tools appear as `mcp__yakshaver__<Server__tool>`. The bridge
+ * token+port are resolved from the same token file the rest of the CLI uses
+ * (or env vars the orchestrator injects).
+ */
+
+/** Env var overrides the orchestrator may inject so we skip the token-file read. */
+const BRIDGE_PORT_ENV = "YAKSHAVER_BRIDGE_PORT";
+const BRIDGE_TOKEN_ENV = "YAKSHAVER_BRIDGE_TOKEN";
+
+export interface McpServeOptions {
+  dev?: boolean;
+  /** Injectable for testing. Defaults to a real {@link BridgeClient}. */
+  client?: Pick<BridgeClient, "get" | "post">;
+}
+
+/**
+ * Build the MCP `Server` instance, registering the list/call handlers that proxy
+ * to the bridge. Exposed (separately from the transport) so tests can drive the
+ * handlers directly without a real stdio pipe.
+ */
+export function createMcpServer(options: McpServeOptions = {}): Server {
+  const client = options.client ?? buildClient(options.dev);
+
+  const server = new Server(
+    { name: "yakshaver", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, () => listToolsViaBridge(client));
+  server.setRequestHandler(CallToolRequestSchema, (request) =>
+    callToolViaBridge(client, request.params.name, request.params.arguments),
+  );
+
+  return server;
+}
+
+/** Proxy `tools/list` to `GET /tools`, mapping summaries to MCP tool descriptors. */
+export async function listToolsViaBridge(
+  client: Pick<BridgeClient, "get">,
+): Promise<{ tools: Array<{ name: string; description?: string; inputSchema: object }> }> {
+  const tools = await client.get<BridgeToolSummary[]>("/tools");
+  return {
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: normalizeInputSchema(t.inputSchema),
+    })),
+  };
+}
+
+/**
+ * Proxy `tools/call` to `POST /tools/call`. A non-`ok` bridge result (incl. a
+ * structured "not approved") becomes an MCP `isError` tool result so the model
+ * sees the refusal rather than treating it as silent success.
+ */
+export async function callToolViaBridge(
+  client: Pick<BridgeClient, "post">,
+  name: string,
+  args: Record<string, unknown> | undefined,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  const result = await client.post<ToolCallResult>("/tools/call", {
+    name,
+    arguments: args ?? {},
+  });
+
+  if (!result.ok) {
+    const prefix = result.notApproved ? "Tool not approved: " : "Tool failed: ";
+    return {
+      isError: true,
+      content: [{ type: "text", text: `${prefix}${result.error ?? "unknown error"}` }],
+    };
+  }
+
+  return { content: [toTextContent(result.result)] };
+}
+
+/** Start the front-door over stdio. Resolves when the transport closes. */
+export async function runMcpServe(options: McpServeOptions = {}): Promise<void> {
+  let server: Server;
+  try {
+    server = createMcpServer(options);
+  } catch (err) {
+    // A misconfigured/absent bridge must produce a CLEAR error, not a silent hang.
+    fail(err);
+    return;
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // The process now lives until stdin closes; the SDK manages the lifecycle.
+}
+
+/** Construct a BridgeClient, honouring orchestrator-injected env overrides. */
+function buildClient(dev?: boolean): BridgeClient {
+  const port = process.env[BRIDGE_PORT_ENV];
+  const token = process.env[BRIDGE_TOKEN_ENV];
+  if (port && token) {
+    const parsedPort = Number(port);
+    if (Number.isFinite(parsedPort) && parsedPort > 0) {
+      return new BridgeClient({
+        dev,
+        tokenLoader: async () => ({
+          port: parsedPort,
+          token,
+          startedAt: new Date().toISOString(),
+        }),
+      });
+    }
+  }
+  return new BridgeClient({ dev });
+}
+
+/** MCP requires `inputSchema` to be an object schema; default to a permissive one. */
+function normalizeInputSchema(
+  schema: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (schema && typeof schema === "object" && schema.type === "object") {
+    return schema;
+  }
+  return { type: "object", properties: {} };
+}
+
+/** Wrap a tool result as MCP text content (stringifying non-strings). */
+function toTextContent(result: unknown): { type: "text"; text: string } {
+  if (typeof result === "string") {
+    return { type: "text", text: result };
+  }
+  return { type: "text", text: JSON.stringify(result ?? null) };
+}
+
+/** Print a clear, actionable error to stderr and set a non-zero exit code. */
+function fail(err: unknown): void {
+  const message =
+    err instanceof BridgeUnavailableError
+      ? err.message
+      : `Failed to start the yakshaver MCP front-door: ${err instanceof Error ? err.message : String(err)}`;
+  console.error(message);
+  process.exitCode = 1;
+}

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -1,6 +1,10 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { BridgeToolSummary, ToolCallResult } from "../shared/cli-bridge/protocol";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
 
@@ -67,16 +71,26 @@ export async function listToolsViaBridge(
   };
 }
 
+/** The MCP tool-result shape this front-door returns over stdio. */
+type McpToolResult = Pick<CallToolResult, "content" | "isError">;
+
 /**
  * Proxy `tools/call` to `POST /tools/call`. A non-`ok` bridge result (incl. a
  * structured "not approved") becomes an MCP `isError` tool result so the model
  * sees the refusal rather than treating it as silent success.
+ *
+ * A bridge-level success (`ok:true`) may still carry an MCP `CallToolResult` whose
+ * own `isError` is true (auth-denied, rate-limit, validation — these resolve
+ * WITHOUT throwing). We pass that shape through verbatim, preserving both the
+ * original `content` AND the `isError` flag, so an underlying tool FAILURE is
+ * never surfaced to Claude as a successful call. (The in-process orchestrator
+ * does the same — see mcp-orchestrator.ts: `ok: !toolErrored`.)
  */
 export async function callToolViaBridge(
   client: Pick<BridgeClient, "post">,
   name: string,
   args: Record<string, unknown> | undefined,
-): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+): Promise<McpToolResult> {
   const result = await client.post<ToolCallResult>("/tools/call", {
     name,
     arguments: args ?? {},
@@ -90,7 +104,31 @@ export async function callToolViaBridge(
     };
   }
 
+  // If the tool returned a native MCP CallToolResult, relay its content + isError
+  // unchanged rather than stringifying it as a single text blob. This is what
+  // preserves a tool-level failure (isError:true) instead of masking it as success.
+  const passthrough = asMcpResult(result.result);
+  if (passthrough) {
+    return passthrough;
+  }
+
   return { content: [toTextContent(result.result)] };
+}
+
+/**
+ * Narrow an arbitrary `execute()` return value to an MCP `CallToolResult` shape
+ * (`{ content: [...], isError? }`). Returns null when it isn't one, so the caller
+ * falls back to stringifying. Only a `content` ARRAY qualifies — that is the MCP
+ * contract — and `isError` is normalized to a boolean (defaulting to false).
+ */
+function asMcpResult(value: unknown): McpToolResult | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as { content?: unknown; isError?: unknown };
+  if (!Array.isArray(obj.content)) return null;
+  return {
+    content: obj.content as CallToolResult["content"],
+    isError: obj.isError === true,
+  };
 }
 
 /** Start the front-door over stdio. Resolves when the transport closes. */

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -5,7 +5,12 @@ import {
   type CallToolResult,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { BridgeToolSummary, ToolCallResult } from "../shared/cli-bridge/protocol";
+import {
+  type BridgeToolSummary,
+  CLI_BRIDGE_PORT_ENV,
+  CLI_BRIDGE_TOKEN_ENV,
+  type ToolCallResult,
+} from "../shared/cli-bridge/protocol";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
 
 /**
@@ -25,10 +30,6 @@ import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
  * token+port are resolved from the same token file the rest of the CLI uses
  * (or env vars the orchestrator injects).
  */
-
-/** Env var overrides the orchestrator may inject so we skip the token-file read. */
-const BRIDGE_PORT_ENV = "YAKSHAVER_BRIDGE_PORT";
-const BRIDGE_TOKEN_ENV = "YAKSHAVER_BRIDGE_TOKEN";
 
 export interface McpServeOptions {
   dev?: boolean;
@@ -57,11 +58,33 @@ export function createMcpServer(options: McpServeOptions = {}): Server {
   return server;
 }
 
-/** Proxy `tools/list` to `GET /tools`, mapping summaries to MCP tool descriptors. */
+/**
+ * Proxy `tools/list` to `GET /tools`, mapping summaries to MCP tool descriptors.
+ *
+ * If the app/bridge becomes UNREACHABLE after the front-door is up (the user
+ * quits/restarts the app, a socket drops mid-shave — surfaced as a
+ * {@link BridgeUnavailableError}), discovery must not abort the whole session
+ * with a JSON-RPC protocol error: it collapses to an empty toolset, mirroring
+ * the bridge router's own never-throw-on-empty contract server-side
+ * (`McpToolBridge.collectToolsOrEmpty`).
+ *
+ * A NON-availability failure (e.g. an authenticated-boundary 401 from a stale
+ * token, or a malformed response) is a persistent misconfiguration, not a
+ * transient dropout — silently returning `[]` would hide it forever, so we let
+ * it propagate.
+ */
 export async function listToolsViaBridge(
   client: Pick<BridgeClient, "get">,
 ): Promise<{ tools: Array<{ name: string; description?: string; inputSchema: object }> }> {
-  const tools = await client.get<BridgeToolSummary[]>("/tools");
+  let tools: BridgeToolSummary[];
+  try {
+    tools = await client.get<BridgeToolSummary[]>("/tools");
+  } catch (err) {
+    if (err instanceof BridgeUnavailableError) {
+      return { tools: [] };
+    }
+    throw err;
+  }
   return {
     tools: tools.map((t) => ({
       name: t.name,
@@ -85,16 +108,32 @@ type McpToolResult = Pick<CallToolResult, "content" | "isError">;
  * original `content` AND the `isError` flag, so an underlying tool FAILURE is
  * never surfaced to Claude as a successful call. (The in-process orchestrator
  * does the same — see mcp-orchestrator.ts: `ok: !toolErrored`.)
+ *
+ * A TRANSPORT failure (the bridge client throws — app quit/restart, socket drop,
+ * non-JSON body mid-shave) is caught and mapped to the SAME `isError` tool-result
+ * shape as the `ok:false` execution-failure path. Per the MCP spec a tool-call
+ * failure must reach the model as `isError:true` so it can see it and self-correct;
+ * a thrown error would instead escape as a JSON-RPC protocol error that aborts the
+ * request unrecoverably.
  */
 export async function callToolViaBridge(
   client: Pick<BridgeClient, "post">,
   name: string,
   args: Record<string, unknown> | undefined,
 ): Promise<McpToolResult> {
-  const result = await client.post<ToolCallResult>("/tools/call", {
-    name,
-    arguments: args ?? {},
-  });
+  let result: ToolCallResult;
+  try {
+    result = await client.post<ToolCallResult>("/tools/call", {
+      name,
+      arguments: args ?? {},
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      isError: true,
+      content: [{ type: "text", text: `Tool failed: ${message}` }],
+    };
+  }
 
   if (!result.ok) {
     const prefix = result.notApproved ? "Tool not approved: " : "Tool failed: ";
@@ -149,8 +188,8 @@ export async function runMcpServe(options: McpServeOptions = {}): Promise<void> 
 
 /** Construct a BridgeClient, honouring orchestrator-injected env overrides. */
 function buildClient(dev?: boolean): BridgeClient {
-  const port = process.env[BRIDGE_PORT_ENV];
-  const token = process.env[BRIDGE_TOKEN_ENV];
+  const port = process.env[CLI_BRIDGE_PORT_ENV];
+  const token = process.env[CLI_BRIDGE_TOKEN_ENV];
   if (port && token) {
     const parsedPort = Number(port);
     if (Number.isFinite(parsedPort) && parsedPort > 0) {

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -149,19 +149,27 @@ export type ToolCallInput = z.infer<typeof ToolCallInputSchema>;
 /**
  * Result envelope from `POST /tools/call`.
  *
+ * A discriminated union on `ok` (matching the house pattern of {@link BridgeResponse}
+ * above) so success and failure each carry ONLY their relevant fields — illegal
+ * states (e.g. `error` on a success, `result` on a failure) are unrepresentable.
+ *
  * `ok:false` with `notApproved:true` is a STRUCTURED refusal (the tool was not
  * whitelisted under the current approval mode) — NOT a transport error, and the
  * caller must surface it to the model rather than retrying or hanging.
  */
-export interface ToolCallResult {
-  ok: boolean;
-  /** Present on success — the tool's raw execute() return value. */
-  result?: unknown;
-  /** Present on failure — a human-readable reason. */
-  error?: string;
-  /** True when the failure is an approval-policy refusal, not an execution error. */
-  notApproved?: boolean;
-}
+export type ToolCallResult =
+  | {
+      ok: true;
+      /** The tool's raw execute() return value. */
+      result?: unknown;
+    }
+  | {
+      ok: false;
+      /** A human-readable reason for the failure. */
+      error: string;
+      /** True when the failure is an approval-policy refusal, not an execution error. */
+      notApproved?: boolean;
+    };
 
 /** Orchestration backends the CLI may set. Mirrors `OrchestrationBackend`. */
 export const OrchestrationBackendSchema = z.enum(["openai", "local-claude"]);

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -122,6 +122,47 @@ export const McpEnabledInputSchema = z.object({
   enabled: z.boolean(),
 });
 
+// ---------------------------------------------------------------------------
+// Aggregated tool endpoints (#915). The bridge exposes the app's full,
+// server-prefixed toolset (INCLUDING internal/in-memory servers) so the single
+// `yakshaver` MCP front-door can list + proxy them to the Claude orchestrator.
+// ---------------------------------------------------------------------------
+
+/** One aggregated tool as listed by `GET /tools`. */
+export interface BridgeToolSummary {
+  /** Server-prefixed name, e.g. `GitHub__create_issue`. */
+  name: string;
+  description?: string;
+  /** JSON Schema (draft-07-ish) describing the tool's input arguments. */
+  inputSchema: Record<string, unknown>;
+}
+
+/** Body accepted by `POST /tools/call`. */
+export const ToolCallInputSchema = z.object({
+  /** Server-prefixed tool name as returned by `GET /tools`. */
+  name: z.string().min(1, "tool name is required"),
+  /** Arguments object passed to the tool's execute(). Defaults to `{}`. */
+  arguments: z.record(z.string(), z.unknown()).optional(),
+});
+export type ToolCallInput = z.infer<typeof ToolCallInputSchema>;
+
+/**
+ * Result envelope from `POST /tools/call`.
+ *
+ * `ok:false` with `notApproved:true` is a STRUCTURED refusal (the tool was not
+ * whitelisted under the current approval mode) — NOT a transport error, and the
+ * caller must surface it to the model rather than retrying or hanging.
+ */
+export interface ToolCallResult {
+  ok: boolean;
+  /** Present on success — the tool's raw execute() return value. */
+  result?: unknown;
+  /** Present on failure — a human-readable reason. */
+  error?: string;
+  /** True when the failure is an approval-policy refusal, not an execution error. */
+  notApproved?: boolean;
+}
+
 /** Orchestration backends the CLI may set. Mirrors `OrchestrationBackend`. */
 export const OrchestrationBackendSchema = z.enum(["openai", "local-claude"]);
 

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -23,6 +23,17 @@ export const CLI_BRIDGE_DEFAULT_PORT = 8765;
 /** Env var that, when truthy, disables the bridge entirely. */
 export const CLI_BRIDGE_DISABLE_ENV = "YAKSHAVER_DISABLE_CLI_BRIDGE";
 
+/**
+ * Env vars the desktop orchestrator injects into the spawned `yakshaver
+ * mcp-serve` front-door so it connects to the live bridge deterministically
+ * (without racing the token file). The orchestrator (producer) WRITES these and
+ * the front-door's `buildClient` (consumer) READS them — they are a cross-module
+ * contract, so they live here as the single source of truth. A rename here is a
+ * compile-checked change on both sides; raw string literals were not.
+ */
+export const CLI_BRIDGE_PORT_ENV = "YAKSHAVER_BRIDGE_PORT";
+export const CLI_BRIDGE_TOKEN_ENV = "YAKSHAVER_BRIDGE_TOKEN";
+
 /** Placeholder shown instead of any secret value. */
 export const REDACTED = "***redacted***";
 

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -32,6 +32,25 @@ export type OrchestrationBackend = "openai" | "local-claude";
 
 export const DEFAULT_ORCHESTRATION_BACKEND: OrchestrationBackend = "openai";
 
+/**
+ * Readiness of the local Claude Code (`local-claude`) orchestration backend, surfaced to the
+ * settings UI so the user learns BEFORE a run that Claude Code can't be driven.
+ *
+ * - `not-installed`     — the `claude` CLI isn't on PATH.
+ * - `not-authenticated` — the CLI is installed but no credentials were detected.
+ * - `ready`             — installed and (best-effort) authenticated.
+ */
+export type OrchestratorReadinessState = "ready" | "not-installed" | "not-authenticated";
+
+export interface OrchestratorReadiness {
+  installed: boolean;
+  authenticated: boolean;
+  ready: boolean;
+  state: OrchestratorReadinessState;
+  /** Short, user-facing guidance. Empty when ready. */
+  message: string;
+}
+
 export type LLMConfigV1 = ModelConfig & {
   version?: 1;
 };

--- a/src/shared/types/workflow-payloads.ts
+++ b/src/shared/types/workflow-payloads.ts
@@ -6,7 +6,14 @@ export interface VideoProcessingPayload {
   steps?: MCPStep[];
 }
 
+/** Which backend drives the Executing Task stage. Stamped at stage start so the UI can badge it. */
+export type OrchestratorBackend = "openai" | "claude-code";
+
 export interface ExecutingTaskPayload extends VideoProcessingPayload {
   mcpResult?: string;
   finalOutput?: string;
+  /** The orchestrator that drove this stage. `claude-code` = local `claude -p`; `openai` = in-process loop. */
+  orchestrator?: OrchestratorBackend;
+  /** Populated when the stage failed (e.g. the loop never created a backlog item, #833). */
+  error?: string;
 }

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -1,9 +1,17 @@
-import type { LLMConfigV2, OrchestrationBackend } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestrationBackend, OrchestratorReadiness } from "@shared/types/llm";
 import { DEFAULT_ORCHESTRATION_BACKEND } from "@shared/types/llm";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { ipcClient } from "@/services/ipc-client";
 import { formatErrorMessage } from "@/utils";
 
@@ -25,7 +33,7 @@ const BACKEND_OPTIONS: readonly BackendOption[] = [
   },
   {
     id: "local-claude",
-    title: "Claude Code (local)",
+    title: "Claude Code",
     description:
       "Drive backlog creation with a local headless `claude` process. Requires the `claude` CLI installed and on PATH.",
   },
@@ -33,7 +41,7 @@ const BACKEND_OPTIONS: readonly BackendOption[] = [
 
 const BACKEND_LABELS: Record<OrchestrationBackend, string> = {
   openai: "OpenAI",
-  "local-claude": "Claude Code (local)",
+  "local-claude": "Claude Code",
 };
 
 export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSettingProps) {
@@ -42,6 +50,23 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
   );
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [pendingBackend, setPendingBackend] = useState<OrchestrationBackend | null>(null);
+  const [readiness, setReadiness] = useState<OrchestratorReadiness | null>(null);
+  const [isCheckingReadiness, setIsCheckingReadiness] = useState<boolean>(false);
+
+  // Probe whether the Claude Code backend is actually usable (CLI installed + signed in). Cheap and
+  // non-blocking; the result drives the warning + instructions below.
+  const checkReadiness = useCallback(async () => {
+    setIsCheckingReadiness(true);
+    try {
+      const result = await ipcClient.llm.checkOrchestratorReadiness();
+      setReadiness(result);
+    } catch (error) {
+      console.error("Failed to check orchestrator readiness", error);
+      setReadiness(null);
+    } finally {
+      setIsCheckingReadiness(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!isActive) {
@@ -67,10 +92,11 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
     };
 
     void load();
+    void checkReadiness();
     return () => {
       cancelled = true;
     };
-  }, [isActive]);
+  }, [isActive, checkReadiness]);
 
   const handleSelect = useCallback(
     async (backend: OrchestrationBackend) => {
@@ -95,6 +121,11 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         }
         setCurrentBackend(backend);
         toast.success(`Orchestrator set to ${BACKEND_LABELS[backend]}`);
+        // Surface readiness right after choosing Claude Code so the user learns immediately if the
+        // CLI is missing or not signed in.
+        if (backend === "local-claude") {
+          void checkReadiness();
+        }
       } catch (error) {
         console.error("Failed to update orchestrator backend", error);
         toast.error(`Failed to update orchestrator: ${formatErrorMessage(error)}`);
@@ -102,7 +133,7 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         setPendingBackend(null);
       }
     },
-    [currentBackend],
+    [currentBackend, checkReadiness],
   );
 
   return (
@@ -110,40 +141,62 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
       <CardHeader className="px-4">
         <CardTitle>Orchestrator</CardTitle>
         <CardDescription>
-          Choose which backend drives backlog creation. Claude Code (local) requires the{" "}
-          <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed.
+          Choose which backend drives backlog creation. Claude Code requires the{" "}
+          <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed, and
+          uses your Claude Code sign-in (no API key).
         </CardDescription>
       </CardHeader>
 
-      <CardContent className="px-4">
-        <div className="grid gap-2 md:grid-cols-2">
-          {BACKEND_OPTIONS.map((option) => {
-            const isSelected = option.id === currentBackend;
-            const isDisabled = isLoading || (!!pendingBackend && pendingBackend !== option.id);
+      <CardContent className="flex flex-col gap-2 px-4">
+        <Select
+          value={currentBackend}
+          onValueChange={(value) => void handleSelect(value as OrchestrationBackend)}
+          disabled={isLoading || pendingBackend !== null}
+        >
+          <SelectTrigger className="w-full md:w-72" aria-label="Orchestrator backend">
+            <SelectValue placeholder="Select an orchestrator" />
+          </SelectTrigger>
+          <SelectContent>
+            {BACKEND_OPTIONS.map((option) => (
+              <SelectItem key={option.id} value={option.id}>
+                {option.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {BACKEND_OPTIONS.find((o) => o.id === currentBackend)?.description}
+        </p>
 
-            return (
-              <button
-                key={option.id}
-                type="button"
-                onClick={() => void handleSelect(option.id)}
-                disabled={isDisabled}
-                aria-pressed={isSelected}
-                className={cn(
-                  "flex h-full flex-col gap-1.5 rounded-md border px-3 py-2 text-left transition-colors",
-                  "disabled:cursor-not-allowed disabled:opacity-60",
-                  isSelected
-                    ? "border-white/50 bg-white/10"
-                    : "border-white/10 hover:border-white/30 hover:bg-white/5",
-                )}
-              >
-                <span className="text-sm font-medium">{option.title}</span>
-                <span className="text-xs leading-relaxed text-muted-foreground">
-                  {option.description}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+        {/* Claude Code readiness: warn + instruct when the backend is selected but the local CLI
+            isn't installed or isn't signed in, so the user fixes it BEFORE a run fails. */}
+        {currentBackend === "local-claude" && readiness && !readiness.ready && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-950/40 px-3 py-2 text-xs leading-relaxed text-amber-100"
+          >
+            <AlertTriangle
+              className="mt-0.5 h-4 w-4 shrink-0 text-amber-400"
+              role="img"
+              aria-label="Claude Code not ready"
+            />
+            <div className="flex min-w-0 flex-col gap-2">
+              <span className="break-words">{readiness.message}</span>
+              <div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 border-amber-500/40 bg-transparent text-amber-100 hover:bg-amber-500/10"
+                  onClick={() => void checkReadiness()}
+                  disabled={isCheckingReadiness}
+                >
+                  {isCheckingReadiness && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
+                  Re-check
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/ui/src/components/settings/settings-health.test.ts
+++ b/src/ui/src/components/settings/settings-health.test.ts
@@ -118,6 +118,73 @@ describe("deriveSettingsHealth", () => {
     });
   });
 
+  describe("Orchestrator readiness (llm)", () => {
+    const notReady = {
+      installed: true,
+      authenticated: false,
+      ready: false,
+      state: "not-authenticated" as const,
+      message: "Claude Code is installed but not signed in.",
+    };
+
+    it("flags Claude Code as critical when selected but not ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm?.severity).toBe("critical");
+      expect(health.llm?.message).toMatch(/signed in/i);
+    });
+
+    it("does NOT flag when the backend is OpenAI, even if a stale readiness is not ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "openai" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("does NOT flag when Claude Code is ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: {
+            installed: true,
+            authenticated: true,
+            ready: true,
+            state: "ready",
+            message: "",
+          },
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("does NOT flag while readiness is still inconclusive (null)", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: null,
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("keeps the missing-model message (more fundamental) over orchestrator readiness", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { languageModel: null, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm?.message).toMatch(/api key/i);
+    });
+  });
+
   describe("Releases (release)", () => {
     it("flags a missing GitHub token as critical", () => {
       expect(deriveSettingsHealth(inputs({ hasGithubToken: false })).release?.severity).toBe(

--- a/src/ui/src/components/settings/settings-health.ts
+++ b/src/ui/src/components/settings/settings-health.ts
@@ -1,5 +1,5 @@
 import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
-import type { LLMConfigV2 } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { MCPServerConfig } from "@shared/types/mcp";
 import { useCallback, useEffect, useState } from "react";
 import { ipcClient } from "@/services/ipc-client";
@@ -35,7 +35,13 @@ export type SettingsHealthMap = Readonly<Record<string, SettingsTabHealth | unde
 
 export interface SettingsHealthInputs {
   /** The persisted LLM config (`ipcClient.llm.getConfig()`), or null if unset. */
-  llmConfig: Pick<LLMConfigV2, "languageModel"> | null;
+  llmConfig: Pick<LLMConfigV2, "languageModel" | "orchestrationBackend"> | null;
+  /**
+   * Readiness of the Claude Code orchestration backend (`ipcClient.llm.checkOrchestratorReadiness()`).
+   * Only meaningful when `orchestrationBackend === "local-claude"`; null/undefined means "not
+   * checked / inconclusive" and never raises a warning.
+   */
+  orchestratorReadiness?: OrchestratorReadiness | null;
   /** Configured MCP servers (`ipcClient.mcp.listServers()`). */
   mcpServers: ReadonlyArray<Pick<MCPServerConfig, "id" | "name" | "enabled">>;
   /** Health by server id; only an explicit `isHealthy === false` counts as down
@@ -66,6 +72,28 @@ export function deriveSettingsHealth(inputs: SettingsHealthInputs): SettingsHeal
       tabId: "llm",
       severity: "critical",
       message: "No language model API key is configured.",
+    };
+  }
+
+  // Orchestrator — when Claude Code is the chosen backend but it isn't ready (CLI missing or not
+  // signed in), the backlog-creation step will fail. Only flag on a positive not-ready result, and
+  // never override the more fundamental missing-model message on the same tab.
+  const readiness = inputs.orchestratorReadiness;
+  if (
+    !map.llm &&
+    inputs.llmConfig?.orchestrationBackend === "local-claude" &&
+    readiness &&
+    !readiness.ready
+  ) {
+    // Keep the nav-tooltip message terse (the full install/sign-in guidance lives in the inline
+    // warning on the Model Settings page); a long message overflows the small hover tooltip.
+    map.llm = {
+      tabId: "llm",
+      severity: "critical",
+      message:
+        readiness.state === "not-installed"
+          ? "Claude Code CLI not found."
+          : "Claude Code isn't signed in.",
     };
   }
 
@@ -113,6 +141,13 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
         ipcClient.githubToken.has().catch(() => true),
       ]);
 
+      // Only probe Claude Code readiness when it's the selected backend — otherwise it's irrelevant
+      // and we skip the spawn entirely.
+      const orchestratorReadiness =
+        llmConfig?.orchestrationBackend === "local-claude"
+          ? await ipcClient.llm.checkOrchestratorReadiness().catch(() => null)
+          : null;
+
       // Only probe health for the enabled backlog providers we might flag.
       const backlog = mcpServers.filter(isEnabledBacklogProvider);
       const mcpHealthById: Record<string, HealthStatusInfo | undefined> = {};
@@ -128,7 +163,15 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
         }),
       );
 
-      setHealth(deriveSettingsHealth({ llmConfig, mcpServers, mcpHealthById, hasGithubToken }));
+      setHealth(
+        deriveSettingsHealth({
+          llmConfig,
+          mcpServers,
+          mcpHealthById,
+          hasGithubToken,
+          orchestratorReadiness,
+        }),
+      );
     } catch {
       // Couldn't read config — say nothing rather than show a misleading indicator.
       setHealth({});

--- a/src/ui/src/components/workflow/WorkflowStepCard.tsx
+++ b/src/ui/src/components/workflow/WorkflowStepCard.tsx
@@ -1,14 +1,62 @@
 import type { WorkflowState, WorkflowStep } from "@shared/types/workflow";
-import { CheckCircle2, ChevronDown, ChevronRight, Loader2, RefreshCw, XCircle } from "lucide-react";
+import type { OrchestratorBackend } from "@shared/types/workflow-payloads";
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  RefreshCw,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { formatErrorMessage } from "@/utils";
 import { ipcClient } from "../../services/ipc-client";
 import type { MCPStep } from "../../types";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
 import { isErrorStep, StageWithContent } from "./StageWithContent";
+
+/**
+ * Reads the active orchestrator that drove the Executing Task stage from its parsed payload.
+ * Stamped backend-side at stage start (see ExecutingTaskPayload.orchestrator).
+ */
+function getOrchestratorBackend(stage: string, parsed: unknown): OrchestratorBackend | null {
+  if (stage !== "executing_task" || !isRecord(parsed)) return null;
+  const backend = parsed.orchestrator;
+  return backend === "claude-code" || backend === "openai" ? backend : null;
+}
+
+/**
+ * A distinct pill marking the Executing Task stage as driven by the local Claude Code orchestrator,
+ * so the user clearly sees it even when Claude's live reasoning is terse.
+ */
+function OrchestratorBadge({ backend }: { backend: OrchestratorBackend }) {
+  if (backend === "claude-code") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-amber-400/40 bg-amber-400/10 text-amber-300"
+        title="Orchestrated by the Claude Code CLI on this machine — uses your Claude Code sign-in, no API key"
+      >
+        <Sparkles className="size-3" />
+        Claude Code
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="border-white/15 bg-white/5 text-white/50"
+      title="OpenAI orchestrator"
+    >
+      OpenAI
+    </Badge>
+  );
+}
 
 const STATUS_CONFIG = {
   in_progress: {
@@ -120,6 +168,8 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
     }
   }, [step.payload, step.stage]);
 
+  const orchestratorBackend = getOrchestratorBackend(step.stage, parsedPayload);
+
   const effectiveStatus: WorkflowStep["status"] =
     hasStepErrors && step.status === "completed" ? "failed" : step.status;
 
@@ -174,6 +224,7 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
             <div className="flex items-center gap-3 flex-1">
               <StatusIcon status={effectiveStatus} />
               <span className={cn("font-medium", config.textClass)}>{label}</span>
+              {orchestratorBackend && <OrchestratorBadge backend={orchestratorBackend} />}
             </div>
             <div className="text-white/50 hover:text-white/90">
               {isExpanded ? (
@@ -187,6 +238,7 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
           <div className="flex items-center gap-3 flex-1">
             <StatusIcon status={effectiveStatus} />
             <span className={cn("font-medium", config.textClass)}>{label}</span>
+            {orchestratorBackend && <OrchestratorBadge backend={orchestratorBackend} />}
           </div>
         )}
         {step.status === "failed" && shaveId && (

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -1,4 +1,4 @@
-import type { LLMConfigV2 } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { TelemetrySettings } from "@shared/types/telemetry";
 import type { UserSettings } from "@shared/types/user-settings";
 import type { WorkflowState } from "@shared/types/workflow";
@@ -67,6 +67,7 @@ declare global {
         getConfig: () => Promise<LLMConfigV2 | null>;
         clearConfig: () => Promise<{ success: boolean }>;
         checkHealth: () => Promise<HealthStatusInfo>;
+        checkOrchestratorReadiness: () => Promise<OrchestratorReadiness>;
       };
       auth: {
         microsoft: {


### PR DESCRIPTION
Closes #915.

## Stacking / merge order
This PR **stacks on #908 + #910 + #914** and is based on `feat/913-cli-orchestrator-setting` (which already contains them) for a clean diff. Merge order:

1. #908 — Claude Code (local) orchestration
2. #910 — yakshaver CLI + localhost config bridge
3. #914 — CLI orchestrator setting (→ `feat/913-cli-orchestrator-setting`)
4. **this PR (#915)** → base `feat/913-cli-orchestrator-setting`

## What & why
The #908 orchestrator serialized **each** enabled MCP server into Claude's `--mcp-config` and injected per-server OAuth tokens — and **skipped internal/in-memory servers entirely** (Claude Code can't reach them over its own transports). This PR replaces that with **one** local MCP front-door (`yakshaver`) that proxies the app's **full aggregated toolset — including the internal servers** — over the existing localhost bridge. That's the key win.

## What changed

### Bridge (extends #910 — same `127.0.0.1` + bearer-token auth)
- `GET /tools` → aggregated, server-prefixed tool list `[{name, description, inputSchema}]` across **all** enabled servers **including internal/in-memory** ones, via `MCPServerManager.collectToolsWithServerPrefixAsync()`. AI-SDK `inputSchema` is resolved to plain JSON Schema. Only names/descriptions/schemas — nothing structural redacted.
- `POST /tools/call` → body `{name, arguments}` (Zod-validated); executes via the ToolSet's `execute()`, applying the app's approval policy **server-side**: `yolo` → run; `ask`/`wait` → run only if whitelisted, else a **structured** `{ok:false, notApproved:true, error}` (never hangs on an interactive prompt). Returns `{ok, result}` / `{ok:false, error}`.
- New `McpToolBridge` (`src/backend/services/mcp/mcp-tool-bridge.ts`) owns flattening + policy; `bridge-router` routes `/tools` + `/tools/call`; `cli-bridge-server` wires the live service; `CliBridgeServer.getToken()` added so the orchestrator can hand the front-door a deterministic token.

### CLI: `yakshaver mcp-serve`
- New subcommand (`src/cli/mcp-serve.ts`) that runs a **stdio MCP server** (`@modelcontextprotocol/sdk` `Server` + `StdioServerTransport`). `tools/list` → `GET /tools`; `tools/call` → `POST /tools/call`. Reads the bridge port+token from the env the orchestrator injects (`YAKSHAVER_BRIDGE_PORT` / `_TOKEN`), falling back to the CLI's existing token-file resolver. A non-`ok` bridge result (incl. "not approved") surfaces as an MCP `isError` tool result. Clear error when the bridge isn't reachable.

### Orchestrator rewire (#908)
- `LocalClaudeOrchestrator` now writes a **single** `--mcp-config` entry:

  ```json
  {
    "mcpServers": {
      "yakshaver": {
        "type": "stdio",
        "command": "<node / electron-as-node>",
        "args": ["<appPath>/dist/cli/index.js", "mcp-serve"],
        "env": {
          "ELECTRON_RUN_AS_NODE": "1",
          "YAKSHAVER_BRIDGE_PORT": "<bridge port>",
          "YAKSHAVER_BRIDGE_TOKEN": "<bridge token>"
        }
      }
    }
  }
  ```

- Tools appear to Claude as `mcp__yakshaver__<Server__tool>`. `--allowedTools` (ask/wait) = the app whitelist re-prefixed to `mcp__yakshaver__…`. Keeps **`--strict-mcp-config`**. Per-server serialization + token injection removed. Progress mapping + `judgeBacklogOutcome` unchanged.

## Tests
All I/O mocked. New/updated suites green (115 tests across the affected files):
- `mcp-tool-bridge.test.ts` — internal-server inclusion in the list; approval enforcement (yolo runs; ask/wait refuse non-whitelisted with a structured result; execute() throw captured).
- `bridge-router.test.ts` — `GET /tools`, `POST /tools/call` proxy + Zod validation + structured-refusal envelope.
- `mcp-serve.test.ts` — tools/list + tools/call proxy mapping, incl. not-approved → MCP `isError`.
- `local-claude-orchestrator.test.ts` — single-entry mcp-config, re-prefixed allowed-tools, `--strict-mcp-config` argv.

Build (`npm run build`, tsc → `dist/cli` + `dist/backend`) green; biome clean on changed files. Pre-existing native-binding suites (better-sqlite3 / ffmpeg) fail only because this isolated worktree installed deps with `--ignore-scripts` (no `electron-rebuild`) — unrelated to this change.

## Deferred — Phase 4.1 (approval-UI routing)
For v1, an `ask`/`wait` call on a non-whitelisted tool returns a structured "not approved" result rather than routing to the in-app approval UI. Wiring that refusal back to the live approval prompt (so a human can approve mid-run) is Phase 4.1.

## PENDING — live e2e (flagged, not yet run)
1. Run the app; ensure the CLI is built (`npm run build` → `dist/cli/index.js`).
2. Set Orchestrator = Claude Code (#914 setting / `yakshaver config set orchestrator --backend local-claude`).
3. Run a shave and confirm Claude **lists + calls** tools through the single `yakshaver` MCP server — **including an internal tool** (the #915 win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)