### PR TITLE
M⚠️ ◾ feat(cli): single yakshaver MCP front-door proxying the aggregated toolset (rebased #915)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -569,6 +569,33 @@ Button variants: `default`, `destructive`, `outline`, `secondary`, `ghost`, `lin
 - **External**: Configure via Settings UI (persisted to `mcp-servers.json`)
 - **Internal**: Add to `src/backend/services/mcp/internal/` and register in MCP orchestrator
 
+Both external and internal/in-memory servers are aggregated by `MCPServerManager`
+(`collectToolsWithServerPrefixAsync()` → a single server-prefixed `ToolSet`) and are
+reachable by every orchestration backend through the **MCP front-door** (see below) —
+there is no longer any server kind that the Claude Code orchestrator cannot reach.
+
+### The MCP Front-Door (single `yakshaver` proxy)
+
+The app exposes its **entire aggregated toolset** — external AND internal/in-memory
+servers, server-prefixed — to the Claude Code orchestrator through one proxy MCP
+server instead of re-declaring each upstream server to Claude:
+
+- **CLI subcommand**: `yakshaver mcp-serve` (`src/cli/mcp-serve.ts`) runs a stdio MCP
+  server named `yakshaver`. The orchestrator spawns it via a one-entry `--mcp-config`;
+  to Claude the tools appear as `mcp__yakshaver__<Server__tool>`. It owns no tools of
+  its own — every `tools/list` / `tools/call` is proxied to the running desktop app
+  over the localhost CLI bridge.
+- **Bridge endpoints** (`src/backend/services/cli-bridge/bridge-router.ts`):
+  - `GET /tools` → the full server-prefixed tool list (names + descriptions + JSON
+    Schema). Returns `[]` (never an error) when no enabled servers are healthy.
+  - `POST /tools/call` → executes one tool by name through the app's tool-approval
+    policy SERVER-SIDE, so a headless run never hangs on an interactive prompt
+    (`yolo` runs everything; `ask`/`wait` run only whitelisted tools, otherwise return
+    a structured "not approved" envelope, never a transport error).
+- **Wiring**: `McpToolBridge` (`src/backend/services/mcp/mcp-tool-bridge.ts`) flattens
+  the AI-SDK `ToolSet` into wire summaries and enforces the approval policy; the front
+  door (`mcp-serve.ts`) maps a `{ok:false}` envelope to an MCP `isError` result.
+
 ### Updating Release Workflows
 
 - macOS arm64 and x64 builds generate separate ZIPs but must publish a single update manifest

--- a/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
+++ b/src/backend/services/cli-bridge/bridge-mcp-transport-switch.test.ts
@@ -61,6 +61,10 @@ function makeServices() {
       getSettingsAsync: async () => ({}) as never,
       updateSettingsAsync: async () => {},
     },
+    tools: {
+      listTools: async () => [],
+      callTool: async () => ({ ok: false, error: "not used in this test" }),
+    },
   };
 }
 

--- a/src/backend/services/cli-bridge/bridge-router.integration.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.integration.test.ts
@@ -66,6 +66,10 @@ async function makeServices(): Promise<BridgeServices> {
       getSettingsAsync: async () => ({ toolApprovalMode: "ask" }) as never,
       updateSettingsAsync: async () => {},
     },
+    tools: {
+      listTools: async () => [],
+      callTool: async () => ({ ok: false, error: "not used in this test" }),
+    },
   };
 }
 

--- a/src/backend/services/cli-bridge/bridge-router.test.ts
+++ b/src/backend/services/cli-bridge/bridge-router.test.ts
@@ -44,6 +44,11 @@ function makeServices(overrides: Partial<BridgeServices> = {}): BridgeServices {
       updateSettingsAsync: vi.fn().mockResolvedValue(undefined),
       ...overrides.settings,
     },
+    tools: {
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ ok: false, error: "not used in this test" }),
+      ...overrides.tools,
+    },
   };
 }
 

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -1,11 +1,14 @@
 import {
   type BridgeResponse,
+  type BridgeToolSummary,
   LlmConfigInputSchema,
   McpEnabledInputSchema,
   McpServerInputSchema,
   type McpServerPatch,
   McpServerPatchSchema,
   OrchestratorInputSchema,
+  ToolCallInputSchema,
+  type ToolCallResult,
 } from "../../../shared/cli-bridge/protocol";
 import {
   redactLlmConfig,
@@ -37,6 +40,15 @@ export interface BridgeServices {
   settings: {
     getSettingsAsync(): Promise<UserSettings>;
     updateSettingsAsync(patch: PartialUserSettings): Promise<void>;
+  };
+  /**
+   * Aggregated MCP toolset front-door (#915). Exposes the app's full,
+   * server-prefixed toolset (incl. internal/in-memory servers) and proxies
+   * tool execution through the app's approval policy.
+   */
+  tools: {
+    listTools(): Promise<BridgeToolSummary[]>;
+    callTool(name: string, args?: Record<string, unknown>): Promise<ToolCallResult>;
   };
 }
 
@@ -96,6 +108,11 @@ export async function routeRequest(
     // /settings
     if (segments[0] === "settings" && segments.length === 1) {
       return await routeSettings(services, req);
+    }
+
+    // /tools and /tools/call
+    if (segments[0] === "tools") {
+      return await routeTools(services, req, segments.slice(1));
     }
 
     return fail(`Unknown route: ${req.method} ${req.path}`, 404);
@@ -262,6 +279,49 @@ async function routeSettings(services: BridgeServices, req: BridgeRequest): Prom
     return ok(await services.settings.getSettingsAsync());
   }
   return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+}
+
+/**
+ * Aggregated toolset front-door (#915).
+ *
+ *  - `GET  /tools`       → the full server-prefixed tool list (incl. internal/
+ *    in-memory servers), names + descriptions + JSON-Schema only.
+ *  - `POST /tools/call`  → execute one tool by name; the approval policy is
+ *    enforced inside the tools service so a refusal is a structured result, not
+ *    an HTTP error (the caller must surface it, not retry).
+ */
+async function routeTools(
+  services: BridgeServices,
+  req: BridgeRequest,
+  rest: string[],
+): Promise<BridgeResult> {
+  // /tools
+  if (rest.length === 0) {
+    if (req.method !== "GET") {
+      return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+    }
+    const tools = await services.tools.listTools();
+    return ok(tools);
+  }
+
+  // /tools/call
+  if (rest.length === 1 && rest[0] === "call") {
+    if (req.method !== "POST") {
+      return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
+    }
+    const parsed = ToolCallInputSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return fail(`Invalid tool call: ${formatZodError(parsed.error)}`);
+    }
+    const result = await services.tools.callTool(parsed.data.name, parsed.data.arguments ?? {});
+    // A tool-level failure (incl. a structured "not approved") is still a
+    // successful BRIDGE response — the envelope carries {ok:false,...} so the
+    // MCP front-door can relay it to the model verbatim. Only transport/route
+    // problems use a non-200 status.
+    return ok(result);
+  }
+
+  return fail(`Unknown route: ${req.method} ${req.path}`, 404);
 }
 
 /** Fields that belong ONLY to an HTTP (streamableHttp) server config. */

--- a/src/backend/services/cli-bridge/bridge-router.ts
+++ b/src/backend/services/cli-bridge/bridge-router.ts
@@ -47,8 +47,12 @@ export interface BridgeServices {
    * tool execution through the app's approval policy.
    */
   tools: {
-    listTools(): Promise<BridgeToolSummary[]>;
-    callTool(name: string, args?: Record<string, unknown>): Promise<ToolCallResult>;
+    listTools(serverFilter?: string[]): Promise<BridgeToolSummary[]>;
+    callTool(
+      name: string,
+      args?: Record<string, unknown>,
+      serverFilter?: string[],
+    ): Promise<ToolCallResult>;
   };
 }
 
@@ -58,6 +62,8 @@ export interface BridgeRequest {
   path: string;
   /** Parsed JSON body (already validated as JSON upstream). */
   body?: unknown;
+  /** Parsed query-string params, e.g. `{ serverFilter: "a,b" }` for `GET /tools`. */
+  query?: Record<string, string>;
 }
 
 export interface BridgeResult {
@@ -300,7 +306,9 @@ async function routeTools(
     if (req.method !== "GET") {
       return fail(`Method not allowed: ${req.method} ${req.path}`, 405);
     }
-    const tools = await services.tools.listTools();
+    // Restrict to the project's selected servers when the front-door forwards a filter
+    // (`?serverFilter=a,b`); absent/empty means every enabled server.
+    const tools = await services.tools.listTools(parseServerFilter(req.query?.serverFilter));
     return ok(tools);
   }
 
@@ -313,7 +321,11 @@ async function routeTools(
     if (!parsed.success) {
       return fail(`Invalid tool call: ${formatZodError(parsed.error)}`);
     }
-    const result = await services.tools.callTool(parsed.data.name, parsed.data.arguments ?? {});
+    const result = await services.tools.callTool(
+      parsed.data.name,
+      parsed.data.arguments ?? {},
+      parsed.data.serverFilter,
+    );
     // A tool-level failure (incl. a structured "not approved") is still a
     // successful BRIDGE response — the envelope carries {ok:false,...} so the
     // MCP front-door can relay it to the model verbatim. Only transport/route
@@ -322,6 +334,16 @@ async function routeTools(
   }
 
   return fail(`Unknown route: ${req.method} ${req.path}`, 404);
+}
+
+/** Parse a `serverFilter` query value (`"a,b"`) into a trimmed id/name list, or undefined if empty. */
+function parseServerFilter(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  const ids = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return ids.length > 0 ? ids : undefined;
 }
 
 /** Fields that belong ONLY to an HTTP (streamableHttp) server config. */

--- a/src/backend/services/cli-bridge/cli-bridge-e2e.integration.test.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-e2e.integration.test.ts
@@ -69,6 +69,10 @@ async function realServices(): Promise<BridgeServices> {
       getSettingsAsync: async () => ({ toolApprovalMode: "ask" }) as never,
       updateSettingsAsync: async () => {},
     },
+    tools: {
+      listTools: async () => [],
+      callTool: async () => ({ ok: false, error: "not used in this test" }),
+    },
   };
 }
 

--- a/src/backend/services/cli-bridge/cli-bridge-server.test.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.test.ts
@@ -56,6 +56,10 @@ function makeServices(): BridgeServices {
       getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: "ask" }),
       updateSettingsAsync: vi.fn(),
     },
+    tools: {
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ ok: false, error: "not used in this test" }),
+    },
   };
 }
 

--- a/src/backend/services/cli-bridge/cli-bridge-server.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.ts
@@ -153,7 +153,8 @@ export class CliBridgeServer {
       return;
     }
 
-    const result = await routeRequest(this.services, { method, path, body });
+    const query = Object.fromEntries(url.searchParams.entries());
+    const result = await routeRequest(this.services, { method, path, body, query });
     this.sendJson(res, result.status, result.body);
   }
 
@@ -309,11 +310,11 @@ export function createDefaultServices(): BridgeServices {
       },
     },
     tools: {
-      async listTools() {
-        return (await getToolBridge()).listTools();
+      async listTools(serverFilter) {
+        return (await getToolBridge()).listTools(serverFilter);
       },
-      async callTool(name, args) {
-        return (await getToolBridge()).callTool(name, args);
+      async callTool(name, args, serverFilter) {
+        return (await getToolBridge()).callTool(name, args, serverFilter);
       },
     },
   };

--- a/src/backend/services/cli-bridge/cli-bridge-server.ts
+++ b/src/backend/services/cli-bridge/cli-bridge-server.ts
@@ -12,6 +12,7 @@ import {
   type CliBridgeTokenFile,
 } from "../../../shared/cli-bridge/protocol";
 import { MCPServerManager } from "../mcp/mcp-server-manager";
+import { McpToolBridge } from "../mcp/mcp-tool-bridge";
 import { applyOpenAtLoginSetting } from "../settings/login-item";
 import { LlmStorage } from "../storage/llm-storage";
 import { UserSettingsStorage } from "../storage/user-settings-storage";
@@ -241,6 +242,15 @@ export class CliBridgeServer {
   getPort(): number | null {
     return this.port;
   }
+
+  /**
+   * The current bearer token, or null if not started. Used by the orchestrator to hand the
+   * `yakshaver mcp-serve` front-door a deterministic token (rather than relying on the token-file
+   * read racing app startup). NOT exposed over HTTP.
+   */
+  getToken(): string | null {
+    return this.token;
+  }
 }
 
 function safeStringEquals(a: string, b: string): boolean {
@@ -298,5 +308,21 @@ export function createDefaultServices(): BridgeServices {
         }
       },
     },
+    tools: {
+      async listTools() {
+        return (await getToolBridge()).listTools();
+      },
+      async callTool(name, args) {
+        return (await getToolBridge()).callTool(name, args);
+      },
+    },
   };
+}
+
+/** Build a {@link McpToolBridge} wired to the live singletons. */
+async function getToolBridge(): Promise<McpToolBridge> {
+  const manager = await MCPServerManager.getInstanceAsync();
+  return new McpToolBridge(manager, {
+    getSettingsAsync: () => UserSettingsStorage.getInstance().getSettingsAsync(),
+  });
 }

