### PR TITLE
S✔ ◾ feat(cli): yakshaver orchestrator + mcp update CLI (rebased #913)

### DIFF
--- a/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
+++ b/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
@@ -153,4 +153,37 @@ describe("bridge -> real MCPServerManager transport switch", () => {
     expect(persisted.command).toBeUndefined();
     expect(persisted.args).toBeUndefined();
   });
+
+  it("preserves common fields (enabled/toolWhitelist) on a transport switch when the incoming config omits them", async () => {
+    // Mirrors the Settings UI, whose McpServerForm submits a config WITHOUT
+    // `enabled`/`toolWhitelist`. A transport switch must keep those from existing,
+    // not reset a disabled server to enabled or drop its whitelist.
+    store = [
+      {
+        id: "srv-4",
+        name: "Test HTTP",
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+        enabled: false,
+        toolWhitelist: ["search"],
+      },
+    ];
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    await manager.updateServerAsync("srv-4", {
+      id: "srv-4",
+      name: "Test HTTP",
+      transport: "stdio",
+      command: "node",
+    } as MCPServerConfig);
+
+    const persisted = store.find((s) => s.id === "srv-4") as unknown as Record<string, unknown>;
+    expect(persisted.transport).toBe("stdio");
+    expect(persisted.command).toBe("node");
+    // Old transport's field stripped...
+    expect(persisted.url).toBeUndefined();
+    // ...but common fields preserved from existing.
+    expect(persisted.enabled).toBe(false);
+    expect(persisted.toolWhitelist).toEqual(["search"]);
+  });
 });

--- a/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
+++ b/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPServerConfig } from "../mcp/types";
+
+/**
+ * Drives the bridge's `mergeMcpPatch` through the REAL
+ * `MCPServerManager.updateServerAsync` (McpStorage mocked to an in-memory store)
+ * to guard the invariant: after a transport switch, no stale field of the old
+ * transport (a secret-bearing `headers`/`url`, or `command`/`args`/`env`)
+ * survives in the PERSISTED config. A mocked manager would miss its second merge.
+ */
+
+// In-memory backing store the mocked McpStorage reads/writes.
+let store: MCPServerConfig[] = [];
+
+vi.mock("../storage/mcp-storage", () => ({
+  McpStorage: {
+    getInstance: () => ({
+      getMcpServerConfigsAsync: async () => store.map((s) => ({ ...s })),
+      storeMcpServers: async (servers: MCPServerConfig[]) => {
+        store = servers.map((s) => ({ ...s }));
+      },
+    }),
+  },
+}));
+
+// Avoid pulling preset servers into the merge for this focused test.
+vi.mock("../../../shared/mcp/preset-servers", () => ({
+  PRESET_MCP_SERVERS: [],
+}));
+
+import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { routeRequest } from "./bridge-router";
+
+function makeServices() {
+  return {
+    mcp: {
+      listAvailableServers: async () => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.listAvailableServers();
+      },
+      addServerAsync: async (config: MCPServerConfig) => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.addServerAsync(config);
+      },
+      updateServerAsync: async (serverId: string, config: MCPServerConfig) => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.updateServerAsync(serverId, config);
+      },
+      removeServerAsync: async (serverId: string) => {
+        const m = await MCPServerManager.getInstanceAsync();
+        return m.removeServerAsync(serverId);
+      },
+      getServerByIdAsync: async (serverId: string) =>
+        MCPServerManager.getServerConfigByIdAsync(serverId),
+    },
+    llm: {
+      getLLMConfig: async () => null,
+      storeLLMConfig: async () => {},
+    },
+    settings: {
+      getSettingsAsync: async () => ({}) as never,
+      updateSettingsAsync: async () => {},
+    },
+  };
+}
+
+describe("bridge -> real MCPServerManager transport switch", () => {
+  beforeEach(() => {
+    store = [];
+  });
+
+  it("HTTP->stdio strips stale url/headers in the PERSISTED config (real manager merge)", async () => {
+    store = [
+      {
+        id: "srv-1",
+        name: "Test HTTP",
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+        headers: { Authorization: "Bearer super-secret" },
+        enabled: true,
+      },
+    ];
+
+    const res = await routeRequest(makeServices(), {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { transport: "stdio", command: "node" },
+    });
+    expect(res.status).toBe(200);
+
+    const persisted = store.find((s) => s.id === "srv-1") as unknown as Record<string, unknown>;
+    expect(persisted.transport).toBe("stdio");
+    expect(persisted.command).toBe("node");
+    // The real second merge must NOT re-introduce the stale HTTP fields.
+    expect(persisted.url).toBeUndefined();
+    expect(persisted.headers).toBeUndefined();
+    expect(JSON.stringify(persisted)).not.toContain("super-secret");
+  });
+
+  it("stdio->HTTP strips stale command/args/env in the PERSISTED config", async () => {
+    store = [
+      {
+        id: "srv-2",
+        name: "Test stdio",
+        transport: "stdio",
+        command: "node",
+        args: ["server.js"],
+        env: { TOKEN: "secret-token" },
+        enabled: true,
+      },
+    ];
+
+    const res = await routeRequest(makeServices(), {
+      method: "PUT",
+      path: "/mcp/servers/srv-2",
+      body: { transport: "streamableHttp", url: "https://new.example.com/mcp" },
+    });
+    expect(res.status).toBe(200);
+
+    const persisted = store.find((s) => s.id === "srv-2") as unknown as Record<string, unknown>;
+    expect(persisted.transport).toBe("streamableHttp");
+    expect(persisted.url).toBe("https://new.example.com/mcp");
+    expect(persisted.command).toBeUndefined();
+    expect(persisted.args).toBeUndefined();
+    expect(persisted.env).toBeUndefined();
+    expect(JSON.stringify(persisted)).not.toContain("secret-token");
+  });
+
+  it("strips a wrong-transport field even when the transport is NOT changed", async () => {
+    // Existing HTTP server; the patch keeps it HTTP but slips in a stdio-only
+    // `command`. The normalized config must not persist that foreign field.
+    store = [
+      {
+        id: "srv-3",
+        name: "Test HTTP",
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+        enabled: true,
+      },
+    ];
+
+    const res = await routeRequest(makeServices(), {
+      method: "PUT",
+      path: "/mcp/servers/srv-3",
+      body: { command: "node", args: ["evil.js"] },
+    });
+    expect(res.status).toBe(200);
+
+    const persisted = store.find((s) => s.id === "srv-3") as unknown as Record<string, unknown>;
+    expect(persisted.transport).toBe("streamableHttp");
+    expect(persisted.url).toBe("https://example.com/mcp");
+    // The stdio-only fields must NOT have leaked onto the HTTP config.
+    expect(persisted.command).toBeUndefined();
+    expect(persisted.args).toBeUndefined();
+  });
+});

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -315,6 +315,20 @@ describe("routeRequest - LLM", () => {
     if (!res.body.ok) throw new Error("expected ok");
     expect((res.body.data as { orchestrationBackend: string }).orchestrationBackend).toBe("openai");
   });
