### PR TITLE
XS✔ ◾ chore: commission ARMADA fleet

### DIFF
--- a/.armada/config.json
+++ b/.armada/config.json
@@ -1,0 +1,50 @@
+{
+  "triggerLabel": "armada",
+  "dispatch": "shipwright",
+  "baseBranch": "main",
+  "authors": "",
+  "autoMerge": false,
+  "notify": "terminal",
+  "bellCommand": "",
+  "mergeMethod": "squash",
+  "maxReviewRounds": 2,
+  "armadaRepo": "calumjs/ARMADA",
+  "autoArmSelfFixes": false,
+  "cartography": "off",
+  "foghorn": {
+    "flavour": "a gruff, proud nautical harbourmaster",
+    "verbosity": "normal",
+    "gate": "terminal",
+    "provider": "",
+    "voice": ""
+  },
+  "lighthouse": {
+    "enabled": false,
+    "autoArm": false,
+    "intervalHours": 24,
+    "commitsSinceScan": 20,
+    "minIdleToDispatch": true,
+    "budget": {
+      "maxRuntimeSec": 300,
+      "maxPlaywrightSec": 120,
+      "maxIssuesPerRun": 3,
+      "maxFindings": 20
+    }
+  },
+  "logbook": "off",
+  "publicIntake": {
+    "enabled": false,
+    "authors": "",
+    "autoArm": true,
+    "maxPerTick": 3,
+    "requireDoubleCheck": true,
+    "closeOnCharter": true
+  },
+  "commands": {
+    "build": "npm run build",
+    "test": "npm test",
+    "lint": "npm run lint",
+    "format": "npm run format",
+    "run": "npm run dev"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.armada/config.json` with auto-detected build/test/lint/format/run commands for this Electron + TypeScript + Biome + Vitest project
- Creates all 10 ARMADA GitHub labels (issue track, PR track, public-intake, fleet-defect)
- All autonomous features default off (`autoMerge`, `autoArmSelfFixes`, `cartography`, `lighthouse`, `publicIntake`) — opt-in by hand editing config

## Detected commands

| Command | Value |
| :--- | :--- |
| `build` | `npm run build` (runs `tsc`) |
| `test` | `npm test` (runs `vitest`) |
| `lint` | `npm run lint` (runs `biome check --write . --error-on-warnings`) |
| `format` | `npm run format` (runs `biome format --write .`) |
| `run` | `npm run dev` |

## Chartered (unarmed — for human review)

- **#932** — `ci: gate every PR on lint/build/test as a required check` — CI workflows already run on PRs but are not yet configured as required status checks on `main`. To arm later: `gh issue edit 932 --add-label armada`

## Test plan
- [ ] Review `.armada/config.json` — adjust any commands or settings before merging
- [ ] Confirm all 10 `armada:*` + `fleet-defect` labels exist on the repo
- [ ] Merge this PR, then run the `crows-nest` skill to arm the lookout

🤖 Generated with [Claude Code](https://claude.com/claude-code)