--- a/src/backend/services/cli-bridge/front-door.integration.test.ts
+++ b/src/backend/services/cli-bridge/front-door.integration.test.ts
@@ -1,0 +1,223 @@
+import { createServer, type Server as HttpServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { ToolSet } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { BridgeClient } from "../../../cli/bridge-client";
+import { callToolViaBridge, listToolsViaBridge } from "../../../cli/mcp-serve";
+import { McpToolBridge, type ToolBridgeManager } from "../mcp/mcp-tool-bridge";
+import { type BridgeServices, routeRequest } from "./bridge-router";
+
+/**
+ * CONNECTED-PATH integration test for the single `yakshaver` MCP front-door (#915).
+ *
+ * The unit suites each mock ONE side of a boundary. This one wires the WHOLE
+ * server-side chain end-to-end with NO mocks on the path under test, and drives it
+ * through the REAL `mcp-serve` proxy + REAL `BridgeClient` over a REAL localhost
+ * HTTP socket — exactly the bytes the spawned front-door exchanges with the app:
+ *
+ *   mcp-serve (listToolsViaBridge / callToolViaBridge)
+ *     → real BridgeClient (real fetch, real Bearer auth)
+ *       → real node:http server (real token check)
+ *         → real routeRequest (real Zod validation + envelope)
+ *           → real McpToolBridge (real flatten + approval policy + execute)
+ *             → in-memory ToolSet (a real internal/in-memory tool — the #915 win)
+ *
+ * The ONLY fake is the leaf `ToolBridgeManager`, standing in for the live
+ * `MCPServerManager` so the test needs neither Electron nor a real provider. It
+ * returns genuine AI-SDK-shaped tools (description + Zod inputSchema + execute),
+ * including an `Internal__*` in-memory tool and a tool that resolves to a native
+ * MCP `CallToolResult` with `isError:true` (an auth-denied call that does NOT
+ * throw) — the failure class that must not reach Claude as a success.
+ *
+ * No Claude/LLM is involved: this proves spawn→bridge→execute, the part the PR's
+ * deferred live e2e leaves unverified.
+ */
+
+const TOKEN = "integration-test-token";
+
+/** A real ToolSet: a GitHub tool, an INTERNAL in-memory tool, and a failing tool. */
+function makeToolSet(): ToolSet {
+  return {
+    GitHub__create_issue: {
+      description: "Create a GitHub issue",
+      inputSchema: z.object({ title: z.string() }),
+      execute: async (input: unknown) => {
+        const { title } = input as { title: string };
+        return { content: [{ type: "text", text: `Created issue: ${title}` }] };
+      },
+    },
+    // The #915 win: an internal/in-memory server tool, reachable here even though
+    // Claude Code can't reach it over its own transports.
+    Internal__fill_template: {
+      description: "Fill the internal template",
+      inputSchema: z.object({ name: z.string() }),
+      execute: async (input: unknown) => {
+        const { name } = input as { name: string };
+        return `Hello ${name}`;
+      },
+    },
+    // A tool whose underlying MCP call FAILS without throwing (auth-denied):
+    // resolves to a CallToolResult with isError:true.
+    GitHub__delete_repo: {
+      description: "Delete a repo (will be denied)",
+      inputSchema: z.object({ repo: z.string() }),
+      execute: async () => ({
+        isError: true,
+        content: [{ type: "text", text: "403 Forbidden: insufficient scopes" }],
+      }),
+    },
+  } as unknown as ToolSet;
+}
+
+function makeManager(whitelist: string[]): ToolBridgeManager {
+  const tools = makeToolSet();
+  return {
+    collectToolsWithServerPrefixAsync: async () => tools,
+    getWhitelistWithServerPrefixAsync: async () => whitelist,
+  };
+}
+
+/** Build the real BridgeServices, with only the tools front-door wired to a real bridge. */
+function makeServices(approvalMode: "yolo" | "ask" | "wait", whitelist: string[]): BridgeServices {
+  const bridge = new McpToolBridge(makeManager(whitelist), {
+    getSettingsAsync: async () => ({ toolApprovalMode: approvalMode }),
+  });
+  // Only the routes this test exercises need real backing; the rest can throw.
+  const notUsed = () => {
+    throw new Error("not part of the front-door path");
+  };
+  return {
+    mcp: {
+      listAvailableServers: notUsed,
+      addServerAsync: notUsed,
+      updateServerAsync: notUsed,
+      removeServerAsync: notUsed,
+      getServerByIdAsync: notUsed,
+    },
+    llm: { getLLMConfig: notUsed, storeLLMConfig: notUsed },
+    settings: { getSettingsAsync: notUsed, updateSettingsAsync: notUsed },
+    tools: {
+      listTools: () => bridge.listTools(),
+      callTool: (name: string, args?: Record<string, unknown>) => bridge.callTool(name, args),
+    },
+  } as unknown as BridgeServices;
+}
+
+/** Stand up a real localhost HTTP server running the real router with Bearer auth. */
+function startBridge(services: BridgeServices): Promise<{ server: HttpServer; port: number }> {
+  const server = createServer((req, res) => {
+    if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Unauthorized" }));
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", async () => {
+      const raw = Buffer.concat(chunks).toString("utf8").trim();
+      const body = raw ? JSON.parse(raw) : undefined;
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const result = await routeRequest(services, {
+        method: req.method ?? "GET",
+        path: url.pathname,
+        body,
+      });
+      const payload = JSON.stringify(result.body);
+      res.writeHead(result.status, { "Content-Type": "application/json" });
+      res.end(payload);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, port });
+    });
+  });
+}
+
+function makeClient(port: number): BridgeClient {
+  return new BridgeClient({
+    tokenLoader: async () => ({ port, token: TOKEN, startedAt: new Date().toISOString() }),
+  });
+}
+
+describe("front-door integration — mcp-serve → BridgeClient → router → McpToolBridge", () => {
+  let server: HttpServer;
+  let port: number;
+
+  afterEach(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function boot(mode: "yolo" | "ask" | "wait", whitelist: string[] = []) {
+    ({ server, port } = await startBridge(makeServices(mode, whitelist)));
+    return makeClient(port);
+  }
+
+  it("lists the full aggregated toolset INCLUDING the internal in-memory tool", async () => {
+    const client = await boot("yolo");
+    const { tools } = await listToolsViaBridge(client);
+
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toContain("GitHub__create_issue");
+    // The #915 headline win, proven over the real HTTP path (not a mock).
+    expect(names).toContain("Internal__fill_template");
+
+    const gh = tools.find((t) => t.name === "GitHub__create_issue");
+    expect(gh?.inputSchema).toMatchObject({ type: "object" });
+    expect((gh?.inputSchema as { properties?: Record<string, unknown> }).properties).toHaveProperty(
+      "title",
+    );
+  });
+
+  it("calls a provider tool end-to-end and returns its content (yolo)", async () => {
+    const client = await boot("yolo");
+    const result = await callToolViaBridge(client, "GitHub__create_issue", { title: "Bug" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "Created issue: Bug" }]);
+  });
+
+  it("calls the INTERNAL in-memory tool end-to-end (#915)", async () => {
+    const client = await boot("yolo");
+    const result = await callToolViaBridge(client, "Internal__fill_template", { name: "Ada" });
+    // A plain-string tool result is wrapped as text content with no error flag.
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toEqual([{ type: "text", text: "Hello Ada" }]);
+  });
+
+  it("surfaces an MCP-level isError (auth-denied) as a FAILURE, not a successful call", async () => {
+    const client = await boot("yolo");
+    const result = await callToolViaBridge(client, "GitHub__delete_repo", { repo: "x" });
+    // The execute() resolved (no throw) with isError:true — it must reach Claude as an error.
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: "403 Forbidden: insufficient scopes" }]);
+  });
+
+  it("refuses a non-whitelisted tool under 'ask' with a structured MCP isError (no hang)", async () => {
+    const client = await boot("ask", /* whitelist */ []);
+    const result = await callToolViaBridge(client, "GitHub__create_issue", { title: "Bug" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({ type: "text" });
+    expect((result.content[0] as { text?: string }).text).toMatch(/not approved/i);
+  });
+
+  it("runs a WHITELISTED tool under 'ask'", async () => {
+    const client = await boot("ask", ["GitHub__create_issue"]);
+    const result = await callToolViaBridge(client, "GitHub__create_issue", { title: "OK" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "Created issue: OK" }]);
+  });
+
+  it("rejects an unauthenticated request at the HTTP boundary", async () => {
+    await boot("yolo");
+    const badClient = new BridgeClient({
+      tokenLoader: async () => ({
+        port,
+        token: "wrong-token",
+        startedAt: new Date().toISOString(),
+      }),
+    });
+    await expect(listToolsViaBridge(badClient)).rejects.toThrow(/unauthorized/i);
+  });
+});

--- a/src/backend/services/cli-bridge/front-door.integration.test.ts
+++ b/src/backend/services/cli-bridge/front-door.integration.test.ts
@@ -73,7 +73,7 @@ function makeToolSet(): ToolSet {
 function makeManager(whitelist: string[]): ToolBridgeManager {
   const tools = makeToolSet();
   return {
-    collectToolsWithServerPrefixAsync: async () => tools,
+    collectToolsForSelectedServersAsync: async () => tools,
     getWhitelistWithServerPrefixAsync: async () => whitelist,
   };
 }
@@ -122,6 +122,7 @@ function startBridge(services: BridgeServices): Promise<{ server: HttpServer; po
         method: req.method ?? "GET",
         path: url.pathname,
         body,
+        query: Object.fromEntries(url.searchParams.entries()),
       });
       const payload = JSON.stringify(result.body);
       res.writeHead(result.status, { "Content-Type": "application/json" });
@@ -219,5 +220,30 @@ describe("front-door integration — mcp-serve → BridgeClient → router → M
       }),
     });
     await expect(listToolsViaBridge(badClient)).rejects.toThrow(/unauthorized/i);
