### PR TITLE
S⚠️ ◾ feat: Claude Code orchestrator readiness — warning + instructions when not installed/signed in

### DIFF
--- a/src/backend/ipc/channels.ts
+++ b/src/backend/ipc/channels.ts
@@ -41,6 +41,7 @@ export const IPC_CHANNELS = {
   LLM_GET_CONFIG: "llm:get-config",
   LLM_CLEAR_CONFIG: "llm:clear-config",
   LLM_CHECK_HEALTH: "llm:check-health",
+  LLM_CHECK_ORCHESTRATOR_READINESS: "llm:check-orchestrator-readiness",
 
   // MCP
   MCP_PROCESS_MESSAGE: "mcp:process-message",

--- a/src/backend/ipc/llm-settings-handlers.ts
+++ b/src/backend/ipc/llm-settings-handlers.ts
@@ -1,5 +1,6 @@
 import type { LLMConfigV2 } from "@shared/types/llm";
 import { type IpcMainInvokeEvent, ipcMain } from "electron";
+import { checkClaudeReadiness } from "../services/mcp/claude-readiness";
 import { LanguageModelProvider } from "../services/mcp/language-model-provider";
 import { LlmStorage } from "../services/storage/llm-storage";
 import { IPC_CHANNELS } from "./channels";
@@ -34,6 +35,12 @@ export class LLMSettingsIPCHandlers {
     ipcMain.handle(IPC_CHANNELS.LLM_CHECK_HEALTH, async () => {
       const provider = await LanguageModelProvider.getInstance();
       return await provider.checkHealth();
+    });
+
+    // Readiness of the Claude Code (local-claude) orchestration backend — installed + (best-effort)
+    // authenticated — so the UI can warn BEFORE a run that Claude Code can't be driven.
+    ipcMain.handle(IPC_CHANNELS.LLM_CHECK_ORCHESTRATOR_READINESS, async () => {
+      return await checkClaudeReadiness();
     });
   }
 }

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -60,6 +60,7 @@ const IPC_CHANNELS = {
   LLM_GET_CONFIG: "llm:get-config",
   LLM_CLEAR_CONFIG: "llm:clear-config",
   LLM_CHECK_HEALTH: "llm:check-health",
+  LLM_CHECK_ORCHESTRATOR_READINESS: "llm:check-orchestrator-readiness",
 
   // MCP
   MCP_PROCESS_MESSAGE: "mcp:process-message",
@@ -249,6 +250,8 @@ const electronAPI = {
     getConfig: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_GET_CONFIG),
     clearConfig: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_CLEAR_CONFIG),
     checkHealth: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_CHECK_HEALTH),