+
+  it("GET /llm/config returns the default backend on a fresh install (null config)", async () => {
+    const services = makeServices({
+      llm: {
+        getLLMConfig: vi.fn().mockResolvedValue(null),
+        storeLLMConfig: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(services, { method: "GET", path: "/llm/config" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    // Must surface a concrete value, never null, even when no config exists yet.
+    expect(res.body.data).toEqual({ orchestrationBackend: "openai" });
+  });
 });
 
 describe("routeRequest - LLM orchestrator", () => {

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -119,6 +119,51 @@ describe("routeRequest - MCP", () => {
     );
   });
 
+  it("PUT /mcp/servers/:id merges ONLY provided fields onto existing", async () => {
+    // Patch only the url; the existing name + headers must be preserved.
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { url: "https://patched.example.com/mcp" },
+    });
+    expect(res.status).toBe(200);
+    expect(services.mcp.updateServerAsync).toHaveBeenCalledWith(
+      "srv-1",
+      expect.objectContaining({
+        id: "srv-1",
+        name: "Test HTTP", // preserved from existing
+        transport: "streamableHttp", // preserved
+        url: "https://patched.example.com/mcp", // updated
+      }),
+    );
+  });
+
+  it("PUT /mcp/servers/:id 404s when the server does not exist", async () => {
+    const svc = makeServices({
+      mcp: {
+        ...makeServices().mcp,
+        getServerByIdAsync: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(svc, {
+      method: "PUT",
+      path: "/mcp/servers/nope",
+      body: { name: "X" },
+    });
+    expect(res.status).toBe(404);
+    expect(svc.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
+  it("PUT /mcp/servers/:id rejects unknown fields via the patch schema", async () => {
+    const res = await routeRequest(services, {
+      method: "PUT",
+      path: "/mcp/servers/srv-1",
+      body: { bogus: "field" },
+    });
+    expect(res.status).toBe(400);
+    expect(services.mcp.updateServerAsync).not.toHaveBeenCalled();
+  });
+
   it("DELETE /mcp/servers/:id removes the server", async () => {
     const res = await routeRequest(services, { method: "DELETE", path: "/mcp/servers/srv-1" });
     expect(res.status).toBe(200);
@@ -261,6 +306,101 @@ describe("routeRequest - LLM", () => {
     });
     expect(res.status).toBe(400);
     expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("GET /llm/config defaults orchestrationBackend to 'openai' when unset", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, { method: "GET", path: "/llm/config" });
+    expect(res.status).toBe(200);
+    if (!res.body.ok) throw new Error("expected ok");
+    expect((res.body.data as { orchestrationBackend: string }).orchestrationBackend).toBe("openai");
+  });
+});
+
+describe("routeRequest - LLM orchestrator", () => {
+  it("POST /llm/config/orchestrator sets the backend, preserving models + keys", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: { orchestrationBackend: "local-claude" },
+    });
+    expect(res.status).toBe(200);
+    // Persisted config merges the backend onto the existing config (keys intact).
+    expect(services.llm.storeLLMConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 2,
+        orchestrationBackend: "local-claude",
+        languageModel: expect.objectContaining({ provider: "openai" }),
+        providerApiKeys: { openai: "sk-secret-123" },
+      }),
+    );
+    // The response never echoes the raw key.
+    if (!res.body.ok) throw new Error("expected ok");
+    expect(JSON.stringify(res.body.data)).not.toContain("sk-secret-123");
+  });
+
+  it("POST /llm/config/orchestrator creates a minimal v2 config when none exists", async () => {
+    const services = makeServices({
+      llm: {
+        getLLMConfig: vi
+          .fn()
+          // first call: none; second call (after store): the stored value
+          .mockResolvedValueOnce(null)
+          .mockResolvedValue({
+            version: 2,
+            languageModel: null,
+            transcriptionModel: null,
+            orchestrationBackend: "openai",
+          }),
+        storeLLMConfig: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: { orchestrationBackend: "openai" },
+    });
+    expect(res.status).toBe(200);
+    expect(services.llm.storeLLMConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 2,
+        languageModel: null,
+        transcriptionModel: null,
+        orchestrationBackend: "openai",
+      }),
+    );
+  });
+
+  it("POST /llm/config/orchestrator rejects an invalid backend via zod", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: { orchestrationBackend: "gpt5" },
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("POST /llm/config/orchestrator rejects a missing backend", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "POST",
+      path: "/llm/config/orchestrator",
+      body: {},
+    });
+    expect(res.status).toBe(400);
+    expect(services.llm.storeLLMConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-POST methods on /llm/config/orchestrator", async () => {
+    const services = makeServices();
+    const res = await routeRequest(services, {
+      method: "GET",
+      path: "/llm/config/orchestrator",
+    });
+    expect(res.status).toBe(405);
   });
 });
 

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,15 +1,17 @@
-import type { LLMConfigV2 } from "@shared/types/llm";
 import {
   type BridgeResponse,
   LlmConfigInputSchema,
   McpEnabledInputSchema,
   McpServerInputSchema,
+  McpServerPatchSchema,
+  OrchestratorInputSchema,
 } from "../../../shared/cli-bridge/protocol";
 import {
   redactLlmConfig,
   redactMcpServer,
   redactMcpServers,
 } from "../../../shared/cli-bridge/redact";