+  });
+
+  it("forwards the front-door's serverFilter end-to-end to the manager (#915 project gate)", async () => {
+    // Capture what the real router/McpToolBridge passes through to the manager so we prove the
+    // `?serverFilter=` query (list) and body filter (call) survive the whole HTTP round-trip.
+    const seen: { list?: string[]; call?: string[] } = {};
+    const services = makeServices("yolo", []);
+    services.tools = {
+      async listTools(serverFilter) {
+        seen.list = serverFilter;
+        return [];
+      },
+      async callTool(_name, _args, serverFilter) {
+        seen.call = serverFilter;
+        return { ok: true, result: "ok" };
+      },
+    };
+    ({ server, port } = await startBridge(services));
+    const client = makeClient(port);
+
+    await listToolsViaBridge(client, ["proj-a", "proj-b"]);
+    await callToolViaBridge(client, "GitHub__create_issue", { title: "x" }, ["proj-a", "proj-b"]);
+
+    expect(seen.list).toEqual(["proj-a", "proj-b"]);
+    expect(seen.call).toEqual(["proj-a", "proj-b"]);
   });
 });

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -15,12 +15,16 @@ vi.mock("../../utils/error-utils", () => ({
 import type { MCPStep } from "../../../shared/types/mcp";
 import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 // vi.mock calls above are hoisted, so this static import sees the stubbed modules.
-import { LocalClaudeOrchestrator } from "./local-claude-orchestrator";
-import type { MCPServerConfig } from "./types";
+import {
+  LocalClaudeOrchestrator,
+  type OrchestratorServerManager,
+  stripFrontDoorPrefix,
+  YAKSHAVER_MCP_SERVER_KEY,
+  type YakshaverFrontDoorConfig,
+} from "./local-claude-orchestrator";
 
 type MockChild = ChildProcess & {
   stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
-  kill: ReturnType<typeof vi.fn>;
 };
 
 function createMockChild(): MockChild {
@@ -28,12 +32,10 @@ function createMockChild(): MockChild {
     stdout: EventEmitter;
     stderr: EventEmitter;
     stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
-    kill: ReturnType<typeof vi.fn>;
   };
   proc.stdout = new EventEmitter();
   proc.stderr = new EventEmitter();
   proc.stdin = { write: vi.fn(), end: vi.fn() };
-  proc.kill = vi.fn();
   return proc as unknown as MockChild;
 }
 
@@ -55,40 +57,22 @@ function makeSpawner(versionExitCode: number, runChild: MockChild, runScript?: (
   return { spawn };
 }
 
-function makeManager(servers: MCPServerConfig[]) {
-  return { listAvailableServers: vi.fn().mockResolvedValue(servers) };
+/** A manager mock exposing the new orchestrator surface: the prefixed whitelist + a warm hook. */
+function makeManager(whitelist: string[] = []): OrchestratorServerManager {
+  return {
+    getWhitelistWithServerPrefixAsync: vi.fn().mockResolvedValue(whitelist),
+    collectToolsWithServerPrefixAsync: vi.fn().mockResolvedValue({}),
+  };
 }
 
 function makeSettings(mode: ToolApprovalMode) {
   return { getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: mode }) };
 }
 
-function makeTokenStorage(tokenByServer: Record<string, string> = {}) {
-  return {
-    getTokensAsync: vi.fn(async (serverId: string) =>
-      tokenByServer[serverId] ? { access_token: tokenByServer[serverId] } : undefined,
-    ),
-  };
-}
-
-const httpServer: MCPServerConfig = {
-  id: "gh-1",
-  name: "GitHub",
-  transport: "streamableHttp",
-  url: "https://mcp.github.test/",
-  toolWhitelist: ["create_issue"],
-  enabled: true,
-};
-
-const stdioServer: MCPServerConfig = {
-  id: "fs-1",
-  name: "Local FS",
-  transport: "stdio",
-  command: "npx",
-  args: ["-y", "fs-mcp"],
-  env: { FOO: "bar" },
-  toolWhitelist: ["read_file"],
-  enabled: true,
+const frontDoor: YakshaverFrontDoorConfig = {
+  command: "/path/to/node",
+  cliEntryPath: "/app/dist/cli/index.js",
+  env: { ELECTRON_RUN_AS_NODE: "1", YAKSHAVER_BRIDGE_PORT: "8765", YAKSHAVER_BRIDGE_TOKEN: "tok" },
 };
 
 describe("LocalClaudeOrchestrator", () => {
@@ -99,24 +83,23 @@ describe("LocalClaudeOrchestrator", () => {
   });
 
   describe("claude availability", () => {
-    it("throws a clear 'exited with an error' message when `claude --version` exits non-zero", async () => {
+    it("throws a clear error when `claude` is not found (--version fails)", async () => {
       const { spawn } = makeSpawner(/* versionExitCode */ 127, runChild);
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("ask"),
         { generateObject: vi.fn() },
       );
 
-      // The binary launched (close fired) but exited non-zero — distinguished from a PATH miss.
       await expect(orch.manualLoopAsync("transcript", undefined, {})).rejects.toThrow(
-        /exited with an error/,
+        /Claude Code CLI was found but `claude --version` exited with an error/,
       );
     });
 
-    it("throws a 'could not be launched' error when spawning `claude --version` errors (ENOENT)", async () => {
+    it("throws a clear error when spawning `claude --version` errors (ENOENT)", async () => {
       const versionChild = createMockChild();
       const spawn = vi.fn((_cmd: string, args: string[]) => {
         if (args.includes("--version")) {
@@ -128,141 +111,79 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("ask"),
         { generateObject: vi.fn() },
       );
 
       await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
-        /could not be launched/,
+        /Claude Code CLI could not be launched/,
       );
     });
   });
 
-  describe("MCP config serialization", () => {
-    it("serializes stdio (command/args/env) and http (url + injected bearer token)", async () => {
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn: vi.fn() },
-        makeManager([stdioServer, httpServer]),
-        makeTokenStorage({ "gh-1": "tok-123" }),
-        makeSettings("ask"),
-        { generateObject: vi.fn() },
-      );
+  describe("single-entry yakshaver MCP config (#915 front-door)", () => {
+    it("writes ONE mcp server entry: yakshaver -> the mcp-serve front-door", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const config = orch.buildMcpConfig(frontDoor);
 
-      const { mcpConfig, allowedTools } = await orch.serializeMcpServers(
-        makeManager([stdioServer, httpServer]),
-        undefined,
-      );
-
-      expect(mcpConfig.mcpServers).toEqual({
-        Local_FS: {
-          type: "stdio",
-          command: "npx",
-          args: ["-y", "fs-mcp"],
-          env: { FOO: "bar" },
-        },
-        GitHub: {
-          type: "http",
-          url: "https://mcp.github.test/",
-          headers: { Authorization: "Bearer tok-123" },
+      expect(Object.keys(config.mcpServers)).toEqual([YAKSHAVER_MCP_SERVER_KEY]);
+      expect(config.mcpServers.yakshaver).toEqual({
+        type: "stdio",
+        command: "/path/to/node",
+        args: ["/app/dist/cli/index.js", "mcp-serve"],
+        env: {
+          ELECTRON_RUN_AS_NODE: "1",
+          YAKSHAVER_BRIDGE_PORT: "8765",
+          YAKSHAVER_BRIDGE_TOKEN: "tok",
         },
       });
-      expect(allowedTools).toEqual(["mcp__Local_FS__read_file", "mcp__GitHub__create_issue"]);
     });
 
-    it("respects the serverFilter and skips disabled + inMemory servers", async () => {
-      const disabled: MCPServerConfig = { ...stdioServer, id: "off", name: "Off", enabled: false };
-      const internal: MCPServerConfig = {
-        id: "in",
-        name: "Internal",
-        transport: "inMemory",
-        enabled: true,
+    it("omits env when the front-door has none", () => {
+      const orch = new LocalClaudeOrchestrator();
+      const config = orch.buildMcpConfig({
+        command: "node",
+        cliEntryPath: "/app/dist/cli/index.js",
+      });
+      expect(config.mcpServers.yakshaver).not.toHaveProperty("env");
+    });
+
+    it("re-prefixes the app's whitelist as mcp__yakshaver__<Server__tool>", async () => {
+      const orch = new LocalClaudeOrchestrator();
+      const manager = makeManager(["GitHub__create_issue", "Internal__fill_template"]);
+
+      const allowed = await orch.buildAllowedTools(manager);
+
+      expect(manager.collectToolsWithServerPrefixAsync).toHaveBeenCalledOnce();
+      expect(allowed).toEqual([
+        "mcp__yakshaver__GitHub__create_issue",
+        "mcp__yakshaver__Internal__fill_template",
+      ]);
+    });
+
+    it("warming failure is non-fatal; the stored whitelist still applies", async () => {
+      const orch = new LocalClaudeOrchestrator();
+      const manager: OrchestratorServerManager = {
+        getWhitelistWithServerPrefixAsync: vi.fn().mockResolvedValue(["GitHub__create_issue"]),
+        collectToolsWithServerPrefixAsync: vi.fn().mockRejectedValue(new Error("no servers")),
       };
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn: vi.fn() },
-        null,
-        makeTokenStorage(),
-      );
-      const mgr = makeManager([stdioServer, httpServer, disabled, internal]);
-
-      const { mcpConfig } = await orch.serializeMcpServers(mgr, ["gh-1"]);
-      expect(Object.keys(mcpConfig.mcpServers)).toEqual(["GitHub"]);
-    });
-
-    it("refreshes an expired OAuth token before injecting it (no stale Bearer header)", async () => {
-      // A refreshable storage whose stored token is expired but has a refresh_token: the helper
-      // must refresh it and inject the NEW access token, matching the in-process client.
-      const refreshableStorage = {
-        getTokensAsync: vi
-          .fn()
-          .mockResolvedValueOnce({
-            access_token: "stale",
-            refresh_token: "r1",
-            expires_in: 3600,
-            storedAt: 1, // long expired
-          })
-          .mockResolvedValue({ access_token: "fresh", refresh_token: "r2", token_type: "Bearer" }),
-        isTokenExpired: vi.fn().mockReturnValue(true),
-        saveTokensAsync: vi.fn().mockResolvedValue(undefined),
-        clearTokensAsync: vi.fn().mockResolvedValue(undefined),
-      };
-      // Stub the backend refresh call the helper invokes.
-      const refreshMod = await import("./mcp-oauth");
-      const refreshSpy = vi
-        .spyOn(refreshMod, "refreshTokenWithBackend")
-        .mockResolvedValue({ access_token: "fresh", refresh_token: "r2", token_type: "Bearer" });
-
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn: vi.fn() },
-        null,
-        refreshableStorage,
-      );
-
-      const { mcpConfig } = await orch.serializeMcpServers(makeManager([httpServer]), undefined);
-      expect(refreshSpy).toHaveBeenCalledWith("https://mcp.github.test/", "r1");
-      expect(refreshableStorage.saveTokensAsync).toHaveBeenCalled();
-      expect((mcpConfig.mcpServers.GitHub as { headers?: Record<string, string> }).headers).toEqual(
-        { Authorization: "Bearer fresh" },
-      );
-      refreshSpy.mockRestore();
-    });
-
-    it("flags servers with no whitelist (under ask/wait) instead of hanging", async () => {
-      const noWhitelist: MCPServerConfig = { ...httpServer, toolWhitelist: [] };
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn: vi.fn() },
-        null,
-        makeTokenStorage(),
-      );
-      const { skippedNonWhitelistedServers, allowedTools } = await orch.serializeMcpServers(
-        makeManager([noWhitelist]),
-        undefined,
-      );
-      expect(skippedNonWhitelistedServers).toEqual(["GitHub"]);
-      expect(allowedTools).toEqual([]);
+      const allowed = await orch.buildAllowedTools(manager);
+      expect(allowed).toEqual(["mcp__yakshaver__GitHub__create_issue"]);
     });
   });
 
   describe("argv building per approval mode", () => {
-    it("always passes the serialized config strictly + the system prompt file", () => {
+    it("always passes --strict-mcp-config + the single --mcp-config", () => {
       const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", []);
-      // --strict-mcp-config keeps the run to YakShaver's servers only (no ambient .mcp.json).
-      expect(argv).toContain("--strict-mcp-config");
-      // The orchestrator role is delivered as the system prompt, not as the user turn.
-      const sysIdx = argv.indexOf("--system-prompt-file");
-      expect(sysIdx).toBeGreaterThan(-1);
-      expect(argv[sysIdx + 1]).toBe("/tmp/sys.txt");
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/prompt.txt", "yolo", []);
       expect(argv).toEqual(
         expect.arrayContaining([
           "-p",
           "--mcp-config",
           "/tmp/cfg.json",
+          "--strict-mcp-config",
           "--output-format",
           "stream-json",
           "--verbose",
@@ -270,62 +191,37 @@ describe("LocalClaudeOrchestrator", () => {
       );
     });
 
-    it("passes --max-turns as the iteration safety cap (default 20, override honoured)", () => {
-      const orch = new LocalClaudeOrchestrator();
-      const def = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", []);
-      const defIdx = def.indexOf("--max-turns");
-      expect(defIdx).toBeGreaterThan(-1);
-      expect(def[defIdx + 1]).toBe("20");
-
-      const custom = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", [], 5);
-      const customIdx = custom.indexOf("--max-turns");
-      expect(customIdx).toBeGreaterThan(-1);
-      expect(custom[customIdx + 1]).toBe("5");
-    });
-
     it("yolo -> --permission-mode bypassPermissions (no --allowedTools)", () => {
       const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "yolo", [
-        "mcp__GitHub__create_issue",
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/prompt.txt", "yolo", [
+        "mcp__yakshaver__GitHub__create_issue",
       ]);
       expect(argv).toContain("--permission-mode");
       expect(argv).toContain("bypassPermissions");
       expect(argv).not.toContain("--allowedTools");
     });
 
-    it("wait -> --permission-mode bypassPermissions (matches OpenAI's auto-approve-after-delay)", () => {
+    it("ask -> --allowedTools built from the yakshaver-prefixed whitelist", () => {
       const orch = new LocalClaudeOrchestrator();
-      // wait auto-approves non-whitelisted tools after a delay on the OpenAI path; the headless
-      // analogue that still RUNS them is bypassPermissions, not a hard deny.
-      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "wait", []);
-      expect(argv).toContain("--permission-mode");
-      expect(argv).toContain("bypassPermissions");
-      expect(argv).not.toContain("--allowedTools");
-      expect(argv).not.toContain("dontAsk");
-    });
-
-    it("ask -> --permission-mode dontAsk + --allowedTools (denies non-whitelisted, never hangs)", () => {
-      const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "ask", [
-        "mcp__GitHub__create_issue",
-        "mcp__Local_FS__read_file",
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/prompt.txt", "ask", [
+        "mcp__yakshaver__GitHub__create_issue",
+        "mcp__yakshaver__Local_FS__read_file",
       ]);
-      // dontAsk converts any approval prompt into a denial so a headless run can't block.
-      const pmIdx = argv.indexOf("--permission-mode");
-      expect(pmIdx).toBeGreaterThan(-1);
-      expect(argv[pmIdx + 1]).toBe("dontAsk");
       const idx = argv.indexOf("--allowedTools");
       expect(idx).toBeGreaterThan(-1);
-      expect(argv[idx + 1]).toBe("mcp__GitHub__create_issue,mcp__Local_FS__read_file");
+      expect(argv[idx + 1]).toBe(
+        "mcp__yakshaver__GitHub__create_issue,mcp__yakshaver__Local_FS__read_file",
+      );
       expect(argv).not.toContain("bypassPermissions");
     });
 
-    it("ask with empty whitelist -> dontAsk and no --allowedTools (no MCP tools run, no hang)", () => {
+    it("wait -> --permission-mode bypassPermissions (headless can't defer the prompt)", () => {
       const orch = new LocalClaudeOrchestrator();
-      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/sys.txt", "ask", []);
-      expect(argv).toContain("dontAsk");
+      const argv = orch.buildArgv("/tmp/cfg.json", "/tmp/prompt.txt", "wait", []);
+      // main maps `wait` -> bypassPermissions (headless can't show the deferred dialog), so an empty
+      // whitelist still runs every tool. There is no --allowedTools because none was passed.
       expect(argv).not.toContain("--allowedTools");
-      expect(argv).not.toContain("bypassPermissions");
+      expect(argv).toContain("bypassPermissions");
     });
   });
 
@@ -348,8 +244,6 @@ describe("LocalClaudeOrchestrator", () => {
         reasoning: "created",
       });
 
-      // Realistic stream: the tool_use block carries an OPAQUE id; the tool_result references it
-      // only via tool_use_id (NOT the tool name). The orchestrator must correlate id -> name.
       const lines = [
         JSON.stringify({
           type: "assistant",
@@ -361,8 +255,10 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_use",
-                id: "toolu_01ABCdef",
-                name: "mcp__GitHub__create_issue",
+                // Real Claude Code stream-json carries an OPAQUE id here, NOT the tool name.
+                // Through the single front-door the name is `mcp__yakshaver__<Server>__<tool>`.
+                id: "toolu_01ABCdef234567",
+                name: "mcp__yakshaver__GitHub__create_issue",
                 input: { title: "Bug" },
               },
             ],
@@ -374,7 +270,8 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_result",
-                tool_use_id: "toolu_01ABCdef",
+                // The result references the tool_use block by its opaque id — never by tool name.
+                tool_use_id: "toolu_01ABCdef234567",
                 content: "Created issue #5: https://github.com/o/r/issues/5",
               },
             ],
@@ -391,8 +288,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([httpServer]),
-        makeTokenStorage({ "gh-1": "tok" }),
+        makeManager(["GitHub__create_issue"]),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject },
       );
@@ -401,7 +298,7 @@ describe("LocalClaudeOrchestrator", () => {
         onStep: (s) => steps.push(s),
       });
 
-      // stdin received only the transcript as the user turn (the system prompt goes via argv).
+      // stdin received the system prompt + transcript
       expect(runChild.stdin.write).toHaveBeenCalled();
       const written = (runChild.stdin.write as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(written).toContain("video transcription: a bug report");
@@ -412,20 +309,28 @@ describe("LocalClaudeOrchestrator", () => {
       expect(types).toContain("tool_result");
       expect(types).toContain("final_result");
 
-      // Reasoning is emitted JSON-encoded ({type,text}) so ReasoningStep renders it (not blank).
+      // Reasoning is wrapped so the UI's <ReasoningStep> (which JSON.parses + renders .text) shows
+      // the text instead of a blank box.
       const reasoningStep = steps.find((s) => s.type === "reasoning");
-      expect(JSON.parse(reasoningStep?.reasoning ?? "{}")).toEqual({
-        type: "text",
+      expect(reasoningStep?.reasoning).toBeDefined();
+      expect(JSON.parse(reasoningStep?.reasoning as string)).toMatchObject({
         text: "I'll create an issue.",
       });
 
-      // The judge must receive the REAL tool name, correlated from the opaque tool_use_id — not
-      // the opaque `toolu_...` id itself.
-      const judgePrompt = generateObject.mock.calls[0][0] as string;
-      expect(judgePrompt).toContain("mcp__GitHub__create_issue");
-      expect(judgePrompt).not.toContain("toolu_01ABCdef");
+      // The single-front-door prefix is stripped from the displayed tool name so it reads as the
+      // real `Server__tool` rather than mis-parsing the server as `mcp`.
+      const toolCallStep = steps.find((s) => s.type === "tool_call");
+      expect(toolCallStep?.toolName).toBe("GitHub__create_issue");
 
       expect(generateObject).toHaveBeenCalledTimes(1);
+      // The judge must see the human-readable tool name (correlated from the opaque tool_use_id),
+      // NOT the raw `toolu_...` id — this is the #833 ground-truth signal. The front-door prefix is
+      // stripped so the judge sees the same `Server__tool` name the OpenAI loop uses.
+      const judgePrompt = (generateObject as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(judgePrompt).toContain("GitHub__create_issue");
+      expect(judgePrompt).not.toContain("mcp__yakshaver__");
+      expect(judgePrompt).not.toContain("toolu_01ABCdef234567");
+
       expect(result.backlogActionSucceeded).toBe(true);
       expect(result.terminationReason).toBe("stop");
       expect(result.artifacts).toEqual([
@@ -443,7 +348,7 @@ describe("LocalClaudeOrchestrator", () => {
             content: [
               {
                 type: "tool_result",
-                tool_use_id: "mcp__GitHub__create_issue",
+                tool_use_id: "toolu_01ERRoredcall99",
                 is_error: true,
                 content: "401 Unauthorized",
               },
@@ -456,8 +361,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([httpServer]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject },
       );
@@ -473,102 +378,14 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject: vi.fn() },
       );
 
       const result = await orch.manualLoopAsync("t", undefined, {});
       expect(result.terminationReason).toBe("max-iterations");
-    });
-
-    it("no judge model + a tool succeeded -> verificationUnavailable (not the generic failure)", async () => {
-      // A user picked Claude Code without configuring an OpenAI/Azure model: the judge is null.
-      // The run must NOT silently report a plain failure — it should flag verificationUnavailable
-      // so the handler tells the user an item MAY have been created instead of "signed out".
-      const lines = [
-        JSON.stringify({
-          type: "user",
-          message: {
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "mcp__GitHub__create_issue",
-                content: "Created issue #7: https://github.com/o/r/issues/7",
-              },
-            ],
-          },
-        }),
-        JSON.stringify({ type: "result", subtype: "success", result: "Done." }),
-      ];
-      const { spawn } = makeSpawner(0, runChild, streamScript(runChild, lines));
-      // No judge provider passed (null) — mirrors "no language model configured".
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn },
-        makeManager([httpServer]),
-        makeTokenStorage(),
-        makeSettings("yolo"),
-        null,
-      );
-
-      const steps: MCPStep[] = [];
-      const result = await orch.manualLoopAsync("t", undefined, { onStep: (s) => steps.push(s) });
-
-      expect(result.backlogActionSucceeded).toBe(false);
-      expect(result.verificationUnavailable).toBe(true);
-      // The user-facing reasoning notice explains the real cause.
-      const reasoning = steps
-        .filter((s) => s.type === "reasoning")
-        .map((s) => s.reasoning ?? "")
-        .join(" ");
-      expect(reasoning).toMatch(/could NOT be verified/i);
-    });
-
-    it("kills the child and rejects when the caller's AbortSignal fires mid-run", async () => {
-      const controller = new AbortController();
-      // A run child that never closes on its own; aborting must kill it and reject.
-      const abortScript = () => {
-        runChild.stdout?.emit("data", Buffer.from(`${JSON.stringify({ type: "assistant" })}\n`));
-        controller.abort();
-      };
-      const { spawn } = makeSpawner(0, runChild, abortScript);
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn },
-        makeManager([]),
-        makeTokenStorage(),
-        makeSettings("yolo"),
-        { generateObject: vi.fn() },
-      );
-
-      await expect(
-        orch.manualLoopAsync("t", undefined, { signal: controller.signal }),
-      ).rejects.toThrow(/cancelled/i);
-      expect(runChild.kill).toHaveBeenCalled();
-    });
-
-    it("kills the child and rejects when the wall-clock run timeout elapses", async () => {
-      // A run child that emits a line but never closes — only the wall-clock timeout can end it.
-      // Real timers (not fake) because the orchestrator does real fs.writeFile before spawning the
-      // run child, which fake timers can't advance past. A tiny 20ms timeout keeps it fast.
-      const stallScript = () => {
-        runChild.stdout?.emit("data", Buffer.from(`${JSON.stringify({ type: "assistant" })}\n`));
-      };
-      const { spawn } = makeSpawner(0, runChild, stallScript);
-      const orch = new LocalClaudeOrchestrator(
-        "claude",
-        { spawn },
-        makeManager([]),
-        makeTokenStorage(),
-        makeSettings("yolo"),
-        { generateObject: vi.fn() },
-        20,
-      );
-
-      await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(/timed out/i);
-      expect(runChild.kill).toHaveBeenCalled();
     });
 
     it("rejects when the process exits non-zero before any result event", async () => {
@@ -580,8 +397,8 @@ describe("LocalClaudeOrchestrator", () => {
       const orch = new LocalClaudeOrchestrator(
         "claude",
         { spawn },
-        makeManager([]),
-        makeTokenStorage(),
+        makeManager(),
+        frontDoor,
         makeSettings("yolo"),
         { generateObject: vi.fn() },
       );
@@ -589,6 +406,19 @@ describe("LocalClaudeOrchestrator", () => {
       await expect(orch.manualLoopAsync("t", undefined, {})).rejects.toThrow(
         /Claude Code process exited with code 1/,
       );
+    });
+  });
+
+  describe("stripFrontDoorPrefix", () => {
+    it("strips the mcp__yakshaver__ front-door prefix so the real Server__tool remains", () => {
+      expect(stripFrontDoorPrefix(`mcp__${YAKSHAVER_MCP_SERVER_KEY}__GitHub__issue_write`)).toBe(
+        "GitHub__issue_write",
+      );
+    });
+
+    it("leaves non-front-door (Claude built-in) tool names unchanged", () => {
+      expect(stripFrontDoorPrefix("Read")).toBe("Read");
+      expect(stripFrontDoorPrefix("mcp__other__Foo__bar")).toBe("mcp__other__Foo__bar");
     });
   });
 });

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -3,11 +3,11 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { CLI_BRIDGE_PORT_ENV, CLI_BRIDGE_TOKEN_ENV } from "../../../shared/cli-bridge/protocol";
 import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 import { getDurationParts } from "../../utils/duration-utils";
 import type { VideoUploadResult } from "../auth/types";
 import type { IProcessSpawner } from "../process/process-spawner";
-import { McpOAuthTokenStorage } from "../storage/mcp-oauth-token-storage";
 import { UserSettingsStorage } from "../storage/user-settings-storage";
 import {
   type IBacklogOrchestrator,
@@ -20,9 +20,7 @@ import {
 } from "./backlog-orchestrator";
 import { LanguageModelProvider } from "./language-model-provider";
 import { MCPServerManager } from "./mcp-server-manager";
-import { getFreshAccessTokenAsync, type RefreshableTokenStorage } from "./mcp-token-refresh";
 import { orchestratorSystemPrompt } from "./prompts";
-import type { MCPServerConfig } from "./types";
 
 /** Default safety cap on tool iterations when the caller doesn't supply one (mirrors the OpenAI loop). */
 const DEFAULT_MAX_TOOL_ITERATIONS = 20;
@@ -69,41 +67,74 @@ export interface ClaudeMcpConfigFile {
   mcpServers: Record<string, ClaudeMcpServer>;
 }
 
-/**
- * Token lookup the orchestrator needs. A bare `getTokensAsync` is enough for tests; the real
- * `McpOAuthTokenStorage` also provides the optional refresh hooks (`isTokenExpired` /
- * `saveTokensAsync` / `clearTokensAsync`) so expired tokens are refreshed before use — see
- * `getFreshAccessTokenAsync`.
- */
-export type TokenLookup = RefreshableTokenStorage;
+/** Fixed MCP server key for the single front-door. Tools appear as `mcp__yakshaver__<Server__tool>`. */
+export const YAKSHAVER_MCP_SERVER_KEY = "yakshaver";
 
-/** Claude Code's tool name format is `mcp__<server>__<tool>`. Server names are sanitized to match. */
-function sanitizeServerName(name: string): string {
-  return name.replace(/\s+/g, "_");
+/** The prefix Claude Code prepends to every front-door tool, e.g. `mcp__yakshaver__GitHub__issue`. */
+const FRONT_DOOR_TOOL_PREFIX = `mcp__${YAKSHAVER_MCP_SERVER_KEY}__`;
+
+/**
+ * Strip the `mcp__yakshaver__` front-door prefix so the real server-prefixed name (`Server__tool`)
+ * is what the judge, tool activity, and UI see — Claude reports tools by their front-door name, but
+ * everything downstream expects the same `Server__tool` names the OpenAI loop uses. Non-front-door
+ * names (Claude built-ins like `Read`) are returned unchanged.
+ */
+export function stripFrontDoorPrefix(toolName: string): string {
+  return toolName.startsWith(FRONT_DOOR_TOOL_PREFIX)
+    ? toolName.slice(FRONT_DOOR_TOOL_PREFIX.length)
+    : toolName;
 }
 
 /**
+ * How to spawn the single `yakshaver mcp-serve` front-door (#915), and how the spawned process
+ * reaches the running app's bridge.
+ *
+ * Injectable so the argv/config unit tests stay pure (no Electron `app`, no `process.execPath`, no
+ * live bridge). The real value is resolved from the Electron app + the running `CliBridgeServer` at
+ * call time.
+ */
+export interface YakshaverFrontDoorConfig {
+  /** Executable that runs the CLI (Electron-as-node in prod, or `node` in tests). */
+  command: string;
+  /** Path to the built CLI entry (`dist/cli/index.js`). The `mcp-serve` arg is appended. */
+  cliEntryPath: string;
+  /** Extra env to pass to the front-door process (bridge port/token, ELECTRON_RUN_AS_NODE). */
+  env?: Record<string, string>;
+}
+
+/**
+ * The MCPServerManager surface the orchestrator now needs: the prefixed whitelist (authoritative
+ * client-side gate) plus an optional tool-collection call to warm the internal clients so built-in
+ * tools are reflected in the whitelist.
+ */
+export type OrchestratorServerManager = Pick<
+  MCPServerManager,
+  "getWhitelistWithServerPrefixAsync"
+> &
+  Partial<Pick<MCPServerManager, "collectToolsWithServerPrefixAsync">>;
+
+/**
  * Drives the backlog-creation step with a local headless `claude -p` process instead of the
- * in-process OpenAI loop. Serializes the enabled MCP servers to a temp `--mcp-config`, maps the
- * tool-approval mode to Claude's permission flags, streams `stream-json` events to `onStep`, and
- * reuses the shared `judgeBacklogOutcome` on the collected tool results.
+ * in-process OpenAI loop.
+ *
+ * As of #915 it no longer serializes each MCP server (and skips internal ones); instead it writes
+ * a SINGLE `--mcp-config` entry — the `yakshaver` MCP front-door — which proxies the app's full
+ * aggregated toolset (including internal/in-memory servers) over the localhost bridge. It still
+ * maps the tool-approval mode to Claude's permission flags, streams `stream-json` events to
+ * `onStep`, and reuses the shared `judgeBacklogOutcome` on the collected tool results.
  */
 export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
   // Storage deps are resolved lazily — only when actually needed — so constructing the orchestrator
-  // (and the argv/serialization unit tests that do) never touches the electron-backed singletons.
+  // (and the argv/config unit tests that do) never touches the electron-backed singletons.
   constructor(
     private readonly claudeCommand: string = "claude",
     private readonly spawner: IProcessSpawner = defaultClaudeSpawner,
-    private readonly serverManager: Pick<MCPServerManager, "listAvailableServers"> | null = null,
-    private readonly tokenStorage: TokenLookup | null = null,
+    private readonly serverManager: OrchestratorServerManager | null = null,
+    private readonly frontDoor: YakshaverFrontDoorConfig | null = null,
     private readonly settingsStorage: Pick<UserSettingsStorage, "getSettingsAsync"> | null = null,
     private readonly judgeProvider: OutcomeJudgeProvider | null = null,
     private readonly runTimeoutMs: number = DEFAULT_RUN_TIMEOUT_MS,
   ) {}
-
-  private getTokenStorage(): TokenLookup {
-    return this.tokenStorage ?? McpOAuthTokenStorage.getInstance();
-  }
 
   private getSettingsStorage(): Pick<UserSettingsStorage, "getSettingsAsync"> {
     return this.settingsStorage ?? UserSettingsStorage.getInstance();
@@ -152,6 +183,7 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
     await this.ensureClaudeAvailable();
 
     const manager = this.serverManager ?? (await MCPServerManager.getInstanceAsync());
+    const frontDoor = this.frontDoor ?? (await resolveFrontDoorConfig());
     const approvalMode = (await this.getSettingsStorage().getSettingsAsync()).toolApprovalMode;
 
     const systemPrompt = this.buildSystemPrompt(
@@ -161,15 +193,14 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
       options.videoFilePath,
     );
 
-    const { mcpConfig, allowedTools, skippedNonWhitelistedServers, droppedInMemoryServers } =
-      await this.serializeMcpServers(manager, options.serverFilter);
+    // #915: one front-door entry proxies the app's full aggregated toolset (incl. internal/in-memory
+    // servers), so there is no per-server serialization, skip, or in-memory drop anymore.
+    // NOTE: `options.serverFilter` does NOT apply to this backend — the front-door always exposes the
+    // app's whole toolset; per-tool gating happens via the approval whitelist below, not a server filter.
+    const mcpConfig = this.buildMcpConfig(frontDoor);
+    const allowedTools = await this.buildAllowedTools(manager);
 
-    this.surfaceServerNotices(
-      approvalMode,
-      skippedNonWhitelistedServers,
-      droppedInMemoryServers,
-      options.onStep,
-    );
+    this.surfaceServerNotices(approvalMode, allowedTools, options.onStep);
 
     const tmpConfigPath = join(tmpdir(), `yakshaver-mcp-${randomUUID()}.json`);
     const tmpPromptPath = join(tmpdir(), `yakshaver-sysprompt-${randomUUID()}.txt`);
@@ -204,20 +235,27 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
   }
 
   /**
-   * Surfaces server-selection caveats to both the log and the UI (via an onStep notice) so the
-   * user understands why a tool/server may be unavailable under the local backend — rather than
-   * seeing a silent run that quietly does less than the OpenAI path would.
+   * Surfaces approval-mode caveats to both the log and the UI (via an onStep notice) so the user
+   * understands why tools may be unavailable under the local backend — rather than seeing a silent
+   * run that quietly does less than the OpenAI path would.
+   *
+   * As of #915 the front-door proxies ALL servers (incl. internal/in-memory ones), so there is no
+   * per-server skip or in-memory-drop notice anymore — only the approval-mode caveats remain.
    */
   private surfaceServerNotices(
     approvalMode: ToolApprovalMode,
-    skippedNonWhitelistedServers: string[],
-    droppedInMemoryServers: string[],
+    allowedTools: string[],
     onStep?: ManualLoopOptions["onStep"],
   ): void {
     const notices: string[] = [];
 
-    if (skippedNonWhitelistedServers.length > 0 && approvalMode === "ask") {
-      const msg = `Claude Code (local) only runs whitelisted tools under "ask" approval mode (no runtime approval prompt). These server(s) have no whitelisted tools, so their tools were not made available: ${skippedNonWhitelistedServers.join(", ")}.`;
+    // Under "ask" only whitelisted tools auto-approve and nothing prompts; an empty whitelist means
+    // no MCP tools can run at all, so warn rather than letting the run silently do nothing.
+    if (approvalMode === "ask" && allowedTools.length === 0) {
+      const msg =
+        'Claude Code (local) only runs whitelisted tools under "ask" approval mode (no runtime ' +
+        "approval prompt), and no tools are currently whitelisted — so no MCP tools will run. " +
+        'Whitelist tools in YakShaver, or switch the approval mode to "yolo".';
       notices.push(msg);
       console.warn(`[LocalClaudeOrchestrator] ${msg}`);
     }
@@ -231,12 +269,6 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
         'Claude Code (local) cannot show the "wait" approval dialog because it runs headlessly, ' +
         "so under this backend every tool runs immediately without a chance to deny (the same as " +
         '"YOLO"). Switch to "ask" to restrict the run to whitelisted tools only.';
-      notices.push(msg);
-      console.warn(`[LocalClaudeOrchestrator] ${msg}`);
-    }
-
-    if (droppedInMemoryServers.length > 0) {
-      const msg = `Claude Code (local) cannot reach YakShaver's built-in in-memory tools, so these are unavailable under this backend (e.g. screenshot capture): ${droppedInMemoryServers.join(", ")}.`;
       notices.push(msg);
       console.warn(`[LocalClaudeOrchestrator] ${msg}`);
     }
@@ -290,98 +322,40 @@ Embed this URL in the task content that you create. Follow user requirements STR
   }
 
   /**
-   * Serializes the enabled MCP servers (respecting `serverFilter`) into Claude Code's
-   * `--mcp-config` format. stdio → {command,args,env}; streamableHttp → {url, headers} with the
-   * OAuth bearer token injected from token storage when present. Also returns the `--allowedTools`
-   * derived from each server's whitelist (used under ask/wait approval modes).
+   * Builds the SINGLE-entry `--mcp-config` (#915): one `yakshaver` MCP server that proxies the
+   * app's full aggregated toolset over the localhost bridge. No per-server serialization and no
+   * OAuth-token injection here — the front-door reaches the app, which applies its own auth.
+   *
+   * The resulting tools appear to Claude as `mcp__yakshaver__<Server__tool>`.
    */
-  public async serializeMcpServers(
-    manager: Pick<MCPServerManager, "listAvailableServers">,
-    serverFilter?: string[],
-  ): Promise<{
-    mcpConfig: ClaudeMcpConfigFile;
-    allowedTools: string[];
-    skippedNonWhitelistedServers: string[];
-    droppedInMemoryServers: string[];
-  }> {
-    const all = await manager.listAvailableServers();
-    const filterSet = serverFilter && serverFilter.length > 0 ? new Set(serverFilter) : null;
-
-    const selected = all.filter((c) => {
-      if (c.enabled === false) return false;
-      if (!filterSet) return true;
-      return filterSet.has(c.id) || filterSet.has(c.name);
-    });
-
-    const mcpServers: Record<string, ClaudeMcpServer> = {};
-    const allowedTools: string[] = [];
-    const skippedNonWhitelistedServers: string[] = [];
-    const droppedInMemoryServers: string[] = [];
-
-    for (const config of selected) {
-      // inMemory servers are YakShaver-internal (e.g. Yak_Video_Tools' screenshot capture); Claude
-      // Code can't reach them over its own transports, so they're dropped for the local backend.
-      // Surface them so the caller can warn the user that the local backend lacks those tools.
-      if (config.transport === "inMemory") {
-        droppedInMemoryServers.push(config.name);
-        continue;
-      }
-
-      const serverKey = sanitizeServerName(config.name);
-      const entry = await this.toClaudeServerEntry(config);
-      if (!entry) continue;
-      mcpServers[serverKey] = entry;
-
-      const whitelist = config.toolWhitelist ?? [];
-      if (whitelist.length === 0) {
-        skippedNonWhitelistedServers.push(config.name);
-      }
-      for (const toolName of whitelist) {
-        allowedTools.push(`mcp__${serverKey}__${toolName}`);
-      }
-    }
-
-    return {
-      mcpConfig: { mcpServers },
-      allowedTools,
-      skippedNonWhitelistedServers,
-      droppedInMemoryServers,
+  public buildMcpConfig(frontDoor: YakshaverFrontDoorConfig): ClaudeMcpConfigFile {
+    const entry: ClaudeStdioServer = {
+      type: "stdio",
+      command: frontDoor.command,
+      args: [frontDoor.cliEntryPath, "mcp-serve"],
     };
+    if (frontDoor.env && Object.keys(frontDoor.env).length > 0) {
+      entry.env = frontDoor.env;
+    }
+    return { mcpServers: { [YAKSHAVER_MCP_SERVER_KEY]: entry } };
   }
 
-  private async toClaudeServerEntry(config: MCPServerConfig): Promise<ClaudeMcpServer | null> {
-    if (config.transport === "stdio") {
-      const entry: ClaudeStdioServer = {
-        type: "stdio",
-        command: config.command,
-      };
-      if (config.args && config.args.length > 0) entry.args = config.args;
-      if (config.env && Object.keys(config.env).length > 0) entry.env = config.env;
-      return entry;
+  /**
+   * Builds the `--allowedTools` list for ask/wait modes: the app's whitelisted, server-prefixed
+   * tool names (`Server__tool`), each re-prefixed for the single front-door so Claude sees them as
+   * `mcp__yakshaver__<Server__tool>`. (Built-in/internal tools are always whitelisted by the
+   * manager, so they flow through here too.) Under yolo this is unused.
+   */
+  public async buildAllowedTools(manager: OrchestratorServerManager): Promise<string[]> {
+    // Warm the MCP clients first (best-effort) so built-in/internal tools — which are only
+    // reflected in the whitelist once their client is connected — are included.
+    if (manager.collectToolsWithServerPrefixAsync) {
+      await manager.collectToolsWithServerPrefixAsync().catch(() => {
+        /* no enabled servers / nothing to warm — the stored whitelist still applies */
+      });
     }
-
-    if (config.transport === "streamableHttp") {
-      const headers: Record<string, string> = { ...config.headers };
-      // Inject the OAuth bearer token so Claude Code authenticates the same way the in-process
-      // client does (built-in servers don't use OAuth). Refresh an expired token first — the same
-      // freshness guarantee MCPServerClient applies — so the local backend doesn't hand Claude a
-      // stale token that an HTTP MCP server would 401.
-      if (!config.builtin) {
-        const accessToken = await getFreshAccessTokenAsync(
-          this.getTokenStorage(),
-          config.id,
-          config.url,
-        );
-        if (accessToken) {
-          headers.Authorization = `Bearer ${accessToken}`;
-        }
-      }
-      const entry: ClaudeHttpServer = { type: "http", url: config.url };
-      if (Object.keys(headers).length > 0) entry.headers = headers;
-      return entry;
-    }
-
-    return null;
+    const prefixedWhitelist = await manager.getWhitelistWithServerPrefixAsync();
+    return prefixedWhitelist.map((name) => `mcp__${YAKSHAVER_MCP_SERVER_KEY}__${name}`);
   }
 
   /**
@@ -636,7 +610,10 @@ Embed this URL in the task content that you create. Follow user requirements STR
             reasoning: JSON.stringify({ type: "text", text: block.text }),
           });
         } else if (block.type === "tool_use") {
-          const toolName = block.name ?? "unknown";
+          // Claude reports the front-door tool name (`mcp__yakshaver__Server__tool`); strip the
+          // prefix once here so both the id->name map (used by the judge) and the UI step carry the
+          // real `Server__tool` name.
+          const toolName = stripFrontDoorPrefix(block.name ?? "unknown");
           // Remember which tool this opaque id belongs to so the matching tool_result (which only
           // carries the id) can be recorded under the real tool name.
           if (block.id) toolNameById.set(block.id, toolName);
@@ -696,6 +673,35 @@ Embed this URL in the task content that you create. Follow user requirements STR
       return null;
     }
   }
+}
+
+/**
+ * Resolve how to spawn the `yakshaver mcp-serve` front-door from the live Electron app + bridge.
+ *
+ * - command: the current binary run as plain Node (`ELECTRON_RUN_AS_NODE=1` + `process.execPath`),
+ *   so we don't depend on a separately-installed node.
+ * - cliEntryPath: the packaged CLI entry, `<appPath>/dist/cli/index.js`.
+ * - env: bridge port + token (so the front-door connects without racing the token file) plus
+ *   `ELECTRON_RUN_AS_NODE`.
+ *
+ * Lazily imports electron + the bridge server so the pure argv/config unit tests (which always
+ * inject a `frontDoor`) never touch these singletons.
+ */
+async function resolveFrontDoorConfig(): Promise<YakshaverFrontDoorConfig> {
+  const { app } = await import("electron");
+  const { CliBridgeServer } = await import("../cli-bridge/cli-bridge-server");
+
+  const cliEntryPath = join(app.getAppPath(), "dist", "cli", "index.js");
+  const env: Record<string, string> = { ELECTRON_RUN_AS_NODE: "1" };
+
+  // Hand the front-door the live bridge port+token so it connects deterministically.
+  const bridge = CliBridgeServer.getInstance();
+  const port = bridge.getPort();
+  const token = bridge.getToken();
+  if (port != null) env[CLI_BRIDGE_PORT_ENV] = String(port);
+  if (token) env[CLI_BRIDGE_TOKEN_ENV] = token;
+
+  return { command: process.execPath, cliEntryPath, env };
 }
 
 /** A loose view of the Claude Code stream-json events we care about. */

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -3,7 +3,11 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CLI_BRIDGE_PORT_ENV, CLI_BRIDGE_TOKEN_ENV } from "../../../shared/cli-bridge/protocol";
+import {
+  CLI_BRIDGE_PORT_ENV,
+  CLI_BRIDGE_SERVER_FILTER_ENV,
+  CLI_BRIDGE_TOKEN_ENV,
+} from "../../../shared/cli-bridge/protocol";
 import type { ToolApprovalMode } from "../../../shared/types/user-settings";
 import { getDurationParts } from "../../utils/duration-utils";
 import type { VideoUploadResult } from "../auth/types";
@@ -183,7 +187,7 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
     await this.ensureClaudeAvailable();
 
     const manager = this.serverManager ?? (await MCPServerManager.getInstanceAsync());
-    const frontDoor = this.frontDoor ?? (await resolveFrontDoorConfig());
+    const frontDoor = this.frontDoor ?? (await resolveFrontDoorConfig(options.serverFilter));
     const approvalMode = (await this.getSettingsStorage().getSettingsAsync()).toolApprovalMode;
 
     const systemPrompt = this.buildSystemPrompt(
@@ -193,10 +197,11 @@ export class LocalClaudeOrchestrator implements IBacklogOrchestrator {
       options.videoFilePath,
     );
 
-    // #915: one front-door entry proxies the app's full aggregated toolset (incl. internal/in-memory
-    // servers), so there is no per-server serialization, skip, or in-memory drop anymore.
-    // NOTE: `options.serverFilter` does NOT apply to this backend — the front-door always exposes the
-    // app's whole toolset; per-tool gating happens via the approval whitelist below, not a server filter.
+    // #915: one front-door entry proxies the app's aggregated toolset (incl. internal/in-memory
+    // servers). `options.serverFilter` (the project's selected servers) is passed to the front-door
+    // via env so the app restricts both the LISTED and the CALLABLE tools to that project — that
+    // server-side filter is the authoritative gate. `--allowedTools` below is only the ask-mode
+    // auto-approve list; it need not be filtered because an unselected tool isn't reachable anyway.
     const mcpConfig = this.buildMcpConfig(frontDoor);
     const allowedTools = await this.buildAllowedTools(manager);
 
@@ -687,7 +692,7 @@ Embed this URL in the task content that you create. Follow user requirements STR
  * Lazily imports electron + the bridge server so the pure argv/config unit tests (which always
  * inject a `frontDoor`) never touch these singletons.
  */
-async function resolveFrontDoorConfig(): Promise<YakshaverFrontDoorConfig> {
+async function resolveFrontDoorConfig(serverFilter?: string[]): Promise<YakshaverFrontDoorConfig> {
   const { app } = await import("electron");
   const { CliBridgeServer } = await import("../cli-bridge/cli-bridge-server");
 
@@ -700,6 +705,10 @@ async function resolveFrontDoorConfig(): Promise<YakshaverFrontDoorConfig> {
   const token = bridge.getToken();
   if (port != null) env[CLI_BRIDGE_PORT_ENV] = String(port);
   if (token) env[CLI_BRIDGE_TOKEN_ENV] = token;
+  // Restrict the front-door to the project's selected servers (empty = all enabled servers).
+  if (serverFilter && serverFilter.length > 0) {
+    env[CLI_BRIDGE_SERVER_FILTER_ENV] = serverFilter.join(",");
+  }
 
   return { command: process.execPath, cliEntryPath, env };
 }

--- a/src/backend/services/mcp/mcp-tool-bridge.test.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.test.ts
@@ -26,10 +26,10 @@ function makeManager(
   tools: ToolSet,
   whitelist: string[] = [],
 ): ToolBridgeManager & {
-  collectToolsWithServerPrefixAsync: ReturnType<typeof vi.fn>;
+  collectToolsForSelectedServersAsync: ReturnType<typeof vi.fn>;
 } {
   return {
-    collectToolsWithServerPrefixAsync: vi.fn().mockResolvedValue(tools),
+    collectToolsForSelectedServersAsync: vi.fn().mockResolvedValue(tools),
     getWhitelistWithServerPrefixAsync: vi.fn().mockResolvedValue(whitelist),
   };
 }
@@ -54,6 +54,13 @@ describe("McpToolBridge.listTools", () => {
     expect((gh?.inputSchema as { properties?: unknown }).properties).toHaveProperty("title");
   });
 
+  it("forwards the serverFilter to the manager so only selected servers are collected", async () => {
+    const manager = makeManager(makeToolSet());
+    const bridge = new McpToolBridge(manager, makeSettings("ask"));
+    await bridge.listTools(["srv-1", "srv-2"]);
+    expect(manager.collectToolsForSelectedServersAsync).toHaveBeenCalledWith(["srv-1", "srv-2"]);
+  });
+
   it("falls back to a permissive object schema when a tool has no inputSchema", async () => {
     const tools = {
       Bare__tool: { description: "no schema", execute: vi.fn() },
@@ -70,7 +77,7 @@ describe("McpToolBridge.listTools", () => {
     // that to [] so the front-door's tools/list returns an empty list rather
     // than a JSON-RPC transport error mid-run.
     const manager = makeManager(makeToolSet());
-    manager.collectToolsWithServerPrefixAsync.mockRejectedValue(
+    manager.collectToolsForSelectedServersAsync.mockRejectedValue(
       new Error("[MCPServerManager]: No MCP clients available"),
     );
     const bridge = new McpToolBridge(manager, makeSettings("ask"));
@@ -105,10 +112,10 @@ describe("McpToolBridge.callTool - approval policy enforcement", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("ask/wait: a NON-whitelisted tool returns a structured not-approved result and does NOT run (no hang)", async () => {
+  it("ask: a NON-whitelisted tool returns a structured not-approved result and does NOT run (no hang)", async () => {
     const bridge = new McpToolBridge(
       makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), /* whitelist */ []),
-      makeSettings("wait"),
+      makeSettings("ask"),
     );
     const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
     expect(executeSpy).not.toHaveBeenCalled();
@@ -116,6 +123,16 @@ describe("McpToolBridge.callTool - approval policy enforcement", () => {
     if (res.ok) throw new Error("expected a not-approved failure");
     expect(res.notApproved).toBe(true);
     expect(res.error).toMatch(/not approved/i);
+  });
+
+  it("wait: runs a NON-whitelisted tool (wait = auto-approve, matching buildArgv's bypassPermissions)", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), /* whitelist */ []),
+      makeSettings("wait"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(executeSpy).toHaveBeenCalledOnce();
+    expect(res.ok).toBe(true);
   });
 
   it("returns a clear error for an unknown tool", async () => {
@@ -140,7 +157,7 @@ describe("McpToolBridge.callTool - approval policy enforcement", () => {
     // tool" structured refusal is returned and the front-door can relay it as an
     // MCP isError result instead of rejecting with a transport error mid-run.
     const manager = makeManager(makeToolSet(), ["GitHub__create_issue"]);
-    manager.collectToolsWithServerPrefixAsync.mockRejectedValue(
+    manager.collectToolsForSelectedServersAsync.mockRejectedValue(
       new Error("[MCPServerManager]: No tools available from selected/healthy servers"),
     );
     const bridge = new McpToolBridge(manager, makeSettings("yolo"));

--- a/src/backend/services/mcp/mcp-tool-bridge.test.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.test.ts
@@ -1,0 +1,164 @@
+import type { ToolSet } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { McpToolBridge, type ToolBridgeManager, type ToolBridgeSettings } from "./mcp-tool-bridge";
+
+/**
+ * Build a ToolSet where each tool carries an AI-SDK-shaped {description, inputSchema, execute}.
+ * `Internal__*` stands in for an internal/in-memory server's tool — the #915 win is that these
+ * are present here even though Claude Code can't reach them over its own transports.
+ */
+function makeToolSet(executeSpies: Record<string, ReturnType<typeof vi.fn>> = {}): ToolSet {
+  const mk = (name: string, description: string) =>
+    ({
+      description,
+      inputSchema: z.object({ title: z.string() }),
+      execute: executeSpies[name] ?? vi.fn().mockResolvedValue(`ran ${name}`),
+    }) as unknown as ToolSet[string];
+
+  return {
+    GitHub__create_issue: mk("GitHub__create_issue", "Create a GitHub issue"),
+    Internal__fill_template: mk("Internal__fill_template", "Fill the internal template"),
+  };
+}
+
+function makeManager(
+  tools: ToolSet,
+  whitelist: string[] = [],
+): ToolBridgeManager & {
+  collectToolsWithServerPrefixAsync: ReturnType<typeof vi.fn>;
+} {
+  return {
+    collectToolsWithServerPrefixAsync: vi.fn().mockResolvedValue(tools),
+    getWhitelistWithServerPrefixAsync: vi.fn().mockResolvedValue(whitelist),
+  };
+}
+
+function makeSettings(mode: "yolo" | "ask" | "wait"): ToolBridgeSettings {
+  return { getSettingsAsync: vi.fn().mockResolvedValue({ toolApprovalMode: mode }) };
+}
+
+describe("McpToolBridge.listTools", () => {
+  it("flattens the aggregated toolset INCLUDING internal servers, with JSON-Schema input", async () => {
+    const bridge = new McpToolBridge(makeManager(makeToolSet()), makeSettings("ask"));
+    const tools = await bridge.listTools();
+
+    const names = tools.map((t) => t.name).sort();
+    // Internal/in-memory server tool is present — the key #915 win.
+    expect(names).toEqual(["GitHub__create_issue", "Internal__fill_template"]);
+
+    const gh = tools.find((t) => t.name === "GitHub__create_issue");
+    expect(gh?.description).toBe("Create a GitHub issue");
+    // Zod inputSchema is resolved to a JSON Schema object.
+    expect(gh?.inputSchema).toMatchObject({ type: "object" });
+    expect((gh?.inputSchema as { properties?: unknown }).properties).toHaveProperty("title");
+  });
+
+  it("falls back to a permissive object schema when a tool has no inputSchema", async () => {
+    const tools = {
+      Bare__tool: { description: "no schema", execute: vi.fn() },
+    } as unknown as ToolSet;
+    const bridge = new McpToolBridge(makeManager(tools), makeSettings("yolo"));
+    const [summary] = await bridge.listTools();
+    expect(summary.inputSchema).toEqual({ type: "object", properties: {} });
+  });
+
+  it("resolves to an EMPTY list (never rejects) when no enabled servers are healthy", async () => {
+    // collectToolsWithServerPrefixAsync throws ("No MCP clients available" /
+    // "No tools available...") whenever zero enabled servers are healthy — e.g.
+    // the first-run "no MCP servers configured" state. The bridge must collapse
+    // that to [] so the front-door's tools/list returns an empty list rather
+    // than a JSON-RPC transport error mid-run.
+    const manager = makeManager(makeToolSet());
+    manager.collectToolsWithServerPrefixAsync.mockRejectedValue(
+      new Error("[MCPServerManager]: No MCP clients available"),
+    );
+    const bridge = new McpToolBridge(manager, makeSettings("ask"));
+    await expect(bridge.listTools()).resolves.toEqual([]);
+  });
+});
+
+describe("McpToolBridge.callTool - approval policy enforcement", () => {
+  let executeSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executeSpy = vi.fn().mockResolvedValue("Created #5");
+  });
+
+  it("yolo: runs ANY tool immediately (no whitelist needed)", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), /* whitelist */ []),
+      makeSettings("yolo"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(executeSpy).toHaveBeenCalledOnce();
+    expect(res).toEqual({ ok: true, result: "Created #5" });
+  });
+
+  it("ask: runs a whitelisted tool", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), ["GitHub__create_issue"]),
+      makeSettings("ask"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(executeSpy).toHaveBeenCalledOnce();
+    expect(res.ok).toBe(true);
+  });
+
+  it("ask/wait: a NON-whitelisted tool returns a structured not-approved result and does NOT run (no hang)", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), /* whitelist */ []),
+      makeSettings("wait"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(executeSpy).not.toHaveBeenCalled();
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected a not-approved failure");
+    expect(res.notApproved).toBe(true);
+    expect(res.error).toMatch(/not approved/i);
+  });
+
+  it("returns a clear error for an unknown tool", async () => {
+    const bridge = new McpToolBridge(makeManager(makeToolSet()), makeSettings("yolo"));
+    const res = await bridge.callTool("Nope__missing", {});
+    expect(res).toEqual({ ok: false, error: "Unknown tool: Nope__missing" });
+  });
+
+  it("captures an execute() throw as a structured failure (does not reject)", async () => {
+    const boom = vi.fn().mockRejectedValue(new Error("boom"));
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: boom }), ["GitHub__create_issue"]),
+      makeSettings("ask"),
+    );
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(res).toEqual({ ok: false, error: "boom" });
+  });
+
+  it("returns a structured failure (never rejects) when no enabled servers are healthy", async () => {
+    // Same degenerate state as the listTools case: collecting the toolset throws.
+    // callTool must collapse it to an empty toolset, so the existing "Unknown
+    // tool" structured refusal is returned and the front-door can relay it as an
+    // MCP isError result instead of rejecting with a transport error mid-run.
+    const manager = makeManager(makeToolSet(), ["GitHub__create_issue"]);
+    manager.collectToolsWithServerPrefixAsync.mockRejectedValue(
+      new Error("[MCPServerManager]: No tools available from selected/healthy servers"),
+    );
+    const bridge = new McpToolBridge(manager, makeSettings("yolo"));
+    const res = await bridge.callTool("GitHub__create_issue", { title: "Bug" });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected a structured failure");
+    expect(res.error).toMatch(/unknown tool/i);
+  });
+
+  it("defaults arguments to {} and passes them to execute()", async () => {
+    const bridge = new McpToolBridge(
+      makeManager(makeToolSet({ GitHub__create_issue: executeSpy }), []),
+      makeSettings("yolo"),
+    );
+    await bridge.callTool("GitHub__create_issue");
+    expect(executeSpy).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ toolCallId: expect.any(String) }),
+    );
+  });
+});

--- a/src/backend/services/mcp/mcp-tool-bridge.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.ts
@@ -10,11 +10,12 @@ import type { ToolApprovalMode } from "../../../shared/types/user-settings";
  */
 export interface ToolBridgeManager {
   /**
-   * The aggregated, server-prefixed toolset across ALL enabled servers —
-   * INCLUDING internal/in-memory ones (the #915 win: these are reachable here
-   * even though Claude Code cannot reach them over its own transports).
+   * The aggregated, server-prefixed toolset — INCLUDING internal/in-memory servers (the #915 win:
+   * reachable here even though Claude Code can't reach them over its own transports). When
+   * `serverFilter` is given, only those server ids/names are included (the project's selected
+   * servers); otherwise every enabled server is.
    */
-  collectToolsWithServerPrefixAsync(): Promise<ToolSet>;
+  collectToolsForSelectedServersAsync(serverFilter?: string[]): Promise<ToolSet>;
   /** Prefixed tool names that may run without interactive approval. */
   getWhitelistWithServerPrefixAsync(): Promise<string[]>;
 }
@@ -44,8 +45,8 @@ export class McpToolBridge {
   ) {}
 
   /** Aggregated tool list for `GET /tools`. Names/descriptions/schemas only. */
-  async listTools(): Promise<BridgeToolSummary[]> {
-    const tools = await this.collectToolsOrEmpty();
+  async listTools(serverFilter?: string[]): Promise<BridgeToolSummary[]> {
+    const tools = await this.collectToolsOrEmpty(serverFilter);
     const summaries: BridgeToolSummary[] = [];
     for (const [name, tool] of Object.entries(tools)) {
       summaries.push({
@@ -60,26 +61,35 @@ export class McpToolBridge {
   /**
    * Execute a single tool by its server-prefixed name for `POST /tools/call`.
    *
-   * Enforces the approval policy first, NEVER hanging: under `ask`/`wait` a
-   * non-whitelisted tool returns `{ok:false, notApproved:true}` rather than
-   * waiting on a UI prompt the headless caller can't answer. (Phase 4.1 will
-   * route these to the in-app approval UI; for v1 it's a clean refusal.)
+   * Enforces the approval policy first, NEVER hanging. Only `ask` gates on the
+   * whitelist (a non-whitelisted tool returns `{ok:false, notApproved:true}`
+   * rather than waiting on a prompt the headless caller can't answer). `yolo` and
+   * `wait` both run everything — matching the orchestrator's `buildArgv`, which
+   * maps `wait` to `bypassPermissions` because the OpenAI backend's `wait` is
+   * "auto-approve after a delay", not a hard deny. Treating `wait` like `ask` here
+   * would hard-deny every non-whitelisted tool and break wait-mode runs.
    */
-  async callTool(name: string, args: Record<string, unknown> = {}): Promise<ToolCallResult> {
-    const tools = await this.collectToolsOrEmpty();
+  async callTool(
+    name: string,
+    args: Record<string, unknown> = {},
+    serverFilter?: string[],
+  ): Promise<ToolCallResult> {
+    // Resolve against the SAME filtered toolset `listTools` exposes, so a tool from an unselected
+    // project isn't reachable even if the model guesses its name (the server-side gate for #915).
+    const tools = await this.collectToolsOrEmpty(serverFilter);
     const tool = tools[name];
     if (!tool) {
       return { ok: false, error: `Unknown tool: ${name}` };
     }
 
     const approvalMode = (await this.settings.getSettingsAsync()).toolApprovalMode;
-    if (approvalMode !== "yolo") {
+    if (approvalMode === "ask") {
       const whitelist = new Set(await this.manager.getWhitelistWithServerPrefixAsync());
       if (!whitelist.has(name)) {
         return {
           ok: false,
           notApproved: true,
-          error: `Tool '${name}' is not approved under the '${approvalMode}' approval mode. Whitelist it in YakShaver, or switch the approval mode to 'yolo'.`,
+          error: `Tool '${name}' is not approved under the 'ask' approval mode. Whitelist it in YakShaver, or switch the approval mode to 'yolo'.`,
         };
       }
     }
@@ -106,19 +116,20 @@ export class McpToolBridge {
    * Resolve the aggregated toolset, treating the "no healthy/enabled servers"
    * degenerate state as an EMPTY toolset rather than an error.
    *
-   * {@link ToolBridgeManager.collectToolsWithServerPrefixAsync} throws when zero
+   * {@link ToolBridgeManager.collectToolsForSelectedServersAsync} throws when zero
    * enabled servers are healthy (e.g. the first-run "no MCP servers configured"
-   * state, or every configured server failing to connect). That throw must NOT
-   * propagate to the bridge router (which would relay it as an HTTP 500 and make
-   * the front-door reject mid-run). Honouring the bridge's "never hang, always
-   * return a structured envelope" contract, we collapse it to `{}`:
+   * state, every configured server failing to connect, or a `serverFilter` that
+   * matches nothing). That throw must NOT propagate to the bridge router (which
+   * would relay it as an HTTP 500 and make the front-door reject mid-run).
+   * Honouring the bridge's "never hang, always return a structured envelope"
+   * contract, we collapse it to `{}`:
    *  - `listTools()` then returns an empty list (tools/list ⇒ []), and
    *  - `callTool()` then returns the existing structured `{ok:false, "Unknown
    *    tool"}` refusal, which the front-door relays as an MCP `isError` result.
    */
-  private async collectToolsOrEmpty(): Promise<ToolSet> {
+  private async collectToolsOrEmpty(serverFilter?: string[]): Promise<ToolSet> {
     try {
-      return await this.manager.collectToolsWithServerPrefixAsync();
+      return await this.manager.collectToolsForSelectedServersAsync(serverFilter);
     } catch {
       return {} as ToolSet;
     }

--- a/src/backend/services/mcp/mcp-tool-bridge.ts
+++ b/src/backend/services/mcp/mcp-tool-bridge.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import { asSchema, type ToolSet } from "ai";
+import type { BridgeToolSummary, ToolCallResult } from "../../../shared/cli-bridge/protocol";
+import type { ToolApprovalMode } from "../../../shared/types/user-settings";
+
+/**
+ * The slice of {@link MCPServerManager} the tool bridge needs. Kept narrow so the
+ * router (and its unit tests) can inject a mock without dragging in Electron, the
+ * MCP clients, or the storage singletons.
+ */
+export interface ToolBridgeManager {
+  /**
+   * The aggregated, server-prefixed toolset across ALL enabled servers —
+   * INCLUDING internal/in-memory ones (the #915 win: these are reachable here
+   * even though Claude Code cannot reach them over its own transports).
+   */
+  collectToolsWithServerPrefixAsync(): Promise<ToolSet>;
+  /** Prefixed tool names that may run without interactive approval. */
+  getWhitelistWithServerPrefixAsync(): Promise<string[]>;
+}
+
+/** The settings slice the bridge needs to read the current approval mode. */
+export interface ToolBridgeSettings {
+  getSettingsAsync(): Promise<{ toolApprovalMode: ToolApprovalMode }>;
+}
+
+/**
+ * Bridges the app's aggregated MCP toolset to the localhost bridge endpoints
+ * (`GET /tools`, `POST /tools/call`) consumed by the single `yakshaver` MCP
+ * front-door (#915).
+ *
+ * Two responsibilities:
+ *  1. Flatten the AI-SDK `ToolSet` (server-prefixed keys → `description` +
+ *     JSON-Schema `inputSchema`) into wire-friendly summaries.
+ *  2. Apply the app's tool-approval policy SERVER-SIDE on every call so a
+ *     headless run never hangs on an interactive prompt: `yolo` runs everything;
+ *     `ask`/`wait` run only whitelisted tools, otherwise return a STRUCTURED
+ *     "not approved" result.
+ */
+export class McpToolBridge {
+  constructor(
+    private readonly manager: ToolBridgeManager,
+    private readonly settings: ToolBridgeSettings,
+  ) {}
+
+  /** Aggregated tool list for `GET /tools`. Names/descriptions/schemas only. */
+  async listTools(): Promise<BridgeToolSummary[]> {
+    const tools = await this.collectToolsOrEmpty();
+    const summaries: BridgeToolSummary[] = [];
+    for (const [name, tool] of Object.entries(tools)) {
+      summaries.push({
+        name,
+        description: extractDescription(tool),
+        inputSchema: await extractInputSchema(tool),
+      });
+    }
+    return summaries;
+  }
+
+  /**
+   * Execute a single tool by its server-prefixed name for `POST /tools/call`.
+   *
+   * Enforces the approval policy first, NEVER hanging: under `ask`/`wait` a
+   * non-whitelisted tool returns `{ok:false, notApproved:true}` rather than
+   * waiting on a UI prompt the headless caller can't answer. (Phase 4.1 will
+   * route these to the in-app approval UI; for v1 it's a clean refusal.)
+   */
+  async callTool(name: string, args: Record<string, unknown> = {}): Promise<ToolCallResult> {
+    const tools = await this.collectToolsOrEmpty();
+    const tool = tools[name];
+    if (!tool) {
+      return { ok: false, error: `Unknown tool: ${name}` };
+    }
+
+    const approvalMode = (await this.settings.getSettingsAsync()).toolApprovalMode;
+    if (approvalMode !== "yolo") {
+      const whitelist = new Set(await this.manager.getWhitelistWithServerPrefixAsync());
+      if (!whitelist.has(name)) {
+        return {
+          ok: false,
+          notApproved: true,
+          error: `Tool '${name}' is not approved under the '${approvalMode}' approval mode. Whitelist it in YakShaver, or switch the approval mode to 'yolo'.`,
+        };
+      }
+    }
+
+    const execute = (tool as { execute?: unknown }).execute;
+    if (typeof execute !== "function") {
+      return { ok: false, error: `Tool '${name}' is not executable` };
+    }
+
+    try {
+      // The AI-SDK execute signature is execute(input, options). The bridge has
+      // no streaming context, so we pass a minimal options object.
+      const result = await (execute as ToolExecute)(args, {
+        toolCallId: `bridge-${randomUUID()}`,
+        messages: [],
+      });
+      return { ok: true, result };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Resolve the aggregated toolset, treating the "no healthy/enabled servers"
+   * degenerate state as an EMPTY toolset rather than an error.
+   *
+   * {@link ToolBridgeManager.collectToolsWithServerPrefixAsync} throws when zero
+   * enabled servers are healthy (e.g. the first-run "no MCP servers configured"
+   * state, or every configured server failing to connect). That throw must NOT
+   * propagate to the bridge router (which would relay it as an HTTP 500 and make
+   * the front-door reject mid-run). Honouring the bridge's "never hang, always
+   * return a structured envelope" contract, we collapse it to `{}`:
+   *  - `listTools()` then returns an empty list (tools/list ⇒ []), and
+   *  - `callTool()` then returns the existing structured `{ok:false, "Unknown
+   *    tool"}` refusal, which the front-door relays as an MCP `isError` result.
+   */
+  private async collectToolsOrEmpty(): Promise<ToolSet> {
+    try {
+      return await this.manager.collectToolsWithServerPrefixAsync();
+    } catch {
+      return {} as ToolSet;
+    }
+  }
+}
+
+type ToolExecute = (
+  input: unknown,
+  options: { toolCallId: string; messages: unknown[] },
+) => Promise<unknown> | unknown;
+
+function extractDescription(tool: unknown): string | undefined {
+  if (tool && typeof tool === "object" && "description" in tool) {
+    const desc = (tool as { description?: unknown }).description;
+    return typeof desc === "string" ? desc : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a tool's `inputSchema` (an AI-SDK FlexibleSchema — Zod, JSON-Schema, or
+ * Standard Schema) to a plain JSON Schema object the MCP front-door can hand to
+ * Claude. Falls back to a permissive empty-object schema if resolution fails.
+ */
+async function extractInputSchema(tool: unknown): Promise<Record<string, unknown>> {
+  const fallback: Record<string, unknown> = { type: "object", properties: {} };
+  if (!tool || typeof tool !== "object" || !("inputSchema" in tool)) {
+    return fallback;
+  }
+  const raw = (tool as { inputSchema?: unknown }).inputSchema;
+  if (raw === undefined || raw === null) return fallback;
+  try {
+    const schema = asSchema(raw as never);
+    const json = await schema.jsonSchema;
+    return (json as Record<string, unknown>) ?? fallback;
+  } catch {
+    // Some tools may already expose a plain JSON-Schema object directly.
+    if (typeof raw === "object") return raw as Record<string, unknown>;
+    return fallback;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { ArgParseError, parseArgs } from "./args";
 import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
 import { buildRequest, type CommandRequest, ID_PLACEHOLDER, UsageError } from "./commands";
+import { runMcpServe } from "./mcp-serve";
 import { printResult } from "./print";
 import { resolveServerIdByName } from "./resolve-name";
 
@@ -28,6 +29,10 @@ MCP
 
   remove/enable/update also accept --name <name> instead of a positional <id>
   (resolved against the server list; errors if the name is missing or ambiguous).
+
+MCP FRONT-DOOR (internal — used by the Claude Code orchestrator)
+  yakshaver mcp-serve                       # run the stdio MCP server that proxies
+                                            # the app's aggregated toolset to Claude
 
 CONFIG
   yakshaver config get [llm|orchestrator|settings]   # defaults to settings
@@ -58,6 +63,13 @@ async function main(argv: string[]): Promise<number> {
   if (parsed.options.help || parsed.positionals.length === 0) {
     console.log(HELP);
     return parsed.positionals.length === 0 && !parsed.options.help ? 1 : 0;
+  }
+
+  // `mcp-serve` is special: it RUNS the stdio MCP front-door (proxying to the bridge) rather than
+  // issuing a single bridge request. The Claude orchestrator spawns this as its one MCP server.
+  if (parsed.positionals[0] === "mcp-serve") {
+    await runMcpServe({ dev: parsed.options.dev === true });
+    return typeof process.exitCode === "number" ? process.exitCode : 0;
   }
 
   let request: CommandRequest;

--- a/src/cli/mcp-serve.test.ts
+++ b/src/cli/mcp-serve.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BridgeToolSummary, ToolCallResult } from "../shared/cli-bridge/protocol";
+import { BridgeUnavailableError } from "./bridge-client";
+import { callToolViaBridge, listToolsViaBridge } from "./mcp-serve";
+
+/** Read the `text` off the first content item (MCP content is a typed union). */
+function firstText(content: Array<{ type: string }>): string | undefined {
+  const item = content[0] as { text?: string };
+  return item.text;
+}
+
+describe("mcp-serve front-door — tools/list proxy", () => {
+  it("maps GET /tools summaries to MCP tool descriptors", async () => {
+    const summaries: BridgeToolSummary[] = [
+      {
+        name: "GitHub__create_issue",
+        description: "Create a GitHub issue",
+        inputSchema: { type: "object", properties: { title: { type: "string" } } },
+      },
+      {
+        name: "Internal__fill_template",
+        description: "internal",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+    const get = vi.fn().mockResolvedValue(summaries);
+
+    const result = await listToolsViaBridge({ get });
+
+    expect(get).toHaveBeenCalledWith("/tools");
+    expect(result.tools.map((t) => t.name)).toEqual([
+      "GitHub__create_issue",
+      "Internal__fill_template",
+    ]);
+    expect(result.tools[0].inputSchema).toMatchObject({ type: "object" });
+  });
+
+  it("normalizes a non-object inputSchema to a permissive object schema", async () => {
+    const get = vi.fn().mockResolvedValue([
+      {
+        name: "Weird__tool",
+        inputSchema: { type: "string" } as unknown as Record<string, unknown>,
+      },
+    ]);
+    const result = await listToolsViaBridge({ get });
+    expect(result.tools[0].inputSchema).toEqual({ type: "object", properties: {} });
+  });
+
+  it("collapses a mid-run bridge UNAVAILABILITY to an empty toolset (not a protocol error)", async () => {
+    // The app quit/restarted after the front-door was up: the GET throws
+    // BridgeUnavailableError. Discovery must not abort the session — it degrades
+    // to [] like the bridge router's own never-throw-on-empty contract.
+    const get = vi.fn().mockRejectedValue(new BridgeUnavailableError("app not running"));
+    const result = await listToolsViaBridge({ get });
+    expect(result.tools).toEqual([]);
+  });
+
+  it("propagates a non-availability failure (e.g. 401/malformed) rather than masking it as []", async () => {
+    // A stale-token 401 or malformed response is a persistent misconfiguration, not
+    // a transient dropout — silently returning [] would hide it, so it must surface.
+    const get = vi.fn().mockRejectedValue(new Error("unauthorized"));
+    await expect(listToolsViaBridge({ get })).rejects.toThrow(/unauthorized/i);
+  });
+});
+
+describe("mcp-serve front-door — tools/call proxy", () => {
+  it("forwards name + arguments to POST /tools/call and returns the result as text content", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, result: "Created #5" } as ToolCallResult);
+
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", { title: "Bug" });
+
+    expect(post).toHaveBeenCalledWith("/tools/call", {
+      name: "GitHub__create_issue",
+      arguments: { title: "Bug" },
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toEqual([{ type: "text", text: "Created #5" }]);
+  });
+
+  it("stringifies a non-string tool result", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, result: { id: 5 } } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "X__y", {});
+    expect(firstText(result.content)).toBe(JSON.stringify({ id: 5 }));
+  });
+
+  it("relays a native MCP CallToolResult's content verbatim (no double-stringify)", async () => {
+    const post = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { content: [{ type: "text", text: "Created #5" }] },
+    } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "Created #5" }]);
+  });
+
+  it("surfaces an MCP-level isError (auth-denied/rate-limit) as isError, NOT a successful call", async () => {
+    // A failed MCP tool resolves WITHOUT throwing, returning { isError: true, content }.
+    // The bridge envelope is still ok:true (transport succeeded), so this case is the
+    // one that previously leaked an underlying failure to Claude as success.
+    const post = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        isError: true,
+        content: [{ type: "text", text: "401 Unauthorized: token expired" }],
+      },
+    } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: "401 Unauthorized: token expired" }]);
+  });
+
+  it("defaults missing arguments to {}", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, result: "ok" } as ToolCallResult);
+    await callToolViaBridge({ post }, "X__y", undefined);
+    expect(post).toHaveBeenCalledWith("/tools/call", { name: "X__y", arguments: {} });
+  });
+
+  it("surfaces a structured not-approved result as an MCP isError tool result", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValue({ ok: false, notApproved: true, error: "not approved" } as ToolCallResult);
+
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+
+    expect(result.isError).toBe(true);
+    expect(firstText(result.content)).toMatch(/Tool not approved: not approved/);
+  });
+
+  it("surfaces an execution failure as an MCP isError tool result", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: false, error: "boom" } as ToolCallResult);
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(true);
+    expect(firstText(result.content)).toMatch(/Tool failed: boom/);
+  });
+
+  it("maps a mid-run bridge transport throw to an isError tool result (not a protocol error)", async () => {
+    // The bridge became unreachable mid-shave (app quit/socket drop): post() throws.
+    // Per MCP, that must reach Claude as a recoverable isError result so it can
+    // self-correct — never escape as a JSON-RPC protocol error.
+    const post = vi
+      .fn()
+      .mockRejectedValue(new Error("YakShaver Desktop doesn't appear to be running"));
+    const result = await callToolViaBridge({ post }, "GitHub__create_issue", {});
+    expect(result.isError).toBe(true);
+    expect(firstText(result.content)).toMatch(
+      /Tool failed: YakShaver Desktop doesn't appear to be running/,
+    );
+  });
+});

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -8,6 +8,7 @@ import {
 import {
   type BridgeToolSummary,
   CLI_BRIDGE_PORT_ENV,
+  CLI_BRIDGE_SERVER_FILTER_ENV,
   CLI_BRIDGE_TOKEN_ENV,
   type ToolCallResult,
 } from "../shared/cli-bridge/protocol";
@@ -35,6 +36,12 @@ export interface McpServeOptions {
   dev?: boolean;
   /** Injectable for testing. Defaults to a real {@link BridgeClient}. */
   client?: Pick<BridgeClient, "get" | "post">;
+  /**
+   * Server ids/names to restrict the toolset to. Injectable for testing; in production it is read
+   * from {@link CLI_BRIDGE_SERVER_FILTER_ENV}, which the orchestrator sets to the project's
+   * selected servers. Undefined/empty means every enabled server.
+   */
+  serverFilter?: string[];
 }
 
 /**
@@ -44,15 +51,18 @@ export interface McpServeOptions {
  */
 export function createMcpServer(options: McpServeOptions = {}): Server {
   const client = options.client ?? buildClient(options.dev);
+  // The orchestrator injects the project's selected servers; the front-door forwards them so the
+  // app restricts the toolset (and tool execution) to that project, not every configured server.
+  const serverFilter = options.serverFilter ?? readServerFilterFromEnv();
 
   const server = new Server(
     { name: "yakshaver", version: "1.0.0" },
     { capabilities: { tools: {} } },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, () => listToolsViaBridge(client));
+  server.setRequestHandler(ListToolsRequestSchema, () => listToolsViaBridge(client, serverFilter));
   server.setRequestHandler(CallToolRequestSchema, (request) =>
-    callToolViaBridge(client, request.params.name, request.params.arguments),
+    callToolViaBridge(client, request.params.name, request.params.arguments, serverFilter),
   );
 
   return server;
@@ -75,10 +85,11 @@ export function createMcpServer(options: McpServeOptions = {}): Server {
  */
 export async function listToolsViaBridge(
   client: Pick<BridgeClient, "get">,
+  serverFilter?: string[],
 ): Promise<{ tools: Array<{ name: string; description?: string; inputSchema: object }> }> {
   let tools: BridgeToolSummary[];
   try {
-    tools = await client.get<BridgeToolSummary[]>("/tools");
+    tools = await client.get<BridgeToolSummary[]>(`/tools${serverFilterQuery(serverFilter)}`);
   } catch (err) {
     if (err instanceof BridgeUnavailableError) {
       return { tools: [] };
@@ -110,12 +121,14 @@ export async function callToolViaBridge(
   client: Pick<BridgeClient, "post">,
   name: string,
   args: Record<string, unknown> | undefined,
+  serverFilter?: string[],
 ): Promise<McpToolResult> {
   let result: ToolCallResult;
   try {
     result = await client.post<ToolCallResult>("/tools/call", {
       name,
       arguments: args ?? {},
+      ...(serverFilter && serverFilter.length > 0 ? { serverFilter } : {}),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -194,6 +207,23 @@ function buildClient(dev?: boolean): BridgeClient {
     }
   }
   return new BridgeClient({ dev });
+}
+
+/** Read the comma-separated server filter the orchestrator injected, as a trimmed list (or undefined). */
+function readServerFilterFromEnv(): string[] | undefined {
+  const raw = process.env[CLI_BRIDGE_SERVER_FILTER_ENV];
+  if (!raw) return undefined;
+  const ids = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return ids.length > 0 ? ids : undefined;
+}
+
+/** Encode a server filter as a `?serverFilter=a,b` query suffix, or "" when there is none. */
+function serverFilterQuery(serverFilter?: string[]): string {
+  if (!serverFilter || serverFilter.length === 0) return "";
+  return `?serverFilter=${encodeURIComponent(serverFilter.join(","))}`;
 }
 
 /** MCP requires `inputSchema` to be an object schema; default to a permissive one. */

--- a/src/cli/mcp-serve.ts
+++ b/src/cli/mcp-serve.ts
@@ -1,0 +1,225 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  type BridgeToolSummary,
+  CLI_BRIDGE_PORT_ENV,
+  CLI_BRIDGE_TOKEN_ENV,
+  type ToolCallResult,
+} from "../shared/cli-bridge/protocol";
+import { BridgeClient, BridgeUnavailableError } from "./bridge-client";
+
+/**
+ * The single `yakshaver` MCP front-door (#915).
+ *
+ * Runs a stdio MCP SERVER that the Claude Code orchestrator spawns (via a
+ * one-entry `--mcp-config`). It owns NO tools itself — every `tools/list` and
+ * `tools/call` is proxied to the running desktop app over the localhost CLI
+ * bridge:
+ *
+ *   tools/list → GET  /tools        (the app's full aggregated, server-prefixed
+ *                                    toolset, INCLUDING internal/in-memory
+ *                                    servers Claude Code can't reach directly)
+ *   tools/call → POST /tools/call   (executes through the app's approval policy)
+ *
+ * To Claude the tools appear as `mcp__yakshaver__<Server__tool>`. The bridge
+ * token+port are resolved from the same token file the rest of the CLI uses
+ * (or env vars the orchestrator injects).
+ */
+
+export interface McpServeOptions {
+  dev?: boolean;
+  /** Injectable for testing. Defaults to a real {@link BridgeClient}. */
+  client?: Pick<BridgeClient, "get" | "post">;
+}
+
+/**
+ * Build the MCP `Server` instance, registering the list/call handlers that proxy
+ * to the bridge. Exposed (separately from the transport) so tests can drive the
+ * handlers directly without a real stdio pipe.
+ */
+export function createMcpServer(options: McpServeOptions = {}): Server {
+  const client = options.client ?? buildClient(options.dev);
+
+  const server = new Server(
+    { name: "yakshaver", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, () => listToolsViaBridge(client));
+  server.setRequestHandler(CallToolRequestSchema, (request) =>
+    callToolViaBridge(client, request.params.name, request.params.arguments),
+  );
+
+  return server;
+}
+
+/**
+ * Proxy `tools/list` to `GET /tools`, mapping summaries to MCP tool descriptors.
+ *
+ * If the app/bridge becomes UNREACHABLE after the front-door is up (the user
+ * quits/restarts the app, a socket drops mid-shave — surfaced as a
+ * {@link BridgeUnavailableError}), discovery must not abort the whole session
+ * with a JSON-RPC protocol error: it collapses to an empty toolset, mirroring
+ * the bridge router's own never-throw-on-empty contract server-side
+ * (`McpToolBridge.collectToolsOrEmpty`).
+ *
+ * A NON-availability failure (e.g. an authenticated-boundary 401 from a stale
+ * token, or a malformed response) is a persistent misconfiguration, not a
+ * transient dropout — silently returning `[]` would hide it forever, so we let
+ * it propagate.
+ */
+export async function listToolsViaBridge(
+  client: Pick<BridgeClient, "get">,
+): Promise<{ tools: Array<{ name: string; description?: string; inputSchema: object }> }> {
+  let tools: BridgeToolSummary[];
+  try {
+    tools = await client.get<BridgeToolSummary[]>("/tools");
+  } catch (err) {
+    if (err instanceof BridgeUnavailableError) {
+      return { tools: [] };
+    }
+    throw err;
+  }
+  return {
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: normalizeInputSchema(t.inputSchema),
+    })),
+  };
+}
+
+/** The MCP tool-result shape this front-door returns over stdio. */
+type McpToolResult = Pick<CallToolResult, "content" | "isError">;
+
+/**
+ * Proxy `tools/call` to `POST /tools/call`. Every failure path becomes an MCP
+ * `isError` result (never a thrown JSON-RPC error, which would abort the run) so
+ * the model sees it and can self-correct:
+ *  - a non-`ok` bridge result (incl. a structured "not approved"),
+ *  - a transport failure (app quit/restart, socket drop, non-JSON body),
+ *  - a tool-level `isError` on an `ok:true` result — passed through verbatim so a
+ *    tool FAILURE is never masked as success (matches the in-process orchestrator).
+ */
+export async function callToolViaBridge(
+  client: Pick<BridgeClient, "post">,
+  name: string,
+  args: Record<string, unknown> | undefined,
+): Promise<McpToolResult> {
+  let result: ToolCallResult;
+  try {
+    result = await client.post<ToolCallResult>("/tools/call", {
+      name,
+      arguments: args ?? {},
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      isError: true,
+      content: [{ type: "text", text: `Tool failed: ${message}` }],
+    };
+  }
+
+  if (!result.ok) {
+    const prefix = result.notApproved ? "Tool not approved: " : "Tool failed: ";
+    return {
+      isError: true,
+      content: [{ type: "text", text: `${prefix}${result.error ?? "unknown error"}` }],
+    };
+  }
+
+  // If the tool returned a native MCP CallToolResult, relay its content + isError
+  // unchanged rather than stringifying it as a single text blob. This is what
+  // preserves a tool-level failure (isError:true) instead of masking it as success.
+  const passthrough = asMcpResult(result.result);
+  if (passthrough) {
+    return passthrough;
+  }
+
+  return { content: [toTextContent(result.result)] };
+}
+
+/**
+ * Narrow an arbitrary `execute()` return value to an MCP `CallToolResult` shape
+ * (`{ content: [...], isError? }`). Returns null when it isn't one, so the caller
+ * falls back to stringifying. Only a `content` ARRAY qualifies — that is the MCP
+ * contract — and `isError` is normalized to a boolean (defaulting to false).
+ */
+function asMcpResult(value: unknown): McpToolResult | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as { content?: unknown; isError?: unknown };
+  if (!Array.isArray(obj.content)) return null;
+  return {
+    content: obj.content as CallToolResult["content"],
+    isError: obj.isError === true,
+  };
+}
+
+/** Start the front-door over stdio. Resolves when the transport closes. */
+export async function runMcpServe(options: McpServeOptions = {}): Promise<void> {
+  let server: Server;
+  try {
+    server = createMcpServer(options);
+  } catch (err) {
+    // A misconfigured/absent bridge must produce a CLEAR error, not a silent hang.
+    fail(err);
+    return;
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // The process now lives until stdin closes; the SDK manages the lifecycle.
+}
+
+/** Construct a BridgeClient, honouring orchestrator-injected env overrides. */
+function buildClient(dev?: boolean): BridgeClient {
+  const port = process.env[CLI_BRIDGE_PORT_ENV];
+  const token = process.env[CLI_BRIDGE_TOKEN_ENV];
+  if (port && token) {
+    const parsedPort = Number(port);
+    if (Number.isFinite(parsedPort) && parsedPort > 0) {
+      return new BridgeClient({
+        dev,
+        tokenLoader: async () => ({
+          port: parsedPort,
+          token,
+          startedAt: new Date().toISOString(),
+        }),
+      });
+    }
+  }
+  return new BridgeClient({ dev });
+}
+
+/** MCP requires `inputSchema` to be an object schema; default to a permissive one. */
+function normalizeInputSchema(
+  schema: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (schema && typeof schema === "object" && schema.type === "object") {
+    return schema;
+  }
+  return { type: "object", properties: {} };
+}
+
+/** Wrap a tool result as MCP text content (stringifying non-strings). */
+function toTextContent(result: unknown): { type: "text"; text: string } {
+  if (typeof result === "string") {
+    return { type: "text", text: result };
+  }
+  return { type: "text", text: JSON.stringify(result ?? null) };
+}
+
+/** Print a clear, actionable error to stderr and set a non-zero exit code. */
+function fail(err: unknown): void {
+  const message =
+    err instanceof BridgeUnavailableError
+      ? err.message
+      : `Failed to start the yakshaver MCP front-door: ${err instanceof Error ? err.message : String(err)}`;
+  console.error(message);
+  process.exitCode = 1;
+}

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -31,6 +31,15 @@ export const CLI_BRIDGE_DEFAULT_PORT = 8765;
 /** Env var that, when truthy, disables the bridge entirely. */
 export const CLI_BRIDGE_DISABLE_ENV = "YAKSHAVER_DISABLE_CLI_BRIDGE";
 
+/**
+ * Env vars the desktop orchestrator injects into the spawned `yakshaver mcp-serve` front-door so it
+ * connects to the live bridge deterministically (without racing the token file). The orchestrator
+ * (producer) WRITES these and the front-door's `buildClient` (consumer) READS them — they are a
+ * cross-module contract, so they live here as the single source of truth.
+ */
+export const CLI_BRIDGE_PORT_ENV = "YAKSHAVER_BRIDGE_PORT";
+export const CLI_BRIDGE_TOKEN_ENV = "YAKSHAVER_BRIDGE_TOKEN";
+
 /** Placeholder shown instead of any secret value. */
 export const REDACTED = "***redacted***";
 
@@ -129,6 +138,55 @@ export type McpServerPatch = z.infer<typeof McpServerPatchSchema>;
 export const McpEnabledInputSchema = z.object({
   enabled: z.boolean(),
 });
+
+// ---------------------------------------------------------------------------
+// Aggregated tool endpoints (#915). The bridge exposes the app's full,
+// server-prefixed toolset (INCLUDING internal/in-memory servers) so the single
+// `yakshaver` MCP front-door can list + proxy them to the Claude orchestrator.
+// ---------------------------------------------------------------------------
+
+/** One aggregated tool as listed by `GET /tools`. */
+export interface BridgeToolSummary {
+  /** Server-prefixed name, e.g. `GitHub__create_issue`. */
+  name: string;
+  description?: string;
+  /** JSON Schema (draft-07-ish) describing the tool's input arguments. */
+  inputSchema: Record<string, unknown>;
+}
+
+/** Body accepted by `POST /tools/call`. */
+export const ToolCallInputSchema = z.object({
+  /** Server-prefixed tool name as returned by `GET /tools`. */
+  name: z.string().min(1, "tool name is required"),
+  /** Arguments object passed to the tool's execute(). Defaults to `{}`. */
+  arguments: z.record(z.string(), z.unknown()).optional(),
+});
+export type ToolCallInput = z.infer<typeof ToolCallInputSchema>;
+
+/**
+ * Result envelope from `POST /tools/call`.
+ *
+ * A discriminated union on `ok` (matching the house pattern of {@link BridgeResponse}
+ * above) so success and failure each carry ONLY their relevant fields — illegal
+ * states (e.g. `error` on a success, `result` on a failure) are unrepresentable.
+ *
+ * `ok:false` with `notApproved:true` is a STRUCTURED refusal (the tool was not
+ * whitelisted under the current approval mode) — NOT a transport error, and the
+ * caller must surface it to the model rather than retrying or hanging.
+ */
+export type ToolCallResult =
+  | {
+      ok: true;
+      /** The tool's raw execute() return value. */
+      result?: unknown;
+    }
+  | {
+      ok: false;
+      /** A human-readable reason for the failure. */
+      error: string;
+      /** True when the failure is an approval-policy refusal, not an execution error. */
+      notApproved?: boolean;
+    };
 
 // LLM config payload (V2). Mirrors LLMConfigV2 so POST /llm/config validates at
 // the boundary instead of trusting an `as` cast, like the MCP/settings routes.

--- a/src/shared/cli-bridge/protocol.ts
+++ b/src/shared/cli-bridge/protocol.ts
@@ -40,6 +40,14 @@ export const CLI_BRIDGE_DISABLE_ENV = "YAKSHAVER_DISABLE_CLI_BRIDGE";
 export const CLI_BRIDGE_PORT_ENV = "YAKSHAVER_BRIDGE_PORT";
 export const CLI_BRIDGE_TOKEN_ENV = "YAKSHAVER_BRIDGE_TOKEN";
 
+/**
+ * Comma-separated server ids/names the front-door must restrict its toolset to (the project's
+ * `selectedMcpServerIds`). When unset/empty the front-door exposes every enabled server. The
+ * orchestrator injects it; `mcp-serve` reads it and forwards it on `GET /tools` + `POST /tools/call`
+ * so the server-side filter is applied where tools actually run.
+ */
+export const CLI_BRIDGE_SERVER_FILTER_ENV = "YAKSHAVER_BRIDGE_SERVER_FILTER";
+
 /** Placeholder shown instead of any secret value. */
 export const REDACTED = "***redacted***";
 
@@ -160,6 +168,12 @@ export const ToolCallInputSchema = z.object({
   name: z.string().min(1, "tool name is required"),
   /** Arguments object passed to the tool's execute(). Defaults to `{}`. */
   arguments: z.record(z.string(), z.unknown()).optional(),
+  /**
+   * Optional server ids/names to restrict resolution to (the project's selected servers). The tool
+   * must belong to one of them, mirroring the `GET /tools` filter, so a call can't reach a tool from
+   * an unselected project even if the model guesses its name.
+   */
+  serverFilter: z.array(z.string()).optional(),
 });
 export type ToolCallInput = z.infer<typeof ToolCallInputSchema>;
 


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Claude Code

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The original #915 branch was built on draft versions of #907/#909/#913 and would have reverted already-merged fixes (e.g. #834) if merged. This branch re-applies only #915's net-new work cleanly on top of the latest main.

> 2. What was changed?

✏️ Added a single yakshaver MCP front-door (yakshaver mcp-serve) plus the bridge's GET /tools / POST /tools/call endpoints, and rewired the local-claude orchestrator to proxy its whole aggregated toolset (including internal/in-memory servers) through that one entry instead of serializing each server.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