+    checkOrchestratorReadiness: () =>
+      ipcRenderer.invoke(IPC_CHANNELS.LLM_CHECK_ORCHESTRATOR_READINESS),
   },
   mcp: {
     processMessage: (

--- a/src/backend/services/mcp/claude-readiness.test.ts
+++ b/src/backend/services/mcp/claude-readiness.test.ts
@@ -1,0 +1,128 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClaudeReadinessDeps,
+  checkClaudeReadiness,
+  detectClaudeAuth,
+  resolveCredentialsPath,
+} from "./claude-readiness";
+
+/** A spawner whose `claude --version` child closes with the given exit code (or emits an error). */
+function makeSpawner(opts: {
+  versionExitCode?: number;
+  spawnError?: boolean;
+  emitError?: boolean;
+}) {
+  const spawn = vi.fn((_cmd: string, _args: string[]) => {
+    if (opts.spawnError) throw new Error("spawn failed");
+    const child = new EventEmitter() as unknown as ChildProcess;
+    setImmediate(() => {
+      if (opts.emitError) child.emit("error", new Error("ENOENT"));
+      else child.emit("close", opts.versionExitCode ?? 0);
+    });
+    return child;
+  });
+  return { spawn };
+}
+
+function makeDeps(overrides: Partial<ClaudeReadinessDeps> = {}): ClaudeReadinessDeps {
+  return {
+    spawner: makeSpawner({ versionExitCode: 0 }),
+    env: {},
+    fileExists: () => false,
+    homeDir: () => "/home/test",
+    claudeCommand: "claude",
+    ...overrides,
+  };
+}
+
+describe("resolveCredentialsPath", () => {
+  it("uses CLAUDE_CONFIG_DIR when set", () => {
+    expect(resolveCredentialsPath({ CLAUDE_CONFIG_DIR: "/custom/dir" }, () => "/home/test")).toBe(
+      join("/custom/dir", ".credentials.json"),
+    );
+  });
+
+  it("falls back to <home>/.claude when CLAUDE_CONFIG_DIR is unset/blank", () => {
+    expect(resolveCredentialsPath({ CLAUDE_CONFIG_DIR: "  " }, () => "/home/test")).toBe(
+      join("/home/test", ".claude", ".credentials.json"),
+    );
+  });
+});
+
+describe("detectClaudeAuth", () => {
+  it("is true when an auth env var is set", () => {
+    const deps = makeDeps();
+    expect(detectClaudeAuth({ ANTHROPIC_API_KEY: "sk-123" }, deps)).toBe(true);
+    expect(detectClaudeAuth({ CLAUDE_CODE_OAUTH_TOKEN: "tok" }, deps)).toBe(true);
+  });
+
+  it("ignores blank/whitespace env values", () => {
+    expect(detectClaudeAuth({ ANTHROPIC_API_KEY: "   " }, makeDeps())).toBe(false);
+  });
+
+  it("is true when the credentials file exists", () => {
+    const credsPath = join("/home/test", ".claude", ".credentials.json");
+    const deps = makeDeps({ fileExists: (p) => p === credsPath });
+    expect(detectClaudeAuth({}, deps)).toBe(true);
+  });
+
+  it("is false with no env and no credentials file", () => {
+    expect(detectClaudeAuth({}, makeDeps())).toBe(false);
+  });
+});
+
+describe("checkClaudeReadiness", () => {
+  it("reports not-installed when `claude --version` exits non-zero", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 127 }) }),
+    );
+    expect(r).toMatchObject({ installed: false, ready: false, state: "not-installed" });
+    expect(r.message).toMatch(/not found on PATH/i);
+  });
+
+  it("reports not-installed when spawning errors (ENOENT)", async () => {
+    const r = await checkClaudeReadiness(makeDeps({ spawner: makeSpawner({ emitError: true }) }));
+    expect(r.state).toBe("not-installed");
+  });
+
+  it("reports not-installed when spawn throws synchronously", async () => {
+    const r = await checkClaudeReadiness(makeDeps({ spawner: makeSpawner({ spawnError: true }) }));
+    expect(r.state).toBe("not-installed");
+  });
+
+  it("reports not-authenticated when installed but no credentials", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 0 }) }),
+    );
+    expect(r).toMatchObject({ installed: true, authenticated: false, ready: false });
+    expect(r.state).toBe("not-authenticated");
+    expect(r.message).toMatch(/not signed in/i);
+  });
+
+  it("reports ready when installed and an auth env var is present", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 0 }), env: { ANTHROPIC_API_KEY: "sk" } }),
+    );
+    expect(r).toEqual({
+      installed: true,
+      authenticated: true,
+      ready: true,
+      state: "ready",
+      message: "",
+    });
+  });
+
+  it("reports ready when installed and a credentials file exists", async () => {
+    const credsPath = join("/home/test", ".claude", ".credentials.json");
+    const r = await checkClaudeReadiness(
+      makeDeps({
+        spawner: makeSpawner({ versionExitCode: 0 }),
+        fileExists: (p) => p === credsPath,
+      }),
+    );
+    expect(r.ready).toBe(true);
+  });
+});