+import { DEFAULT_ORCHESTRATION_BACKEND, type LLMConfigV2 } from "../../../shared/types/llm";
 import type { PartialUserSettings, UserSettings } from "../../../shared/types/user-settings";
 import { PartialUserSettingsSchema } from "../../../shared/types/user-settings";
 import type { MCPServerConfig } from "../mcp/types";
@@ -80,9 +82,14 @@ export async function routeRequest(
       return await routeMcp(services, req, segments.slice(2));
     }
 
-    // /llm/config
+    // /llm/config and /llm/config/orchestrator
     if (segments[0] === "llm" && segments[1] === "config") {
-      return await routeLlm(services, req);
+      if (segments.length === 2) {
+        return await routeLlm(services, req);
+      }
+      if (segments.length === 3 && segments[2] === "orchestrator") {
+        return await routeLlmOrchestrator(services, req);
+      }
     }
 
     // /settings
@@ -144,16 +151,21 @@ async function routeMcp(
   // /mcp/servers/:id
   if (rest.length === 1) {
     if (req.method === "PUT") {
-      const parsed = McpServerInputSchema.safeParse(req.body);
+      // Merge-update: validate ONLY the provided fields (every field optional)
+      // and overlay them on the existing server. The server must already exist.
+      const parsed = McpServerPatchSchema.safeParse(req.body);
       if (!parsed.success) {
         return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
       }
       const existing = await services.mcp.getServerByIdAsync(serverId);
-      if (existing?.builtin) {
+      if (!existing) {
+        return fail(`MCP server '${serverId}' not found`, 404);
+      }
+      if (existing.builtin) {
         return fail(BUILTIN_IMMUTABLE_MESSAGE, 409);
       }
       const merged = {
-        ...(existing ?? {}),
+        ...existing,
         ...(parsed.data as object),
         id: serverId,
       } as MCPServerConfig;
@@ -177,7 +189,16 @@ async function routeMcp(
 async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {
   if (req.method === "GET") {
     const config = await services.llm.getLLMConfig();
-    return ok(redactLlmConfig(config));
+    const redacted = redactLlmConfig(config);
+    // Surface the effective orchestration backend so `config get` always shows a
+    // concrete value even when the field has never been set (defaults to openai).
+    if (redacted && typeof redacted === "object") {
+      const r = redacted as Record<string, unknown>;
+      if (r.orchestrationBackend === undefined) {
+        r.orchestrationBackend = DEFAULT_ORCHESTRATION_BACKEND;
+      }
+    }
+    return ok(redacted);
   }
   if (req.method === "POST") {
     const parsed = LlmConfigInputSchema.safeParse(req.body);
@@ -189,6 +210,40 @@ async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<B
     return ok(redactLlmConfig(stored));
   }
   return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+/**
+ * Set only the orchestration backend on the current LLMConfigV2.
+ *
+ * Merges server-side so the existing models + api keys are preserved (the CLI
+ * never sends or echoes secrets). When no config exists yet a minimal V2 config
+ * is created with the chosen backend.
+ */
+async function routeLlmOrchestrator(
+  services: BridgeServices,
+  req: BridgeRequest,
+): Promise<BridgeResult> {
+  if (req.method !== "POST") {
+    return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+  }
+  const parsed = OrchestratorInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(`Invalid orchestrator payload: ${formatZodError(parsed.error)}`);
+  }
+
+  const existing = await services.llm.getLLMConfig();
+  const merged: LLMConfigV2 = existing
+    ? { ...existing, orchestrationBackend: parsed.data.orchestrationBackend }
+    : {
+        version: 2,
+        languageModel: null,
+        transcriptionModel: null,
+        orchestrationBackend: parsed.data.orchestrationBackend,
+      };
+
+  await services.llm.storeLLMConfig(merged);
+  const stored = await services.llm.getLLMConfig();
+  return ok(redactLlmConfig(stored));
 }
 
 async function routeSettings(services: BridgeServices, req: BridgeRequest): Promise<BridgeResult> {

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -3,6 +3,7 @@ import {
   LlmConfigInputSchema,
   McpEnabledInputSchema,
   McpServerInputSchema,
+  type McpServerPatch,
   McpServerPatchSchema,
   OrchestratorInputSchema,
 } from "../../../shared/cli-bridge/protocol";
@@ -151,8 +152,8 @@ async function routeMcp(
   // /mcp/servers/:id
   if (rest.length === 1) {
     if (req.method === "PUT") {
-      // Merge-update: validate ONLY the provided fields (every field optional)
-      // and overlay them on the existing server. The server must already exist.
+      // Merge-update: validate the provided fields, then merge via mergeMcpPatch
+      // (which normalizes a transport switch). The server must already exist.
       const parsed = McpServerPatchSchema.safeParse(req.body);
       if (!parsed.success) {
         return fail(`Invalid server config: ${formatZodError(parsed.error)}`);
@@ -164,11 +165,11 @@ async function routeMcp(
       if (existing.builtin) {
         return fail(BUILTIN_IMMUTABLE_MESSAGE, 409);
       }
-      const merged = {
-        ...existing,
-        ...(parsed.data as object),
-        id: serverId,
-      } as MCPServerConfig;
+      const mergeResult = mergeMcpPatch(existing, parsed.data);
+      if (!mergeResult.ok) {
+        return fail(mergeResult.error);
+      }
+      const merged = mergeResult.value;
       await services.mcp.updateServerAsync(serverId, merged);
       return ok(redactMcpServer(merged));
     }
@@ -197,8 +198,10 @@ async function routeLlm(services: BridgeServices, req: BridgeRequest): Promise<B
       if (r.orchestrationBackend === undefined) {
         r.orchestrationBackend = DEFAULT_ORCHESTRATION_BACKEND;
       }
+      return ok(redacted);
     }
-    return ok(redacted);
+    // Fresh install: no LLM config yet (null) — surface the default, not `null`.
+    return ok({ orchestrationBackend: DEFAULT_ORCHESTRATION_BACKEND });
   }
   if (req.method === "POST") {
     const parsed = LlmConfigInputSchema.safeParse(req.body);
@@ -259,6 +262,55 @@ async function routeSettings(services: BridgeServices, req: BridgeRequest): Prom
     return ok(await services.settings.getSettingsAsync());
   }
   return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+/** Fields that belong ONLY to an HTTP (streamableHttp) server config. */
+const HTTP_ONLY_FIELDS = ["url", "headers", "version", "timeoutMs"] as const;
+/** Fields that belong ONLY to a stdio server config. */
+const STDIO_ONLY_FIELDS = ["command", "args", "env", "cwd", "stderr"] as const;
+
+type MergeResult = { ok: true; value: MCPServerConfig } | { ok: false; error: string };
+
+/**
+ * Merge a validated patch onto an existing MCP server config, normalized to the
+ * TARGET transport: fields belonging only to the OTHER transport are stripped so
+ * no foreign field survives (whether the patch switches transport or just slips
+ * in a wrong-transport field). A transport switch also requires the new
+ * transport's mandatory field (`url` for HTTP, `command` for stdio).
+ */
+function mergeMcpPatch(existing: MCPServerConfig, patch: McpServerPatch): MergeResult {
+  const targetTransport = patch.transport ?? existing.transport;
+  const transportChanged = patch.transport !== undefined && patch.transport !== existing.transport;
+
+  const merged: Record<string, unknown> = {
+    ...(existing as unknown as Record<string, unknown>),
+    ...(patch as Record<string, unknown>),
+    id: existing.id,
+  };
+
+  // Strip the OTHER transport's fields so no foreign field survives.
+  const staleFields = targetTransport === "streamableHttp" ? STDIO_ONLY_FIELDS : HTTP_ONLY_FIELDS;
+  for (const field of staleFields) {
+    delete merged[field];
+  }
+
+  if (transportChanged) {
+    // Require the new transport's mandatory field (from the patch or existing).
+    if (targetTransport === "streamableHttp" && typeof merged.url !== "string") {
+      return {
+        ok: false,
+        error: "Changing transport to http requires --url",
+      };
+    }
+    if (targetTransport === "stdio" && typeof merged.command !== "string") {
+      return {
+        ok: false,
+        error: "Changing transport to stdio requires --command",
+      };
+    }
+  }
+
+  return { ok: true, value: merged as unknown as MCPServerConfig };
 }
 
 function formatZodError(error: {

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -7,6 +7,11 @@ import { McpStorage } from "../storage/mcp-storage";
 import { type CreateClientOptions, MCPServerClient } from "./mcp-server-client";
 import type { MCPServerConfig } from "./types";
 
+/** Fields valid ONLY on an HTTP (streamableHttp) server config. */
+const HTTP_ONLY_FIELDS = ["url", "headers", "version", "timeoutMs"] as const;
+/** Fields valid ONLY on a stdio server config. */
+const STDIO_ONLY_FIELDS = ["command", "args", "env", "cwd", "stderr"] as const;
+
 export class MCPServerManager {
   private static instance: MCPServerManager;
   private static internalServerConfigs: MCPServerConfig[] = [];
@@ -296,17 +301,24 @@ export class MCPServerManager {
 
     const existing = storedConfigs[index];
 
-    // On a transport change, REPLACE rather than overlay: overlaying onto
-    // `existing` would re-introduce the old transport's fields (e.g. a stale url +
-    // secret-bearing headers on a now-stdio server). Caller supplies a complete config.
-    const transportChanged = existing.transport !== config.transport;
-    const merged: MCPServerConfig = transportChanged
-      ? ({ ...(config as unknown as Record<string, unknown>), id: existing.id } as MCPServerConfig)
-      : ({
-          ...existing,
-          ...(config as unknown as Record<string, unknown>),
-          id: existing.id,
-        } as MCPServerConfig);
+    const mergedRecord: Record<string, unknown> = {
+      ...(existing as unknown as Record<string, unknown>),
+      ...(config as unknown as Record<string, unknown>),
+      id: existing.id,
+    };
+
+    // On a transport change, strip ONLY the old transport's transport-specific
+    // fields (e.g. a stale url + secret-bearing headers on a now-stdio server).
+    // Common fields like `enabled`/`toolWhitelist` are preserved from `existing`
+    // even when the incoming config omits them.
+    if (existing.transport !== config.transport) {
+      const staleFields = config.transport === "stdio" ? HTTP_ONLY_FIELDS : STDIO_ONLY_FIELDS;
+      for (const field of staleFields) {
+        delete mergedRecord[field];
+      }
+    }
+
+    const merged = mergedRecord as unknown as MCPServerConfig;
 
     MCPServerManager.validateServerConfig(merged);
 

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -296,11 +296,17 @@ export class MCPServerManager {
 
     const existing = storedConfigs[index];
 
-    const merged: MCPServerConfig = {
-      ...existing,
-      ...(config as unknown as Record<string, unknown>),
-      id: existing.id,
-    } as MCPServerConfig;
+    // On a transport change, REPLACE rather than overlay: overlaying onto
+    // `existing` would re-introduce the old transport's fields (e.g. a stale url +
+    // secret-bearing headers on a now-stdio server). Caller supplies a complete config.
+    const transportChanged = existing.transport !== config.transport;
+    const merged: MCPServerConfig = transportChanged
+      ? ({ ...(config as unknown as Record<string, unknown>), id: existing.id } as MCPServerConfig)
+      : ({
+          ...existing,
+          ...(config as unknown as Record<string, unknown>),
+          id: existing.id,
+        } as MCPServerConfig);
 
     MCPServerManager.validateServerConfig(merged);
 

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -219,6 +219,67 @@ describe("buildRequest - mcp", () => {
   it("url-encodes ids with special chars", () => {
     expect(build(["mcp", "remove", "a/b c"]).path).toBe("/mcp/servers/a%2Fb%20c");
   });
+
+  it("mcp update with only --url PUTs only the provided field", () => {
+    const req = build(["mcp", "update", "srv-9", "--url", "https://new.example.com/mcp"]);
+    expect(req).toMatchObject({ method: "PUT", path: "/mcp/servers/srv-9" });
+    expect(req.body).toEqual({ url: "https://new.example.com/mcp" });
+  });
+
+  it("mcp update sends ONLY provided fields (no transport unless given)", () => {
+    const req = build(["mcp", "update", "srv-9", "--name", "Renamed", "--env", "K=V"]);
+    expect(req.body).toEqual({ name: "Renamed", env: { K: "V" } });
+  });
+
+  it("mcp update normalizes --transport http to streamableHttp", () => {
+    const req = build(["mcp", "update", "srv-9", "--transport", "http"]);
+    expect(req.body).toEqual({ transport: "streamableHttp" });
+  });
+
+  it("mcp update rejects an unknown transport", () => {
+    expect(() => build(["mcp", "update", "srv-9", "--transport", "carrier-pigeon"])).toThrow(
+      UsageError,
+    );
+  });
+
+  it("mcp update with no fields throws a usage error", () => {
+    expect(() => build(["mcp", "update", "srv-9"])).toThrow(/No fields to update/);
+  });
+
+  it("mcp update without id or --name throws a usage error", () => {
+    expect(() => build(["mcp", "update"])).toThrow(UsageError);
+  });
+});
+
+describe("buildRequest - mcp --name selector", () => {
+  it("mcp remove --name sets resolveName and an {id} placeholder path", () => {
+    const req = build(["mcp", "remove", "--name", "My Server"]);
+    expect(req.method).toBe("DELETE");
+    expect(req.path).toBe("/mcp/servers/{id}");
+    expect(req.resolveName).toBe("My Server");
+  });
+
+  it("mcp enable --name sets resolveName", () => {
+    const req = build(["mcp", "enable", "--name", "My Server"]);
+    expect(req.path).toBe("/mcp/servers/{id}/enabled");
+    expect(req.resolveName).toBe("My Server");
+    expect(req.body).toEqual({ enabled: true });
+  });
+
+  it("mcp update --name resolves the target and does NOT treat --name as a rename", () => {
+    const req = build(["mcp", "update", "--name", "My Server", "--url", "https://x.example/mcp"]);
+    expect(req.path).toBe("/mcp/servers/{id}");
+    expect(req.resolveName).toBe("My Server");
+    // --name was consumed as the selector, so it is NOT in the patch body.
+    expect(req.body).toEqual({ url: "https://x.example/mcp" });
+  });
+
+  it("mcp update <id> --name treats --name as a rename (id is the selector)", () => {
+    const req = build(["mcp", "update", "srv-9", "--name", "Renamed"]);
+    expect(req.path).toBe("/mcp/servers/srv-9");
+    expect(req.resolveName).toBeUndefined();
+    expect(req.body).toEqual({ name: "Renamed" });
+  });
 });
 
 describe("buildRequest - config", () => {
@@ -251,6 +312,34 @@ describe("buildRequest - config", () => {
 
   it("config set llm is unsupported", () => {
     expect(() => build(["config", "set", "llm"])).toThrow(/not supported/);
+  });
+
+  it("config get orchestrator -> GET /llm/config", () => {
+    expect(build(["config", "get", "orchestrator"])).toMatchObject({
+      method: "GET",
+      path: "/llm/config",
+    });
+  });
+
+  it("config set orchestrator --backend local-claude -> POST", () => {
+    const req = build(["config", "set", "orchestrator", "--backend", "local-claude"]);
+    expect(req).toMatchObject({ method: "POST", path: "/llm/config/orchestrator" });
+    expect(req.body).toEqual({ orchestrationBackend: "local-claude" });
+  });
+
+  it("config set orchestrator --backend openai -> POST", () => {
+    const req = build(["config", "set", "orchestrator", "--backend", "openai"]);
+    expect(req.body).toEqual({ orchestrationBackend: "openai" });
+  });
+
+  it("config set orchestrator rejects an unknown backend", () => {
+    expect(() => build(["config", "set", "orchestrator", "--backend", "gpt5"])).toThrow(
+      /--backend must be one of/,
+    );
+  });
+
+  it("config set orchestrator requires --backend", () => {
+    expect(() => build(["config", "set", "orchestrator"])).toThrow(/Missing required --backend/);
   });
 });
 

--- a/src/cli/commands.test.ts
+++ b/src/cli/commands.test.ts
@@ -231,6 +231,22 @@ describe("buildRequest - mcp", () => {
     expect(req.body).toEqual({ name: "Renamed", env: { K: "V" } });
   });
 
+  it("mcp update collects repeatable --arg values verbatim (like add)", () => {
+    const req = build(["mcp", "update", "srv-9", "--arg", "-y", "--arg", "/My Docs/server.js"]);
+    expect(req.body).toEqual({ args: ["-y", "/My Docs/server.js"] });
+  });
+
+  it("mcp update supports the legacy space-split --args", () => {
+    const req = build(["mcp", "update", "srv-9", "--args", "a b c"]);
+    expect(req.body).toEqual({ args: ["a", "b", "c"] });
+  });
+
+  it("mcp update rejects mixing --arg and --args", () => {
+    expect(() => build(["mcp", "update", "srv-9", "--arg", "a", "--args", "b c"])).toThrow(
+      UsageError,
+    );
+  });
+
   it("mcp update normalizes --transport http to streamableHttp", () => {
     const req = build(["mcp", "update", "srv-9", "--transport", "http"]);
     expect(req.body).toEqual({ transport: "streamableHttp" });

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -116,7 +116,7 @@ function buildMcpRequest(
         options,
         "update <id> | --name <name> [--url ... | --command ... | --args ... | --env ... | --header ... | --transport ...]",
       );
-      const body = buildMcpPatch(options, target.usedNameForLookup);
+      const body = buildMcpPatch(options, multiOptions, target.usedNameForLookup);
       return {
         ...target,
         method: "PUT",
@@ -202,6 +202,7 @@ function resolveTarget(
  */
 function buildMcpPatch(
   options: Record<string, string | boolean>,
+  multiOptions: Record<string, string[]>,
   nameUsedForLookup: boolean,
 ): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
@@ -229,8 +230,9 @@ function buildMcpPatch(
   const command = optionalString(options, "command");
   if (command !== undefined) patch.command = command;
 
-  const argsValue = optionalString(options, "args");
-  if (argsValue !== undefined) patch.args = argsValue.split(" ").filter(Boolean);
+  // Mirror `mcp add`: repeatable verbatim `--arg` or legacy `--args` (exclusive).
+  const args = parseStdioArgs(options, multiOptions);
+  if (args !== undefined) patch.args = args;
 
   const env = parseKeyValueList(optionalString(options, "env"));
   if (env !== undefined) patch.env = env;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -13,7 +13,17 @@ export interface CommandRequest {
   body?: unknown;
   /** Short human label used when pretty-printing the result. */
   label: string;
+  /**
+   * When set, the CLI must first resolve this MCP server NAME to an id (via
+   * `GET /mcp/servers`) and substitute it for the `{id}` placeholder in `path`
+   * before issuing the request. Kept out of {@link buildRequest} so that
+   * function stays pure (no fetch); the runtime resolution lives in index.ts.
+   */
+  resolveName?: string;
 }
+
+/** Placeholder substituted with a resolved server id when `resolveName` is set. */
+export const ID_PLACEHOLDER = "{id}";
 
 /**
  * Translate parsed CLI args into a bridge request.
@@ -79,24 +89,40 @@ function buildMcpRequest(
     }
 
     case "remove": {
-      const id = rest[0];
-      if (!id) throw new UsageError("Usage: yakshaver mcp remove <id>");
+      const target = resolveTarget(rest[0], options, "remove <id> | --name <name>");
       return {
+        ...target,
         method: "DELETE",
-        path: `/mcp/servers/${encodeURIComponent(id)}`,
+        path: `/mcp/servers/${target.idSegment}`,
         label: "Removed MCP server",
       };
     }
 
     case "enable": {
-      const id = rest[0];
-      if (!id) throw new UsageError("Usage: yakshaver mcp enable <id> [--off]");
+      const target = resolveTarget(rest[0], options, "enable <id> | --name <name> [--off]");
       const enabled = options.off !== true;
       return {
+        ...target,
         method: "POST",
-        path: `/mcp/servers/${encodeURIComponent(id)}/enabled`,
+        path: `/mcp/servers/${target.idSegment}/enabled`,
         body: { enabled },
         label: enabled ? "Enabled MCP server" : "Disabled MCP server",
+      };
+    }
+
+    case "update": {
+      const target = resolveTarget(
+        rest[0],
+        options,
+        "update <id> | --name <name> [--url ... | --command ... | --args ... | --env ... | --header ... | --transport ...]",
+      );
+      const body = buildMcpPatch(options, target.usedNameForLookup);
+      return {
+        ...target,
+        method: "PUT",
+        path: `/mcp/servers/${target.idSegment}`,
+        body,
+        label: "Updated MCP server",
       };
     }
 
@@ -142,6 +168,84 @@ function parseStdioArgs(
   return undefined;
 }
 
+/**
+ * Resolve the server target for `remove`/`enable`/`update`.
+ *
+ * The selector is EITHER a positional id OR `--name <name>` (resolved to an id
+ * at runtime via the bridge). When a positional id is given, `--name` is free to
+ * act as a rename field on `update` (see {@link buildMcpPatch}); when no
+ * positional id is given, `--name` IS the selector and is consumed for lookup.
+ */
+function resolveTarget(
+  positionalId: string | undefined,
+  options: Record<string, string | boolean>,
+  usage: string,
+): { idSegment: string; resolveName?: string; usedNameForLookup: boolean } {
+  const name = optionalString(options, "name");
+
+  if (positionalId) {
+    // id is the selector; --name (if any) is a value to apply, not a lookup.
+    return { idSegment: encodeURIComponent(positionalId), usedNameForLookup: false };
+  }
+  if (name) {
+    return { idSegment: ID_PLACEHOLDER, resolveName: name, usedNameForLookup: true };
+  }
+  throw new UsageError(`Usage: yakshaver mcp ${usage}`);
+}
+
+/**
+ * Build the merge-update body for `mcp update`. Includes ONLY the fields the
+ * user actually provided so unspecified fields are preserved server-side.
+ *
+ * `--name` is reserved for server lookup when used as a selector, so we only
+ * treat `--name` as a rename when it was NOT consumed to resolve the target.
+ */
+function buildMcpPatch(
+  options: Record<string, string | boolean>,
+  nameUsedForLookup: boolean,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+
+  if (!nameUsedForLookup) {
+    const name = optionalString(options, "name");
+    if (name !== undefined) patch.name = name;
+  }
+
+  const description = optionalString(options, "description");
+  if (description !== undefined) patch.description = description;
+
+  const transport = optionalString(options, "transport");
+  if (transport !== undefined) {
+    const normalized = transport === "http" ? "streamableHttp" : transport;
+    if (normalized !== "stdio" && normalized !== "streamableHttp") {
+      throw new UsageError("--transport must be one of: stdio, http (streamableHttp)");
+    }
+    patch.transport = normalized;
+  }
+
+  const url = optionalString(options, "url");
+  if (url !== undefined) patch.url = url;
+
+  const command = optionalString(options, "command");
+  if (command !== undefined) patch.command = command;
+
+  const argsValue = optionalString(options, "args");
+  if (argsValue !== undefined) patch.args = argsValue.split(" ").filter(Boolean);
+
+  const env = parseKeyValueList(optionalString(options, "env"));
+  if (env !== undefined) patch.env = env;
+
+  const headers = parseKeyValueList(optionalString(options, "header"));
+  if (headers !== undefined) patch.headers = headers;
+
+  if (Object.keys(patch).length === 0) {
+    throw new UsageError(
+      "No fields to update. Provide at least one of --name/--description/--url/--command/--args/--env/--header/--transport",
+    );
+  }
+  return patch;
+}
+
 function buildConfigRequest(
   action: string | undefined,
   rest: string[],
@@ -150,16 +254,30 @@ function buildConfigRequest(
   const target = rest[0] ?? "settings"; // default to settings
 
   if (action === "get") {
-    if (target === "llm") {
+    if (target === "llm" || target === "orchestrator") {
+      // The LLM config carries `orchestrationBackend`; `get orchestrator` is an
+      // alias that surfaces the same payload.
       return { method: "GET", path: "/llm/config", label: "LLM config" };
     }
     if (target === "settings") {
       return { method: "GET", path: "/settings", label: "User settings" };
     }
-    throw new UsageError("Usage: yakshaver config get [llm|settings]");
+    throw new UsageError("Usage: yakshaver config get [llm|orchestrator|settings]");
   }
 
   if (action === "set") {
+    if (target === "orchestrator") {
+      const backend = requireString(options, "backend");
+      if (backend !== "openai" && backend !== "local-claude") {
+        throw new UsageError("--backend must be one of: openai, local-claude");
+      }
+      return {
+        method: "POST",
+        path: "/llm/config/orchestrator",
+        body: { orchestrationBackend: backend },
+        label: "Updated orchestration backend",
+      };
+    }
     if (target === "settings") {
       const body = buildSettingsPatch(options);
       return { method: "PATCH", path: "/settings", body, label: "Updated settings" };
@@ -167,10 +285,13 @@ function buildConfigRequest(
     if (target === "llm") {
       throw new UsageError(
         "Setting the full LLM config via the CLI is not supported (it requires secrets). " +
-          "Configure providers in the app UI.",
+          "Configure providers in the app UI, or set the orchestrator with " +
+          "`config set orchestrator --backend <openai|local-claude>`.",
       );
     }
-    throw new UsageError("Usage: yakshaver config set settings --<key> <value>");
+    throw new UsageError(
+      "Usage: yakshaver config set [settings --<key> <value> | orchestrator --backend <openai|local-claude>]",
+    );
   }
 
   throw new UsageError(`Unknown config subcommand: ${action ?? "(none)"}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,7 @@ MCP
   yakshaver mcp list
   yakshaver mcp add --name <name> --transport stdio --command <cmd> [--arg <a> --arg <b> ...] [--env "K=V,K2=V2"]
   yakshaver mcp add --name <name> --transport http  --url <url> [--header "K=V"]
-  yakshaver mcp update <id> [--name ... --url ... --command ... --args ... --env ... --header ... --transport ...]
+  yakshaver mcp update <id> [--name ... --url ... --command ... --arg ... --env ... --header ... --transport ...]
   yakshaver mcp remove <id>
   yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { ArgParseError, parseArgs } from "./args";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
-import { buildRequest, type CommandRequest, UsageError } from "./commands";
+import { buildRequest, type CommandRequest, ID_PLACEHOLDER, UsageError } from "./commands";
 import { printResult } from "./print";
+import { resolveServerIdByName } from "./resolve-name";
 
 const HELP = `yakshaver — configure YakShaver Desktop from the terminal
 
@@ -16,6 +17,7 @@ MCP
   yakshaver mcp list
   yakshaver mcp add --name <name> --transport stdio --command <cmd> [--arg <a> --arg <b> ...] [--env "K=V,K2=V2"]
   yakshaver mcp add --name <name> --transport http  --url <url> [--header "K=V"]
+  yakshaver mcp update <id> [--name ... --url ... --command ... --args ... --env ... --header ... --transport ...]
   yakshaver mcp remove <id>
   yakshaver mcp enable <id> [--off]        # --off disables instead of enabling
 
@@ -24,10 +26,14 @@ MCP
   begin with -- (e.g. --arg --port --arg 3000). The legacy --args "a b c" splits
   on spaces and cannot express an argument that itself contains a space.
 
+  remove/enable/update also accept --name <name> instead of a positional <id>
+  (resolved against the server list; errors if the name is missing or ambiguous).
+
 CONFIG
-  yakshaver config get [llm|settings]      # defaults to settings
+  yakshaver config get [llm|orchestrator|settings]   # defaults to settings
   yakshaver config set settings --tool-approval-mode <yolo|wait|ask>
   yakshaver config set settings --open-at-login <true|false>
+  yakshaver config set orchestrator --backend <openai|local-claude>
 
 GLOBAL
   --dev      Target the dev build (YakShaverDev) userData
@@ -71,10 +77,15 @@ async function main(argv: string[]): Promise<number> {
   const client = new BridgeClient({ dev: parsed.options.dev === true ? true : undefined });
 
   try {
-    const data = await client.request(request.method, request.path, request.body);
+    const path = await resolvePath(client, request);
+    const data = await client.request(request.method, path, request.body);
     printResult(request.label, data, parsed.options.json === true);
     return 0;
   } catch (err) {
+    if (err instanceof UsageError) {
+      console.error(`Error: ${err.message}`);
+      return 2;
+    }
     if (err instanceof BridgeUnavailableError) {
       console.error(err.message);
       return 3;
@@ -82,6 +93,18 @@ async function main(argv: string[]): Promise<number> {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
   }
+}
+
+/**
+ * If the request targets an MCP server by name, resolve the name to a concrete
+ * id via `GET /mcp/servers` and substitute it into the path. Otherwise return
+ * the path unchanged. Throws a {@link UsageError} on 0 or >1 matches.
+ */
+async function resolvePath(client: BridgeClient, request: CommandRequest): Promise<string> {
+  if (!request.resolveName) return request.path;
+  const servers = await client.get<unknown[]>("/mcp/servers");
+  const id = resolveServerIdByName(servers, request.resolveName);
+  return request.path.replace(ID_PLACEHOLDER, encodeURIComponent(id));
 }
 
 main(process.argv.slice(2))

--- a/src/cli/resolve-name.test.ts
+++ b/src/cli/resolve-name.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { UsageError } from "./commands";
+import { resolveServerIdByName } from "./resolve-name";
+
+describe("resolveServerIdByName", () => {
+  const servers = [
+    { id: "srv-1", name: "Alpha" },
+    { id: "srv-2", name: "Beta" },
+    { id: "srv-3", name: "Beta" }, // duplicate name -> ambiguous
+  ];
+
+  it("resolves a unique name to its id", () => {
+    expect(resolveServerIdByName(servers, "Alpha")).toBe("srv-1");
+  });
+
+  it("throws a UsageError when no server matches", () => {
+    expect(() => resolveServerIdByName(servers, "Gamma")).toThrow(UsageError);
+    expect(() => resolveServerIdByName(servers, "Gamma")).toThrow(/No MCP server found/);
+  });
+
+  it("throws a UsageError listing ids when the name is ambiguous", () => {
+    expect(() => resolveServerIdByName(servers, "Beta")).toThrow(/Multiple MCP servers match/);
+    expect(() => resolveServerIdByName(servers, "Beta")).toThrow(/srv-2, srv-3/);
+  });
+
+  it("treats a non-array input as empty (no match)", () => {
+    expect(() => resolveServerIdByName(null, "Alpha")).toThrow(/No MCP server found/);
+  });
+
+  it("rejects a matched server that has no usable id", () => {
+    expect(() => resolveServerIdByName([{ name: "Alpha" }], "Alpha")).toThrow(/no usable id/);
+  });
+});

--- a/src/cli/resolve-name.ts
+++ b/src/cli/resolve-name.ts
@@ -1,0 +1,34 @@
+import { UsageError } from "./commands";
+
+/**
+ * Resolve a unique MCP server id from a list of servers (as returned by
+ * `GET /mcp/servers`) given a server name.
+ *
+ * Pure and side-effect free so the matching + ambiguity rules are unit-testable
+ * in isolation. Matching is case-sensitive and exact on `name`.
+ *
+ * @throws {UsageError} when zero or more than one server matches the name.
+ */
+export function resolveServerIdByName(servers: unknown, name: string): string {
+  const list = Array.isArray(servers) ? servers : [];
+  const matches = list.filter(
+    (s): s is { id?: unknown; name?: unknown } =>
+      !!s && typeof s === "object" && (s as { name?: unknown }).name === name,
+  );
+
+  if (matches.length === 0) {
+    throw new UsageError(`No MCP server found with name '${name}'`);
+  }
+  if (matches.length > 1) {
+    const ids = matches.map((m) => String(m.id ?? "?")).join(", ");
+    throw new UsageError(
+      `Multiple MCP servers match name '${name}' (ids: ${ids}). Use the positional <id> instead.`,
+    );
+  }
+
+  const id = matches[0].id;
+  if (typeof id !== "string" || id.length === 0) {
+    throw new UsageError(`MCP server '${name}' has no usable id`);
+  }
+  return id;
+}

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -95,6 +95,36 @@ export const McpServerInputSchema = z.discriminatedUnion("transport", [
 ]);
 export type McpServerInput = z.infer<typeof McpServerInputSchema>;
 
+/**
+ * Input accepted by PUT /mcp/servers/:id (merge-update).
+ *
+ * Unlike {@link McpServerInputSchema}, every field is optional so callers can
+ * send ONLY the fields they want to change. The router merges the provided
+ * fields onto the existing server config. `transport` is optional here; when
+ * omitted the existing transport is preserved.
+ */
+export const McpServerPatchSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    description: z.string().optional(),
+    enabled: z.boolean().optional(),
+    toolWhitelist: z.array(z.string()).optional(),
+    transport: z.enum(["stdio", "streamableHttp"]).optional(),
+    // http
+    url: z.string().url("url must be a valid URL").optional(),
+    headers: stringRecord.optional(),
+    timeoutMs: z.number().int().positive().optional(),
+    // stdio
+    command: z.string().min(1).optional(),
+    args: z.array(z.string()).optional(),
+    env: stringRecord.optional(),
+    cwd: z.string().optional(),
+    stderr: z.enum(["inherit", "ignore", "pipe"]).optional(),
+    version: z.string().optional(),
+  })
+  .strict();
+export type McpServerPatch = z.infer<typeof McpServerPatchSchema>;
+
 /** Input accepted by POST /mcp/servers/:id/enabled. */
 export const McpEnabledInputSchema = z.object({
   enabled: z.boolean(),
@@ -127,6 +157,14 @@ export const LlmConfigInputSchema = z.object({
   languageModel: ModelConfigInputSchema.nullable(),
   transcriptionModel: ModelConfigInputSchema.nullable(),
   providerApiKeys: z.record(z.string(), z.string()).optional(),
+});
+
+/** Orchestration backends the CLI may set. Mirrors `OrchestrationBackend`. */
+export const OrchestrationBackendSchema = z.enum(["openai", "local-claude"]);
+
+/** Input accepted by POST /llm/config/orchestrator. */
+export const OrchestratorInputSchema = z.object({
+  orchestrationBackend: OrchestrationBackendSchema,
 });
 
 /**


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Calude Code

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ https://github.com/SSWConsulting/SSW.YakShaver.Desktop/pull/914 contained some outdated code, causing significant conflicts with the main branch. Rebuilding the new branch to cherry-pick the changes, and also made some minor optimizations along the way.

> 2. What was changed?

✏️ Adds a yakshaver CLI orchestrator-backend setting (config set/get orchestrator), mcp update with a --name selector, and transport-switch normalization — rebuilt cleanly on the latest main (the original [#913](https://github.com/SSWConsulting/SSW.YakShaver.Desktop/pull/914) was conflict-ridden from being based on pre-merge #907/#909). Drops the parts main already has; adds tests and minor review hardening.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ @calumjs 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
