### PR TITLE
XS✔ ◾ armada: commission

### DIFF
--- a/.armada/config.json
+++ b/.armada/config.json
@@ -42,7 +42,7 @@
   },
   "commands": {
     "build": "npm run build",
-    "test": "npx vitest run",
+    "test": "npm rebuild better-sqlite3 --build-from-source && npx vitest run",
     "lint": "npm run lint",
     "format": "npm run format",
     "run": "npm run start"

--- a/.armada/config.json
+++ b/.armada/config.json
@@ -1,0 +1,50 @@
+{
+  "triggerLabel": "armada",
+  "dispatch": "shipwright",
+  "baseBranch": "main",
+  "authors": "",
+  "autoMerge": false,
+  "notify": "terminal",
+  "bellCommand": "",
+  "mergeMethod": "squash",
+  "maxReviewRounds": 2,
+  "armadaRepo": "calumjs/ARMADA",
+  "autoArmSelfFixes": false,
+  "cartography": "off",
+  "foghorn": {
+    "flavour": "a gruff, proud nautical harbourmaster",
+    "verbosity": "normal",
+    "gate": "terminal",
+    "provider": "",
+    "voice": ""
+  },
+  "lighthouse": {
+    "enabled": false,
+    "autoArm": false,
+    "intervalHours": 24,
+    "commitsSinceScan": 20,
+    "minIdleToDispatch": true,
+    "budget": {
+      "maxRuntimeSec": 300,
+      "maxPlaywrightSec": 120,
+      "maxIssuesPerRun": 3,
+      "maxFindings": 20
+    }
+  },
+  "logbook": "off",
+  "publicIntake": {
+    "enabled": false,
+    "authors": "",
+    "autoArm": true,
+    "maxPerTick": 3,
+    "requireDoubleCheck": true,
+    "closeOnCharter": true
+  },
+  "commands": {
+    "build": "npm run build",
+    "test": "npx vitest run",
+    "lint": "npm run lint",
+    "format": "npm run format",
+    "run": "npm run start"
+  }
+}


### PR DESCRIPTION
Bootstrap ARMADA for this repo: adds `.armada/config.json` and the `armada:*` labels.

Review the detected build/test commands + `baseBranch`, then merge to arm the fleet.