--- a/src/backend/services/mcp/claude-readiness.ts
+++ b/src/backend/services/mcp/claude-readiness.ts
@@ -1,0 +1,123 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { OrchestratorReadiness } from "../../../shared/types/llm";
+import type { IClaudeProcessSpawner } from "./local-claude-orchestrator";
+
+export type { OrchestratorReadiness } from "../../../shared/types/llm";
+
+/** Dependencies, injected so the unit tests stay pure (no real `claude`, no real FS/env). */
+export interface ClaudeReadinessDeps {
+  spawner: IClaudeProcessSpawner;
+  /** Process environment to inspect for auth env vars. */
+  env: NodeJS.ProcessEnv;
+  /** Existence check for the credentials file (injectable for tests). */
+  fileExists: (path: string) => boolean;
+  /** Resolver for the user's home directory (injectable for tests). */
+  homeDir: () => string;
+  /** Command used to invoke the CLI. */
+  claudeCommand: string;
+}
+
+const INSTALL_MESSAGE =
+  "Claude Code CLI not found on PATH. Install it (npm i -g @anthropic-ai/claude-code), or switch the Orchestrator to OpenAI.";
+
+const SIGN_IN_MESSAGE =
+  "Claude Code is installed but not signed in. Run `claude` in a terminal and complete the login, then re-check — or switch the Orchestrator to OpenAI.";
+
+/**
+ * Auth env vars that let `claude -p` run without an interactive login. Mirrors Claude Code's
+ * documented credential-precedence chain (cloud providers, bearer/API tokens, long-lived OAuth).
+ */
+const AUTH_ENV_VARS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "CLAUDE_CODE_USE_FOUNDRY",
+] as const;
+
+export const defaultClaudeReadinessDeps: Omit<ClaudeReadinessDeps, "claudeCommand"> = {
+  spawner: { spawn: (command, args) => spawn(command, args) },
+  env: process.env,
+  fileExists: (path) => existsSync(path),
+  homeDir: () => homedir(),
+};
+
+/**
+ * Resolve the path to Claude Code's credentials file, honouring `CLAUDE_CONFIG_DIR`
+ * and otherwise falling back to `<home>/.claude/.credentials.json`.
+ */
+export function resolveCredentialsPath(env: NodeJS.ProcessEnv, homeDir: () => string): string {
+  const baseDir = env.CLAUDE_CONFIG_DIR?.trim() || join(homeDir(), ".claude");
+  return join(baseDir, ".credentials.json");
+}
+
+/**
+ * Best-effort, NON-BILLING authentication signal: an auth env var is set, OR a credentials file
+ * exists at the resolved config dir.
+ *
+ * Known limitation: a macOS login that stores its token ONLY in the Keychain leaves no
+ * credentials file, so this can report `false` for an actually-signed-in mac user. That is a
+ * false "not ready" warning, never a false "ready" — and the run-time error path (which surfaces
+ * Claude's own auth error) remains the authoritative check. A Keychain probe / `claude -p` probe
+ * can be layered on later without changing this contract.
+ */
+export function detectClaudeAuth(env: NodeJS.ProcessEnv, deps: ClaudeReadinessDeps): boolean {
+  const hasAuthEnv = AUTH_ENV_VARS.some((name) => {
+    const value = env[name];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+  if (hasAuthEnv) return true;
+
+  return deps.fileExists(resolveCredentialsPath(env, deps.homeDir));
+}
+
+/** Spawn `claude --version` and resolve true iff it exits 0. Never rejects. */
+function detectClaudeInstalled(deps: ClaudeReadinessDeps): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = deps.spawner.spawn(deps.claudeCommand, ["--version"]);
+    } catch {
+      resolve(false);
+      return;
+    }
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}
+
+/**
+ * Compute the readiness of the Claude Code orchestration backend: is the CLI installed, and
+ * does it appear authenticated? Pure given its injected deps; never throws.
+ */
+export async function checkClaudeReadiness(
+  deps: ClaudeReadinessDeps = { ...defaultClaudeReadinessDeps, claudeCommand: "claude" },
+): Promise<OrchestratorReadiness> {
+  const installed = await detectClaudeInstalled(deps);
+  if (!installed) {
+    return {
+      installed: false,
+      authenticated: false,
+      ready: false,
+      state: "not-installed",
+      message: INSTALL_MESSAGE,
+    };
+  }
+
+  const authenticated = detectClaudeAuth(deps.env, deps);
+  if (!authenticated) {
+    return {
+      installed: true,
+      authenticated: false,
+      ready: false,
+      state: "not-authenticated",
+      message: SIGN_IN_MESSAGE,
+    };
+  }
+
+  return { installed: true, authenticated: true, ready: true, state: "ready", message: "" };
+}

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -356,9 +356,14 @@ Embed this URL in the task content that you create. Follow user requirements STR
         if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
 
         if (code !== 0 && terminationReason === "unknown") {
+          // A non-zero exit with no result event is most commonly an auth failure (the headless
+          // `claude -p` can't prompt for login, so it exits with an auth error on stderr). Append
+          // actionable guidance so the user isn't left with a bare exit code.
+          const guidance =
+            " Claude Code may not be signed in — run `claude` in a terminal to log in, or switch the Orchestrator to OpenAI in Settings.";
           reject(
             new Error(
-              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}`,
+              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}${guidance}`,
             ),
           );
           return;

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -32,6 +32,25 @@ export type OrchestrationBackend = "openai" | "local-claude";
 
 export const DEFAULT_ORCHESTRATION_BACKEND: OrchestrationBackend = "openai";
 
+/**
+ * Readiness of the local Claude Code (`local-claude`) orchestration backend, surfaced to the
+ * settings UI so the user learns BEFORE a run that Claude Code can't be driven.
+ *
+ * - `not-installed`     — the `claude` CLI isn't on PATH.
+ * - `not-authenticated` — the CLI is installed but no credentials were detected.
+ * - `ready`             — installed and (best-effort) authenticated.
+ */
+export type OrchestratorReadinessState = "ready" | "not-installed" | "not-authenticated";
+
+export interface OrchestratorReadiness {
+  installed: boolean;
+  authenticated: boolean;
+  ready: boolean;
+  state: OrchestratorReadinessState;
+  /** Short, user-facing guidance. Empty when ready. */
+  message: string;
+}
+
 export type LLMConfigV1 = ModelConfig & {
   version?: 1;
 };

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -180,8 +180,8 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
               role="img"
               aria-label="Claude Code not ready"
             />
-            <div className="flex flex-col gap-2">
-              <span>{readiness.message}</span>
+            <div className="flex min-w-0 flex-col gap-2">
+              <span className="break-words">{readiness.message}</span>
               <div>
                 <Button
                   variant="outline"

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -1,7 +1,9 @@
-import type { LLMConfigV2, OrchestrationBackend } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestrationBackend, OrchestratorReadiness } from "@shared/types/llm";
 import { DEFAULT_ORCHESTRATION_BACKEND } from "@shared/types/llm";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
@@ -48,6 +50,23 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
   );
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [pendingBackend, setPendingBackend] = useState<OrchestrationBackend | null>(null);
+  const [readiness, setReadiness] = useState<OrchestratorReadiness | null>(null);
+  const [isCheckingReadiness, setIsCheckingReadiness] = useState<boolean>(false);
+
+  // Probe whether the Claude Code backend is actually usable (CLI installed + signed in). Cheap and
+  // non-blocking; the result drives the warning + instructions below.
+  const checkReadiness = useCallback(async () => {
+    setIsCheckingReadiness(true);
+    try {
+      const result = await ipcClient.llm.checkOrchestratorReadiness();
+      setReadiness(result);
+    } catch (error) {
+      console.error("Failed to check orchestrator readiness", error);
+      setReadiness(null);
+    } finally {
+      setIsCheckingReadiness(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!isActive) {
@@ -73,10 +92,11 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
     };
 
     void load();
+    void checkReadiness();
     return () => {
       cancelled = true;
     };
-  }, [isActive]);
+  }, [isActive, checkReadiness]);
 
   const handleSelect = useCallback(
     async (backend: OrchestrationBackend) => {
@@ -101,6 +121,11 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         }
         setCurrentBackend(backend);
         toast.success(`Orchestrator set to ${BACKEND_LABELS[backend]}`);
+        // Surface readiness right after choosing Claude Code so the user learns immediately if the
+        // CLI is missing or not signed in.
+        if (backend === "local-claude") {
+          void checkReadiness();
+        }
       } catch (error) {
         console.error("Failed to update orchestrator backend", error);
         toast.error(`Failed to update orchestrator: ${formatErrorMessage(error)}`);
@@ -108,7 +133,7 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         setPendingBackend(null);
       }
     },
-    [currentBackend],
+    [currentBackend, checkReadiness],
   );
 
   return (
@@ -142,6 +167,36 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         <p className="text-xs leading-relaxed text-muted-foreground">
           {BACKEND_OPTIONS.find((o) => o.id === currentBackend)?.description}
         </p>
+
+        {/* Claude Code readiness: warn + instruct when the backend is selected but the local CLI
+            isn't installed or isn't signed in, so the user fixes it BEFORE a run fails. */}
+        {currentBackend === "local-claude" && readiness && !readiness.ready && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-950/40 px-3 py-2 text-xs leading-relaxed text-amber-100"
+          >
+            <AlertTriangle
+              className="mt-0.5 h-4 w-4 shrink-0 text-amber-400"
+              role="img"
+              aria-label="Claude Code not ready"
+            />
+            <div className="flex flex-col gap-2">
+              <span>{readiness.message}</span>
+              <div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 border-amber-500/40 bg-transparent text-amber-100 hover:bg-amber-500/10"
+                  onClick={() => void checkReadiness()}
+                  disabled={isCheckingReadiness}
+                >
+                  {isCheckingReadiness && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
+                  Re-check
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/ui/src/components/settings/settings-health.test.ts
+++ b/src/ui/src/components/settings/settings-health.test.ts
@@ -118,6 +118,73 @@ describe("deriveSettingsHealth", () => {
     });
   });
 
+  describe("Orchestrator readiness (llm)", () => {
+    const notReady = {
+      installed: true,
+      authenticated: false,
+      ready: false,
+      state: "not-authenticated" as const,
+      message: "Claude Code is installed but not signed in.",
+    };
+
+    it("flags Claude Code as critical when selected but not ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm?.severity).toBe("critical");
+      expect(health.llm?.message).toMatch(/signed in/i);
+    });
+
+    it("does NOT flag when the backend is OpenAI, even if a stale readiness is not ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "openai" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("does NOT flag when Claude Code is ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: {
+            installed: true,
+            authenticated: true,
+            ready: true,
+            state: "ready",
+            message: "",
+          },
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("does NOT flag while readiness is still inconclusive (null)", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: null,
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("keeps the missing-model message (more fundamental) over orchestrator readiness", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { languageModel: null, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm?.message).toMatch(/api key/i);
+    });
+  });
+
   describe("Releases (release)", () => {
     it("flags a missing GitHub token as critical", () => {
       expect(deriveSettingsHealth(inputs({ hasGithubToken: false })).release?.severity).toBe(

--- a/src/ui/src/components/settings/settings-health.ts
+++ b/src/ui/src/components/settings/settings-health.ts
@@ -85,10 +85,15 @@ export function deriveSettingsHealth(inputs: SettingsHealthInputs): SettingsHeal
     readiness &&
     !readiness.ready
   ) {
+    // Keep the nav-tooltip message terse (the full install/sign-in guidance lives in the inline
+    // warning on the Model Settings page); a long message overflows the small hover tooltip.
     map.llm = {
       tabId: "llm",
       severity: "critical",
-      message: readiness.message || "Claude Code orchestration isn't ready.",
+      message:
+        readiness.state === "not-installed"
+          ? "Claude Code CLI not found."
+          : "Claude Code isn't signed in.",
     };
   }
 

--- a/src/ui/src/components/settings/settings-health.ts
+++ b/src/ui/src/components/settings/settings-health.ts
@@ -1,5 +1,5 @@
 import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
-import type { LLMConfigV2 } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { MCPServerConfig } from "@shared/types/mcp";
 import { useCallback, useEffect, useState } from "react";
 import { ipcClient } from "@/services/ipc-client";
@@ -35,7 +35,13 @@ export type SettingsHealthMap = Readonly<Record<string, SettingsTabHealth | unde
 
 export interface SettingsHealthInputs {
   /** The persisted LLM config (`ipcClient.llm.getConfig()`), or null if unset. */
-  llmConfig: Pick<LLMConfigV2, "languageModel"> | null;
+  llmConfig: Pick<LLMConfigV2, "languageModel" | "orchestrationBackend"> | null;
+  /**
+   * Readiness of the Claude Code orchestration backend (`ipcClient.llm.checkOrchestratorReadiness()`).
+   * Only meaningful when `orchestrationBackend === "local-claude"`; null/undefined means "not
+   * checked / inconclusive" and never raises a warning.
+   */
+  orchestratorReadiness?: OrchestratorReadiness | null;
   /** Configured MCP servers (`ipcClient.mcp.listServers()`). */
   mcpServers: ReadonlyArray<Pick<MCPServerConfig, "id" | "name" | "enabled">>;
   /** Health by server id; only an explicit `isHealthy === false` counts as down
@@ -66,6 +72,23 @@ export function deriveSettingsHealth(inputs: SettingsHealthInputs): SettingsHeal
       tabId: "llm",
       severity: "critical",
       message: "No language model API key is configured.",
+    };
+  }
+
+  // Orchestrator — when Claude Code is the chosen backend but it isn't ready (CLI missing or not
+  // signed in), the backlog-creation step will fail. Only flag on a positive not-ready result, and
+  // never override the more fundamental missing-model message on the same tab.
+  const readiness = inputs.orchestratorReadiness;
+  if (
+    !map.llm &&
+    inputs.llmConfig?.orchestrationBackend === "local-claude" &&
+    readiness &&
+    !readiness.ready
+  ) {
+    map.llm = {
+      tabId: "llm",
+      severity: "critical",
+      message: readiness.message || "Claude Code orchestration isn't ready.",
     };
   }
 
@@ -113,6 +136,13 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
         ipcClient.githubToken.has().catch(() => true),
       ]);
 
+      // Only probe Claude Code readiness when it's the selected backend — otherwise it's irrelevant
+      // and we skip the spawn entirely.
+      const orchestratorReadiness =
+        llmConfig?.orchestrationBackend === "local-claude"
+          ? await ipcClient.llm.checkOrchestratorReadiness().catch(() => null)
+          : null;
+
       // Only probe health for the enabled backlog providers we might flag.
       const backlog = mcpServers.filter(isEnabledBacklogProvider);
       const mcpHealthById: Record<string, HealthStatusInfo | undefined> = {};
@@ -128,7 +158,15 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
         }),
       );
 
-      setHealth(deriveSettingsHealth({ llmConfig, mcpServers, mcpHealthById, hasGithubToken }));
+      setHealth(
+        deriveSettingsHealth({
+          llmConfig,
+          mcpServers,
+          mcpHealthById,
+          hasGithubToken,
+          orchestratorReadiness,
+        }),
+      );
     } catch {
       // Couldn't read config — say nothing rather than show a misleading indicator.
       setHealth({});

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -1,4 +1,4 @@
-import type { LLMConfigV2 } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { TelemetrySettings } from "@shared/types/telemetry";
 import type { UserSettings } from "@shared/types/user-settings";
 import type { WorkflowState } from "@shared/types/workflow";
@@ -67,6 +67,7 @@ declare global {
         getConfig: () => Promise<LLMConfigV2 | null>;
         clearConfig: () => Promise<{ success: boolean }>;
         checkHealth: () => Promise<HealthStatusInfo>;
+        checkOrchestratorReadiness: () => Promise<OrchestratorReadiness>;
       };
       auth: {
         microsoft: {


### PR DESCRIPTION
## What & why

When the Orchestrator is set to **Claude Code** (`local-claude`), the app only checked that the `claude` CLI was on PATH (`claude --version`) before a run. That passes even when the CLI is **not signed in**, so the user hit a generic mid-processing failure (`Claude Code process exited with code N. Error: <raw stderr>`) instead of being told up front.

This PR makes readiness visible and actionable.

## Changes

- **Backend readiness check** — new `checkClaudeReadiness()` (`claude-readiness.ts`): `installed` via `claude --version`, `authenticated` via auth env vars (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` / cloud-provider flags) or a credentials file under `CLAUDE_CONFIG_DIR`/`~/.claude`. Non-billing, never throws, fully injected for tests.
- **IPC** — shared `OrchestratorReadiness` type, `llm:check-orchestrator-readiness` channel + handler + preload + renderer wiring.
- **Settings → LLM** — when Claude Code is selected but not ready, an amber warning with the specific reason (install vs sign-in) + a **Re-check** button.
- **Settings nav** — the LLM tab shows the existing `#878` warning triangle when Claude Code is selected but not ready (without overriding the more fundamental "no language model API key" message).
- **Run-time backstop** — the failure message now appends actionable guidance ("Claude Code may not be signed in — run `claude` … or switch to OpenAI").

## Known limitation

Auth detection is best-effort and non-billing: a macOS login that stores its token **only** in the Keychain leaves no credentials file, so this can show a false "not signed in" warning there. It is never a false "ready", and the run-time error remains authoritative. A Keychain/`claude -p` probe can be layered on later without changing the contract.

## Tests

- `claude-readiness.test.ts` — installed / not-installed (exit, ENOENT, throw) / authenticated (env, creds file) / not-authenticated; `resolveCredentialsPath` honours `CLAUDE_CONFIG_DIR`.
- `settings-health.test.ts` — flags Claude-Code-not-ready, ignores it for OpenAI, ignores when ready/inconclusive, and keeps the missing-model message precedence.
- Existing `local-claude-orchestrator` tests still pass (28 backend / 18 settings-health).

## Stacking

Builds on **#917** (base branch `feat/917-claude-orchestration-indicator`). Review after the rest of the stack (#908 → #914 → #916 → #917).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
