### PR TITLE
M⚠️ ◾ feat: Claude Code (local) orchestration readiness indicator + never-blank Executing Task (rebase #917)

### DIFF
--- a/src/backend/ipc/channels.ts
+++ b/src/backend/ipc/channels.ts
@@ -45,6 +45,7 @@ export const IPC_CHANNELS = {
   LLM_GET_CONFIG: "llm:get-config",
   LLM_CLEAR_CONFIG: "llm:clear-config",
   LLM_CHECK_HEALTH: "llm:check-health",
+  LLM_CHECK_ORCHESTRATOR_READINESS: "llm:check-orchestrator-readiness",
 
   // MCP
   MCP_PROCESS_MESSAGE: "mcp:process-message",

--- a/src/backend/ipc/llm-settings-handlers.ts
+++ b/src/backend/ipc/llm-settings-handlers.ts
@@ -1,5 +1,6 @@
 import type { LLMConfigV2 } from "@shared/types/llm";
 import { type IpcMainInvokeEvent, ipcMain } from "electron";
+import { checkClaudeReadiness } from "../services/mcp/claude-readiness";
 import { LanguageModelProvider } from "../services/mcp/language-model-provider";
 import { LlmStorage } from "../services/storage/llm-storage";
 import { IPC_CHANNELS } from "./channels";
@@ -34,6 +35,12 @@ export class LLMSettingsIPCHandlers {
     ipcMain.handle(IPC_CHANNELS.LLM_CHECK_HEALTH, async () => {
       const provider = await LanguageModelProvider.getInstance();
       return await provider.checkHealth();
+    });
+
+    // Readiness of the Claude Code (local-claude) orchestration backend — installed + (best-effort)
+    // authenticated — so the UI can warn BEFORE a run that Claude Code can't be driven.
+    ipcMain.handle(IPC_CHANNELS.LLM_CHECK_ORCHESTRATOR_READINESS, async () => {
+      return await checkClaudeReadiness();
     });
   }
 }

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -8,6 +8,7 @@ import {
   ProgressStage as WorkflowProgressStage,
   type WorkflowState,
 } from "../../shared/types/workflow";
+import type { OrchestratorBackend } from "../../shared/types/workflow-payloads";
 import { INITIAL_SUMMARY_PROMPT, TASK_EXECUTION_PROMPT } from "../constants/prompts";
 import { IdentityServerAuthService } from "../services/auth/identity-server-auth";
 import type { VideoUploadResult } from "../services/auth/types";
@@ -48,7 +49,7 @@ import {
 import { formatAndReportError } from "../utils/error-utils";
 import { IPC_CHANNELS } from "./channels";
 
-export type { VideoProcessingContext, RetryResult };
+export type { RetryResult, VideoProcessingContext };
 
 export const TranscriptSummarySchema = z.object({
   taskType: z.string(),
@@ -145,9 +146,12 @@ export class ProcessVideoIPCHandlers {
               ? this.lastVideoFilePath
               : undefined;
 
-          const mcpAdapter = new McpWorkflowAdapter(workflowManager);
+          const { orchestrator, backend } = await this.getBacklogOrchestrator();
 
-          const orchestrator = await this.getBacklogOrchestrator();
+          const mcpAdapter = new McpWorkflowAdapter(workflowManager, {
+            orchestrator: backend,
+          });
+
           const loopResult = await orchestrator.manualLoopAsync(
             intermediateOutput,
             videoUploadResult,
@@ -579,12 +583,13 @@ export class ProcessVideoIPCHandlers {
 
         const serverFilter = projectDetails?.selectedMcpServerIds;
 
+        const { orchestrator, backend } = await this.getBacklogOrchestrator();
+
         const mcpAdapter = new McpWorkflowAdapter(workflowManager, {
           transcriptText,
           intermediateOutput,
+          orchestrator: backend,
         });
-
-        const orchestrator = await this.getBacklogOrchestrator();
 
         // transcriptText guaranteed by: normal flow sets it in TRANSCRIBING; retry validated at entry
         const loopResult = await orchestrator.manualLoopAsync(
@@ -794,11 +799,17 @@ export class ProcessVideoIPCHandlers {
    * `local-claude` drives the step with a headless `claude -p`; anything else (including a config
    * with no `orchestrationBackend` field) uses the in-process OpenAI loop. Falls back to OpenAI if
    * the config can't be read so the stage never hard-fails on a config hiccup.
+   *
+   * Returns the chosen orchestrator alongside a UI-facing `backend` label (stamped into the
+   * Executing Task payload so the stage card can badge which orchestrator is active).
    */
-  private async getBacklogOrchestrator(): Promise<IBacklogOrchestrator> {
-    let backend: string | undefined;
+  private async getBacklogOrchestrator(): Promise<{
+    orchestrator: IBacklogOrchestrator;
+    backend: OrchestratorBackend;
+  }> {
+    let configuredBackend: string | undefined;
     try {
-      backend = (await LlmStorage.getInstance().getLLMConfig())?.orchestrationBackend;
+      configuredBackend = (await LlmStorage.getInstance().getLLMConfig())?.orchestrationBackend;
     } catch (error) {
       console.warn(
         "[ProcessVideo] Failed to read orchestration backend, defaulting to OpenAI",
@@ -806,12 +817,12 @@ export class ProcessVideoIPCHandlers {
       );
     }
 
-    if (backend === "local-claude") {
+    if (configuredBackend === "local-claude") {
       console.log("[ProcessVideo] Using local Claude Code orchestrator");
-      return new LocalClaudeOrchestrator();
+      return { orchestrator: new LocalClaudeOrchestrator(), backend: "claude-code" };
     }
 
-    return await MCPOrchestrator.getInstanceAsync();
+    return { orchestrator: await MCPOrchestrator.getInstanceAsync(), backend: "openai" };
   }
 
   private async formatFinalResult(mcpResult: string | undefined): Promise<string | undefined> {

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -61,6 +61,7 @@ const IPC_CHANNELS = {
   LLM_GET_CONFIG: "llm:get-config",
   LLM_CLEAR_CONFIG: "llm:clear-config",
   LLM_CHECK_HEALTH: "llm:check-health",
+  LLM_CHECK_ORCHESTRATOR_READINESS: "llm:check-orchestrator-readiness",
 
   // MCP
   MCP_PROCESS_MESSAGE: "mcp:process-message",
@@ -255,6 +256,8 @@ const electronAPI = {
     getConfig: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_GET_CONFIG),
     clearConfig: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_CLEAR_CONFIG),
     checkHealth: () => ipcRenderer.invoke(IPC_CHANNELS.LLM_CHECK_HEALTH),
+    checkOrchestratorReadiness: () =>
+      ipcRenderer.invoke(IPC_CHANNELS.LLM_CHECK_ORCHESTRATOR_READINESS),
   },
   mcp: {
     processMessage: (

--- a/src/backend/services/mcp/claude-readiness.test.ts
+++ b/src/backend/services/mcp/claude-readiness.test.ts
@@ -1,0 +1,128 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClaudeReadinessDeps,
+  checkClaudeReadiness,
+  detectClaudeAuth,
+  resolveCredentialsPath,
+} from "./claude-readiness";
+
+/** A spawner whose `claude --version` child closes with the given exit code (or emits an error). */
+function makeSpawner(opts: {
+  versionExitCode?: number;
+  spawnError?: boolean;
+  emitError?: boolean;
+}) {
+  const spawn = vi.fn((_cmd: string, _args: string[]) => {
+    if (opts.spawnError) throw new Error("spawn failed");
+    const child = new EventEmitter() as unknown as ChildProcess;
+    setImmediate(() => {
+      if (opts.emitError) child.emit("error", new Error("ENOENT"));
+      else child.emit("close", opts.versionExitCode ?? 0);
+    });
+    return child;
+  });
+  return { spawn };
+}
+
+function makeDeps(overrides: Partial<ClaudeReadinessDeps> = {}): ClaudeReadinessDeps {
+  return {
+    spawner: makeSpawner({ versionExitCode: 0 }),
+    env: {},
+    fileExists: () => false,
+    homeDir: () => "/home/test",
+    claudeCommand: "claude",
+    ...overrides,
+  };
+}
+
+describe("resolveCredentialsPath", () => {
+  it("uses CLAUDE_CONFIG_DIR when set", () => {
+    expect(resolveCredentialsPath({ CLAUDE_CONFIG_DIR: "/custom/dir" }, () => "/home/test")).toBe(
+      join("/custom/dir", ".credentials.json"),
+    );
+  });
+
+  it("falls back to <home>/.claude when CLAUDE_CONFIG_DIR is unset/blank", () => {
+    expect(resolveCredentialsPath({ CLAUDE_CONFIG_DIR: "  " }, () => "/home/test")).toBe(
+      join("/home/test", ".claude", ".credentials.json"),
+    );
+  });
+});
+
+describe("detectClaudeAuth", () => {
+  it("is true when an auth env var is set", () => {
+    const deps = makeDeps();
+    expect(detectClaudeAuth({ ANTHROPIC_API_KEY: "sk-123" }, deps)).toBe(true);
+    expect(detectClaudeAuth({ CLAUDE_CODE_OAUTH_TOKEN: "tok" }, deps)).toBe(true);
+  });
+
+  it("ignores blank/whitespace env values", () => {
+    expect(detectClaudeAuth({ ANTHROPIC_API_KEY: "   " }, makeDeps())).toBe(false);
+  });
+
+  it("is true when the credentials file exists", () => {
+    const credsPath = join("/home/test", ".claude", ".credentials.json");
+    const deps = makeDeps({ fileExists: (p) => p === credsPath });
+    expect(detectClaudeAuth({}, deps)).toBe(true);
+  });
+
+  it("is false with no env and no credentials file", () => {
+    expect(detectClaudeAuth({}, makeDeps())).toBe(false);
+  });
+});
+
+describe("checkClaudeReadiness", () => {
+  it("reports not-installed when `claude --version` exits non-zero", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 127 }) }),
+    );
+    expect(r).toMatchObject({ installed: false, ready: false, state: "not-installed" });
+    expect(r.message).toMatch(/not found on PATH/i);
+  });
+
+  it("reports not-installed when spawning errors (ENOENT)", async () => {
+    const r = await checkClaudeReadiness(makeDeps({ spawner: makeSpawner({ emitError: true }) }));
+    expect(r.state).toBe("not-installed");
+  });
+
+  it("reports not-installed when spawn throws synchronously", async () => {
+    const r = await checkClaudeReadiness(makeDeps({ spawner: makeSpawner({ spawnError: true }) }));
+    expect(r.state).toBe("not-installed");
+  });
+
+  it("reports not-authenticated when installed but no credentials", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 0 }) }),
+    );
+    expect(r).toMatchObject({ installed: true, authenticated: false, ready: false });
+    expect(r.state).toBe("not-authenticated");
+    expect(r.message).toMatch(/not signed in/i);
+  });
+
+  it("reports ready when installed and an auth env var is present", async () => {
+    const r = await checkClaudeReadiness(
+      makeDeps({ spawner: makeSpawner({ versionExitCode: 0 }), env: { ANTHROPIC_API_KEY: "sk" } }),
+    );
+    expect(r).toEqual({
+      installed: true,
+      authenticated: true,
+      ready: true,
+      state: "ready",
+      message: "",
+    });
+  });
+
+  it("reports ready when installed and a credentials file exists", async () => {
+    const credsPath = join("/home/test", ".claude", ".credentials.json");
+    const r = await checkClaudeReadiness(
+      makeDeps({
+        spawner: makeSpawner({ versionExitCode: 0 }),
+        fileExists: (p) => p === credsPath,
+      }),
+    );
+    expect(r.ready).toBe(true);
+  });
+});

--- a/src/backend/services/mcp/claude-readiness.ts
+++ b/src/backend/services/mcp/claude-readiness.ts
@@ -1,0 +1,123 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { OrchestratorReadiness } from "../../../shared/types/llm";
+import type { IProcessSpawner } from "../process/process-spawner";
+
+export type { OrchestratorReadiness } from "../../../shared/types/llm";
+
+/** Dependencies, injected so the unit tests stay pure (no real `claude`, no real FS/env). */
+export interface ClaudeReadinessDeps {
+  spawner: IProcessSpawner;
+  /** Process environment to inspect for auth env vars. */
+  env: NodeJS.ProcessEnv;
+  /** Existence check for the credentials file (injectable for tests). */
+  fileExists: (path: string) => boolean;
+  /** Resolver for the user's home directory (injectable for tests). */
+  homeDir: () => string;
+  /** Command used to invoke the CLI. */
+  claudeCommand: string;
+}
+
+const INSTALL_MESSAGE =
+  "Claude Code CLI not found on PATH. Install it (npm i -g @anthropic-ai/claude-code), or switch the Orchestrator to OpenAI.";
+
+const SIGN_IN_MESSAGE =
+  "Claude Code is installed but not signed in. Run `claude` in a terminal and complete the login, then re-check — or switch the Orchestrator to OpenAI.";
+
+/**
+ * Auth env vars that let `claude -p` run without an interactive login. Mirrors Claude Code's
+ * documented credential-precedence chain (cloud providers, bearer/API tokens, long-lived OAuth).
+ */
+const AUTH_ENV_VARS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "CLAUDE_CODE_USE_FOUNDRY",
+] as const;
+
+export const defaultClaudeReadinessDeps: Omit<ClaudeReadinessDeps, "claudeCommand"> = {
+  spawner: { spawn: (command, args) => spawn(command, args) },
+  env: process.env,
+  fileExists: (path) => existsSync(path),
+  homeDir: () => homedir(),
+};
+
+/**
+ * Resolve the path to Claude Code's credentials file, honouring `CLAUDE_CONFIG_DIR`
+ * and otherwise falling back to `<home>/.claude/.credentials.json`.
+ */
+export function resolveCredentialsPath(env: NodeJS.ProcessEnv, homeDir: () => string): string {
+  const baseDir = env.CLAUDE_CONFIG_DIR?.trim() || join(homeDir(), ".claude");
+  return join(baseDir, ".credentials.json");
+}
+
+/**
+ * Best-effort, NON-BILLING authentication signal: an auth env var is set, OR a credentials file
+ * exists at the resolved config dir.
+ *
+ * Known limitation: a macOS login that stores its token ONLY in the Keychain leaves no
+ * credentials file, so this can report `false` for an actually-signed-in mac user. That is a
+ * false "not ready" warning, never a false "ready" — and the run-time error path (which surfaces
+ * Claude's own auth error) remains the authoritative check. A Keychain probe / `claude -p` probe
+ * can be layered on later without changing this contract.
+ */
+export function detectClaudeAuth(env: NodeJS.ProcessEnv, deps: ClaudeReadinessDeps): boolean {
+  const hasAuthEnv = AUTH_ENV_VARS.some((name) => {
+    const value = env[name];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+  if (hasAuthEnv) return true;
+
+  return deps.fileExists(resolveCredentialsPath(env, deps.homeDir));
+}
+
+/** Spawn `claude --version` and resolve true iff it exits 0. Never rejects. */
+function detectClaudeInstalled(deps: ClaudeReadinessDeps): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = deps.spawner.spawn(deps.claudeCommand, ["--version"]);
+    } catch {
+      resolve(false);
+      return;
+    }
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}
+
+/**
+ * Compute the readiness of the Claude Code orchestration backend: is the CLI installed, and
+ * does it appear authenticated? Pure given its injected deps; never throws.
+ */
+export async function checkClaudeReadiness(
+  deps: ClaudeReadinessDeps = { ...defaultClaudeReadinessDeps, claudeCommand: "claude" },
+): Promise<OrchestratorReadiness> {
+  const installed = await detectClaudeInstalled(deps);
+  if (!installed) {
+    return {
+      installed: false,
+      authenticated: false,
+      ready: false,
+      state: "not-installed",
+      message: INSTALL_MESSAGE,
+    };
+  }
+
+  const authenticated = detectClaudeAuth(deps.env, deps);
+  if (!authenticated) {
+    return {
+      installed: true,
+      authenticated: false,
+      ready: false,
+      state: "not-authenticated",
+      message: SIGN_IN_MESSAGE,
+    };
+  }
+
+  return { installed: true, authenticated: true, ready: true, state: "ready", message: "" };
+}

--- a/src/backend/services/mcp/local-claude-orchestrator.test.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.test.ts
@@ -298,12 +298,14 @@ describe("LocalClaudeOrchestrator", () => {
         onStep: (s) => steps.push(s),
       });
 
-      // stdin received the system prompt + transcript
+      // stdin received the transcript as the user turn (the system prompt goes via argv)
       expect(runChild.stdin.write).toHaveBeenCalled();
       const written = (runChild.stdin.write as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(written).toContain("video transcription: a bug report");
 
       const types = steps.map((s) => s.type);
+      // A `start` step is always emitted first so the Executing Task box is never empty.
+      expect(types[0]).toBe("start");
       expect(types).toContain("reasoning");
       expect(types).toContain("tool_call");
       expect(types).toContain("tool_result");

--- a/src/backend/services/mcp/local-claude-orchestrator.ts
+++ b/src/backend/services/mcp/local-claude-orchestrator.ts
@@ -438,6 +438,13 @@ Embed this URL in the task content that you create. Follow user requirements STR
 
     const child = this.spawner.spawn(this.claudeCommand, argv);
 
+    // Always emit a first line so the Executing Task box is never empty, even before Claude
+    // streams anything (and even when its narration ends up terse).
+    options.onStep?.({
+      type: "start",
+      message: "Orchestrating with Claude Code…",
+    });
+
     // The orchestrator role is delivered via `--system-prompt` (in argv), so only the transcript
     // goes on stdin as the user turn. Passing it over stdin avoids argv length limits.
     const userPrompt = `video transcription: ${videoTranscription}`;
@@ -547,9 +554,14 @@ Embed this URL in the task content that you create. Follow user requirements STR
         if (stdoutBuffer.trim()) handleLine(stdoutBuffer);
 
         if (code !== 0 && terminationReason === "unknown") {
+          // A non-zero exit with no result event is most commonly an auth failure (the headless
+          // `claude -p` can't prompt for login, so it exits with an auth error on stderr). Append
+          // actionable guidance so the user isn't left with a bare exit code.
+          const guidance =
+            " Claude Code may not be signed in — run `claude` in a terminal to log in, or switch the Orchestrator to OpenAI in Settings.";
           reject(
             new Error(
-              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}`,
+              `Claude Code process exited with code ${code ?? "unknown"}.${stderr ? ` Error: ${stderr}` : ""}${guidance}`,
             ),
           );
           return;
@@ -608,8 +620,10 @@ Embed this URL in the task content that you create. Follow user requirements STR
     if (event.type === "assistant" && event.message?.content) {
       for (const block of event.message.content) {
         if (block.type === "text" && block.text) {
-          // Match the OpenAI loop's payload shape so ReasoningStep's JSON.parse path renders it
-          // (it reads `parsed.text`). Emitting raw text here would render blank in the UI.
+          // The UI's <ReasoningStep> JSON.parses `reasoning` and renders `parsed.text` — matching
+          // how the OpenAI loop emits it. Wrap Claude's raw text the same way; emitting a bare
+          // string would fail that parse and render a BLANK reasoning box (the root cause of the
+          // sparse Executing Task box under the local-claude backend).
           onStep?.({
             type: "reasoning",
             reasoning: JSON.stringify({ type: "text", text: block.text }),

--- a/src/backend/services/workflow/mcp-workflow-adapter.test.ts
+++ b/src/backend/services/workflow/mcp-workflow-adapter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { MCPStep } from "../../../shared/types/mcp";
+import { ProgressStage as WorkflowProgressStage } from "../../../shared/types/workflow";
+import type { ExecutingTaskPayload } from "../../../shared/types/workflow-payloads";
+import { McpWorkflowAdapter } from "./mcp-workflow-adapter";
+import type { WorkflowStateManager } from "./workflow-state-manager";
+
+/**
+ * Minimal in-memory stand-in for {@link WorkflowStateManager} that records the EXECUTING_TASK
+ * payload/status the way the real manager would, without pulling in electron/telemetry singletons.
+ */
+function makeStubManager() {
+  const store: { payload?: string; status: string } = { status: "not_started" };
+  const manager = {
+    getStepState: () => ({ payload: store.payload, status: store.status }),
+    updateStagePayload: (_stage: unknown, payload: unknown, status?: string) => {
+      store.payload = JSON.stringify(payload);
+      if (status) store.status = status;
+    },
+    completeStage: (_stage: unknown, payload?: unknown) => {
+      store.payload = payload ? JSON.stringify(payload) : undefined;
+      store.status = "completed";
+    },
+    failStage: (_stage: unknown, _error: string) => {
+      store.payload = JSON.stringify({ error: _error });
+      store.status = "failed";
+    },
+  } as unknown as WorkflowStateManager;
+
+  const readPayload = (): ExecutingTaskPayload =>
+    store.payload ? (JSON.parse(store.payload) as ExecutingTaskPayload) : { steps: [] };
+
+  return { manager, readPayload, getStatus: () => store.status };
+}
+
+describe("McpWorkflowAdapter", () => {
+  it("seeds the orchestrator backend into the EXECUTING_TASK payload at construction", () => {
+    const { manager, readPayload } = makeStubManager();
+
+    new McpWorkflowAdapter(manager, { orchestrator: "claude-code" });
+
+    expect(readPayload().orchestrator).toBe("claude-code");
+    expect(readPayload().steps).toEqual([]);
+  });
+
+  it("defaults to the openai backend label when seeded as such", () => {
+    const { manager, readPayload } = makeStubManager();
+
+    new McpWorkflowAdapter(manager, { transcriptText: "hi", orchestrator: "openai" });
+
+    expect(readPayload().orchestrator).toBe("openai");
+    expect(readPayload().transcriptText).toBe("hi");
+  });
+
+  it("preserves the orchestrator field as steps stream in and the stage completes", () => {
+    const { manager, readPayload } = makeStubManager();
+    const adapter = new McpWorkflowAdapter(manager, { orchestrator: "claude-code" });
+
+    const start: MCPStep = { type: "start", message: "Orchestrating with Claude Code (local)…" };
+    adapter.onStep(start);
+
+    expect(readPayload().orchestrator).toBe("claude-code");
+    expect(readPayload().steps).toHaveLength(1);
+
+    adapter.complete("done", "final");
+
+    const final = readPayload();
+    expect(final.orchestrator).toBe("claude-code");
+    expect(final.steps).toHaveLength(1);
+    expect(final.mcpResult).toBe("done");
+  });
+
+  it("preserves the streamed steps and orchestrator badge on the failed path (#833)", () => {
+    const { manager, readPayload, getStatus } = makeStubManager();
+    const adapter = new McpWorkflowAdapter(manager, { orchestrator: "claude-code" });
+
+    adapter.onStep({ type: "start", message: "Orchestrating with Claude Code…" });
+    adapter.onStep({ type: "tool_call", toolName: "create_backlog_item" });
+
+    adapter.fail("drafted result", "final output", "No work item was created");
+
+    const final = readPayload();
+    expect(getStatus()).toBe("failed");
+    // failStage clobbers the slot to { error } — fail() must restore the snapshot taken first.
+    expect(final.orchestrator).toBe("claude-code");
+    expect(final.steps).toHaveLength(2);
+    expect(final.error).toBe("No work item was created");
+    expect(final.mcpResult).toBe("drafted result");
+    expect(final.finalOutput).toBe("final output");
+  });
+
+  it("does not stamp an orchestrator when none is provided", () => {
+    const { manager, readPayload } = makeStubManager();
+
+    // No initialContext at all — payload is only seeded once a step arrives.
+    const adapter = new McpWorkflowAdapter(manager);
+    adapter.onStep({ type: "start" });
+
+    expect(readPayload().orchestrator).toBeUndefined();
+  });
+
+  it("targets the EXECUTING_TASK stage", () => {
+    expect(WorkflowProgressStage.EXECUTING_TASK).toBe("executing_task");
+  });
+});

--- a/src/backend/services/workflow/mcp-workflow-adapter.ts
+++ b/src/backend/services/workflow/mcp-workflow-adapter.ts
@@ -1,6 +1,9 @@
 import type { MCPStep } from "../../../shared/types/mcp";
 import { ProgressStage as WorkflowProgressStage } from "../../../shared/types/workflow";
-import type { ExecutingTaskPayload } from "../../../shared/types/workflow-payloads";
+import type {
+  ExecutingTaskPayload,
+  OrchestratorBackend,
+} from "../../../shared/types/workflow-payloads";
 import type { WorkflowStateManager } from "./workflow-state-manager";
 
 export class McpWorkflowAdapter {
@@ -9,7 +12,11 @@ export class McpWorkflowAdapter {
 
   constructor(
     workflowManager: WorkflowStateManager,
-    initialContext?: { transcriptText?: string; intermediateOutput?: unknown },
+    initialContext?: {
+      transcriptText?: string;
+      intermediateOutput?: unknown;
+      orchestrator?: OrchestratorBackend;
+    },
   ) {
     this.workflowManager = workflowManager;
 
@@ -66,12 +73,15 @@ export class McpWorkflowAdapter {
    * created a backlog item (#833).
    */
   public fail(finalResult: unknown, finalOutput: string | undefined, errorMessage: string) {
+    // Snapshot the streamed steps + orchestrator badge BEFORE failStage() clobbers the payload:
     // failStage records the error + telemetry but REPLACES the stage payload with just { error }.
+    const existing = this.getPayload();
     this.workflowManager.failStage(WorkflowProgressStage.EXECUTING_TASK, errorMessage);
-    // Re-attach the drafted result afterwards (keeping the failed status and the error) so the
-    // user can still see what the model produced.
+    // Re-attach the snapshotted result afterwards (keeping the failed status and the error) so the
+    // user can still see the streamed steps, the orchestrator badge, and what the model produced.
     const payload = {
-      ...this.getPayload(),
+      ...existing,
+      error: errorMessage,
       mcpResult: typeof finalResult === "string" ? finalResult : JSON.stringify(finalResult),
       finalOutput,
     };

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -32,6 +32,25 @@ export type OrchestrationBackend = "openai" | "local-claude";
 
 export const DEFAULT_ORCHESTRATION_BACKEND: OrchestrationBackend = "openai";
 
+/**
+ * Readiness of the local Claude Code (`local-claude`) orchestration backend, surfaced to the
+ * settings UI so the user learns BEFORE a run that Claude Code can't be driven.
+ *
+ * - `not-installed`     — the `claude` CLI isn't on PATH.
+ * - `not-authenticated` — the CLI is installed but no credentials were detected.
+ * - `ready`             — installed and (best-effort) authenticated.
+ */
+export type OrchestratorReadinessState = "ready" | "not-installed" | "not-authenticated";
+
+export interface OrchestratorReadiness {
+  installed: boolean;
+  authenticated: boolean;
+  ready: boolean;
+  state: OrchestratorReadinessState;
+  /** Short, user-facing guidance. Empty when ready. */
+  message: string;
+}
+
 export type LLMConfigV1 = ModelConfig & {
   version?: 1;
 };

--- a/src/shared/types/workflow-payloads.ts
+++ b/src/shared/types/workflow-payloads.ts
@@ -6,7 +6,14 @@ export interface VideoProcessingPayload {
   steps?: MCPStep[];
 }
 
+/** Which backend drives the Executing Task stage. Stamped at stage start so the UI can badge it. */
+export type OrchestratorBackend = "openai" | "claude-code";
+
 export interface ExecutingTaskPayload extends VideoProcessingPayload {
   mcpResult?: string;
   finalOutput?: string;
+  /** The orchestrator that drove this stage. `claude-code` = local `claude -p`; `openai` = in-process loop. */
+  orchestrator?: OrchestratorBackend;
+  /** Populated when the stage failed (e.g. the loop never created a backlog item, #833). */
+  error?: string;
 }

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -1,9 +1,17 @@
-import type { LLMConfigV2, OrchestrationBackend } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestrationBackend, OrchestratorReadiness } from "@shared/types/llm";
 import { DEFAULT_ORCHESTRATION_BACKEND } from "@shared/types/llm";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { ipcClient } from "@/services/ipc-client";
 import { formatErrorMessage } from "@/utils";
 
@@ -25,7 +33,7 @@ const BACKEND_OPTIONS: readonly BackendOption[] = [
   },
   {
     id: "local-claude",
-    title: "Claude Code (local)",
+    title: "Claude Code",
     description:
       'Drive backlog creation with a local headless `claude` process. Requires the `claude` CLI installed and on PATH, and still needs a configured OpenAI/Azure language model to verify success. Under "ask" approval mode only whitelisted tools run (no runtime approval prompt), and YakShaver\'s built-in screenshot tools are unavailable.',
   },
@@ -33,7 +41,7 @@ const BACKEND_OPTIONS: readonly BackendOption[] = [
 
 const BACKEND_LABELS: Record<OrchestrationBackend, string> = {
   openai: "OpenAI",
-  "local-claude": "Claude Code (local)",
+  "local-claude": "Claude Code",
 };
 
 export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSettingProps) {
@@ -42,6 +50,23 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
   );
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [pendingBackend, setPendingBackend] = useState<OrchestrationBackend | null>(null);
+  const [readiness, setReadiness] = useState<OrchestratorReadiness | null>(null);
+  const [isCheckingReadiness, setIsCheckingReadiness] = useState<boolean>(false);
+
+  // Probe whether the Claude Code backend is actually usable (CLI installed + signed in). Cheap and
+  // non-blocking; the result drives the warning + instructions below.
+  const checkReadiness = useCallback(async () => {
+    setIsCheckingReadiness(true);
+    try {
+      const result = await ipcClient.llm.checkOrchestratorReadiness();
+      setReadiness(result);
+    } catch (error) {
+      console.error("Failed to check orchestrator readiness", error);
+      setReadiness(null);
+    } finally {
+      setIsCheckingReadiness(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!isActive) {
@@ -67,10 +92,11 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
     };
 
     void load();
+    void checkReadiness();
     return () => {
       cancelled = true;
     };
-  }, [isActive]);
+  }, [isActive, checkReadiness]);
 
   const handleSelect = useCallback(
     async (backend: OrchestrationBackend) => {
@@ -95,6 +121,11 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         }
         setCurrentBackend(backend);
         toast.success(`Orchestrator set to ${BACKEND_LABELS[backend]}`);
+        // Surface readiness right after choosing Claude Code so the user learns immediately if the
+        // CLI is missing or not signed in.
+        if (backend === "local-claude") {
+          void checkReadiness();
+        }
       } catch (error) {
         console.error("Failed to update orchestrator backend", error);
         toast.error(`Failed to update orchestrator: ${formatErrorMessage(error)}`);
@@ -102,7 +133,7 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         setPendingBackend(null);
       }
     },
-    [currentBackend],
+    [currentBackend, checkReadiness],
   );
 
   return (
@@ -110,40 +141,62 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
       <CardHeader className="px-4">
         <CardTitle>Orchestrator</CardTitle>
         <CardDescription>
-          Choose which backend drives backlog creation. Claude Code (local) requires the{" "}
-          <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed.
+          Choose which backend drives backlog creation. Claude Code requires the{" "}
+          <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed, and
+          uses your Claude Code sign-in (no API key).
         </CardDescription>
       </CardHeader>
 
-      <CardContent className="px-4">
-        <div className="grid gap-2 md:grid-cols-2">
-          {BACKEND_OPTIONS.map((option) => {
-            const isSelected = option.id === currentBackend;
-            const isDisabled = isLoading || (!!pendingBackend && pendingBackend !== option.id);
+      <CardContent className="flex flex-col gap-2 px-4">
+        <Select
+          value={currentBackend}
+          onValueChange={(value) => void handleSelect(value as OrchestrationBackend)}
+          disabled={isLoading || pendingBackend !== null}
+        >
+          <SelectTrigger className="w-full md:w-72" aria-label="Orchestrator backend">
+            <SelectValue placeholder="Select an orchestrator" />
+          </SelectTrigger>
+          <SelectContent>
+            {BACKEND_OPTIONS.map((option) => (
+              <SelectItem key={option.id} value={option.id}>
+                {option.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {BACKEND_OPTIONS.find((o) => o.id === currentBackend)?.description}
+        </p>
 
-            return (
-              <button
-                key={option.id}
-                type="button"
-                onClick={() => void handleSelect(option.id)}
-                disabled={isDisabled}
-                aria-pressed={isSelected}
-                className={cn(
-                  "flex h-full flex-col gap-1.5 rounded-md border px-3 py-2 text-left transition-colors",
-                  "disabled:cursor-not-allowed disabled:opacity-60",
-                  isSelected
-                    ? "border-white/50 bg-white/10"
-                    : "border-white/10 hover:border-white/30 hover:bg-white/5",
-                )}
-              >
-                <span className="text-sm font-medium">{option.title}</span>
-                <span className="text-xs leading-relaxed text-muted-foreground">
-                  {option.description}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+        {/* Claude Code readiness: warn + instruct when the backend is selected but the local CLI
+            isn't installed or isn't signed in, so the user fixes it BEFORE a run fails. */}
+        {currentBackend === "local-claude" && readiness && !readiness.ready && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-950/40 px-3 py-2 text-xs leading-relaxed text-amber-100"
+          >
+            <AlertTriangle
+              className="mt-0.5 h-4 w-4 shrink-0 text-amber-400"
+              role="img"
+              aria-label="Claude Code not ready"
+            />
+            <div className="flex min-w-0 flex-col gap-2">
+              <span className="break-words">{readiness.message}</span>
+              <div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 border-amber-500/40 bg-transparent text-amber-100 hover:bg-amber-500/10"
+                  onClick={() => void checkReadiness()}
+                  disabled={isCheckingReadiness}
+                >
+                  {isCheckingReadiness && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
+                  Re-check
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -44,6 +44,11 @@ const BACKEND_LABELS: Record<OrchestrationBackend, string> = {
   "local-claude": "Claude Code",
 };
 
+/** Narrows a raw Select value to a known backend, so `onValueChange` doesn't rely on a bare cast. */
+function isOrchestrationBackend(value: string): value is OrchestrationBackend {
+  return BACKEND_OPTIONS.some((option) => option.id === value);
+}
+
 export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSettingProps) {
   const [currentBackend, setCurrentBackend] = useState<OrchestrationBackend>(
     DEFAULT_ORCHESTRATION_BACKEND,
@@ -54,7 +59,9 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
   const [isCheckingReadiness, setIsCheckingReadiness] = useState<boolean>(false);
 
   // Probe whether the Claude Code backend is actually usable (CLI installed + signed in). Cheap and
-  // non-blocking; the result drives the warning + instructions below.
+  // non-blocking; the result drives the warning + instructions below. Only relevant for the
+  // local-claude backend — it spawns `claude --version`, so skip (and clear) it for OpenAI to
+  // avoid spawning the CLI when Claude Code isn't in use.
   const checkReadiness = useCallback(async () => {
     setIsCheckingReadiness(true);
     try {
@@ -79,7 +86,15 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
       try {
         const cfg = await ipcClient.llm.getConfig();
         if (!cancelled) {
-          setCurrentBackend(cfg?.orchestrationBackend ?? DEFAULT_ORCHESTRATION_BACKEND);
+          const backend = cfg?.orchestrationBackend ?? DEFAULT_ORCHESTRATION_BACKEND;
+          setCurrentBackend(backend);
+          // Only probe Claude Code readiness when it's the selected backend; otherwise clear any
+          // stale result so a prior local-claude warning doesn't linger under OpenAI.
+          if (backend === "local-claude") {
+            void checkReadiness();
+          } else {
+            setReadiness(null);
+          }
         }
       } catch (error) {
         console.error("Failed to load orchestrator backend setting", error);
@@ -92,7 +107,6 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
     };
 
     void load();
-    void checkReadiness();
     return () => {
       cancelled = true;
     };
@@ -143,14 +157,16 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
         <CardDescription>
           Choose which backend drives backlog creation. Claude Code requires the{" "}
           <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed, and
-          uses your Claude Code sign-in (no API key).
+          uses your Claude Code sign-in instead of an Anthropic API key.
         </CardDescription>
       </CardHeader>
 
       <CardContent className="flex flex-col gap-2 px-4">
         <Select
           value={currentBackend}
-          onValueChange={(value) => void handleSelect(value as OrchestrationBackend)}
+          onValueChange={(value) => {
+            if (isOrchestrationBackend(value)) void handleSelect(value);
+          }}
           disabled={isLoading || pendingBackend !== null}
         >
           <SelectTrigger className="w-full md:w-72" aria-label="Orchestrator backend">

--- a/src/ui/src/components/settings/settings-health.test.ts
+++ b/src/ui/src/components/settings/settings-health.test.ts
@@ -118,6 +118,73 @@ describe("deriveSettingsHealth", () => {
     });
   });
 
+  describe("Orchestrator readiness (llm)", () => {
+    const notReady = {
+      installed: true,
+      authenticated: false,
+      ready: false,
+      state: "not-authenticated" as const,
+      message: "Claude Code is installed but not signed in.",
+    };
+
+    it("flags Claude Code as critical when selected but not ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm?.severity).toBe("critical");
+      expect(health.llm?.message).toMatch(/signed in/i);
+    });
+
+    it("does NOT flag when the backend is OpenAI, even if a stale readiness is not ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "openai" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("does NOT flag when Claude Code is ready", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: {
+            installed: true,
+            authenticated: true,
+            ready: true,
+            state: "ready",
+            message: "",
+          },
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("does NOT flag while readiness is still inconclusive (null)", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { ...healthyLlm, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: null,
+        }),
+      );
+      expect(health.llm).toBeUndefined();
+    });
+
+    it("keeps the missing-model message (more fundamental) over orchestrator readiness", () => {
+      const health = deriveSettingsHealth(
+        inputs({
+          llmConfig: { languageModel: null, orchestrationBackend: "local-claude" },
+          orchestratorReadiness: notReady,
+        }),
+      );
+      expect(health.llm?.message).toMatch(/api key/i);
+    });
+  });
+
   describe("Releases (release)", () => {
     it("flags a missing GitHub token as critical", () => {
       expect(deriveSettingsHealth(inputs({ hasGithubToken: false })).release?.severity).toBe(

--- a/src/ui/src/components/settings/settings-health.ts
+++ b/src/ui/src/components/settings/settings-health.ts
@@ -1,5 +1,5 @@
 import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
-import type { LLMConfigV2 } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { MCPServerConfig } from "@shared/types/mcp";
 import { useCallback, useEffect, useState } from "react";
 import { ipcClient } from "@/services/ipc-client";
@@ -35,7 +35,13 @@ export type SettingsHealthMap = Readonly<Record<string, SettingsTabHealth | unde
 
 export interface SettingsHealthInputs {
   /** The persisted LLM config (`ipcClient.llm.getConfig()`), or null if unset. */
-  llmConfig: Pick<LLMConfigV2, "languageModel"> | null;
+  llmConfig: Pick<LLMConfigV2, "languageModel" | "orchestrationBackend"> | null;
+  /**
+   * Readiness of the Claude Code orchestration backend (`ipcClient.llm.checkOrchestratorReadiness()`).
+   * Only meaningful when `orchestrationBackend === "local-claude"`; null/undefined means "not
+   * checked / inconclusive" and never raises a warning.
+   */
+  orchestratorReadiness?: OrchestratorReadiness | null;
   /** Configured MCP servers (`ipcClient.mcp.listServers()`). */
   mcpServers: ReadonlyArray<Pick<MCPServerConfig, "id" | "name" | "enabled">>;
   /** Health by server id; only an explicit `isHealthy === false` counts as down
@@ -66,6 +72,28 @@ export function deriveSettingsHealth(inputs: SettingsHealthInputs): SettingsHeal
       tabId: "llm",
       severity: "critical",
       message: "No language model API key is configured.",
+    };
+  }
+
+  // Orchestrator — when Claude Code is the chosen backend but it isn't ready (CLI missing or not
+  // signed in), the backlog-creation step will fail. Only flag on a positive not-ready result, and
+  // never override the more fundamental missing-model message on the same tab.
+  const readiness = inputs.orchestratorReadiness;
+  if (
+    !map.llm &&
+    inputs.llmConfig?.orchestrationBackend === "local-claude" &&
+    readiness &&
+    !readiness.ready
+  ) {
+    // Keep the nav-tooltip message terse (the full install/sign-in guidance lives in the inline
+    // warning on the Model Settings page); a long message overflows the small hover tooltip.
+    map.llm = {
+      tabId: "llm",
+      severity: "critical",
+      message:
+        readiness.state === "not-installed"
+          ? "Claude Code CLI not found."
+          : "Claude Code isn't signed in.",
     };
   }
 
@@ -113,6 +141,13 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
         ipcClient.githubToken.has().catch(() => true),
       ]);
 
+      // Only probe Claude Code readiness when it's the selected backend — otherwise it's irrelevant
+      // and we skip the spawn entirely.
+      const orchestratorReadiness =
+        llmConfig?.orchestrationBackend === "local-claude"
+          ? await ipcClient.llm.checkOrchestratorReadiness().catch(() => null)
+          : null;
+
       // Only probe health for the enabled backlog providers we might flag.
       const backlog = mcpServers.filter(isEnabledBacklogProvider);
       const mcpHealthById: Record<string, HealthStatusInfo | undefined> = {};
@@ -128,7 +163,15 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
         }),
       );
 
-      setHealth(deriveSettingsHealth({ llmConfig, mcpServers, mcpHealthById, hasGithubToken }));
+      setHealth(
+        deriveSettingsHealth({
+          llmConfig,
+          mcpServers,
+          mcpHealthById,
+          hasGithubToken,
+          orchestratorReadiness,
+        }),
+      );
     } catch {
       // Couldn't read config — say nothing rather than show a misleading indicator.
       setHealth({});

--- a/src/ui/src/components/workflow/WorkflowStepCard.tsx
+++ b/src/ui/src/components/workflow/WorkflowStepCard.tsx
@@ -40,7 +40,7 @@ function OrchestratorBadge({ backend }: { backend: OrchestratorBackend }) {
       <Badge
         variant="outline"
         className="border-amber-400/40 bg-amber-400/10 text-amber-300"
-        title="Orchestrated by the Claude Code CLI on this machine — uses your Claude Code sign-in, no API key"
+        title="Orchestrated by the Claude Code CLI on this machine — uses your Claude Code sign-in instead of an Anthropic API key"
       >
         <Sparkles className="size-3" />
         Claude Code

--- a/src/ui/src/components/workflow/WorkflowStepCard.tsx
+++ b/src/ui/src/components/workflow/WorkflowStepCard.tsx
@@ -1,14 +1,62 @@
 import type { WorkflowState, WorkflowStep } from "@shared/types/workflow";
-import { CheckCircle2, ChevronDown, ChevronRight, Loader2, RefreshCw, XCircle } from "lucide-react";
+import type { OrchestratorBackend } from "@shared/types/workflow-payloads";
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  RefreshCw,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { formatErrorMessage, isErrorStep } from "@/utils";
 import { ipcClient } from "../../services/ipc-client";
 import type { MCPStep } from "../../types";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
 import { StageWithContent } from "./StageWithContent";
+
+/**
+ * Reads the active orchestrator that drove the Executing Task stage from its parsed payload.
+ * Stamped backend-side at stage start (see ExecutingTaskPayload.orchestrator).
+ */
+function getOrchestratorBackend(stage: string, parsed: unknown): OrchestratorBackend | null {
+  if (stage !== "executing_task" || !isRecord(parsed)) return null;
+  const backend = parsed.orchestrator;
+  return backend === "claude-code" || backend === "openai" ? backend : null;
+}
+
+/**
+ * A distinct pill marking the Executing Task stage as driven by the local Claude Code orchestrator,
+ * so the user clearly sees it even when Claude's live reasoning is terse.
+ */
+function OrchestratorBadge({ backend }: { backend: OrchestratorBackend }) {
+  if (backend === "claude-code") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-amber-400/40 bg-amber-400/10 text-amber-300"
+        title="Orchestrated by the Claude Code CLI on this machine — uses your Claude Code sign-in, no API key"
+      >
+        <Sparkles className="size-3" />
+        Claude Code
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="border-white/15 bg-white/5 text-white/50"
+      title="OpenAI orchestrator"
+    >
+      OpenAI
+    </Badge>
+  );
+}
 
 const STATUS_CONFIG = {
   in_progress: {
@@ -120,6 +168,8 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
     }
   }, [step.payload, step.stage]);
 
+  const orchestratorBackend = getOrchestratorBackend(step.stage, parsedPayload);
+
   const effectiveStatus: WorkflowStep["status"] =
     hasStepErrors && step.status === "completed" ? "failed" : step.status;
 
@@ -174,6 +224,7 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
             <div className="flex items-center gap-3 flex-1">
               <StatusIcon status={effectiveStatus} />
               <span className={cn("font-medium", config.textClass)}>{label}</span>
+              {orchestratorBackend && <OrchestratorBadge backend={orchestratorBackend} />}
             </div>
             <div className="text-white/50 hover:text-white/90">
               {isExpanded ? (
@@ -187,6 +238,7 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
           <div className="flex items-center gap-3 flex-1">
             <StatusIcon status={effectiveStatus} />
             <span className={cn("font-medium", config.textClass)}>{label}</span>
+            {orchestratorBackend && <OrchestratorBadge backend={orchestratorBackend} />}
           </div>
         )}
         {step.status === "failed" && shaveId && (

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -1,4 +1,4 @@
-import type { LLMConfigV2 } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { TelemetrySettings } from "@shared/types/telemetry";
 import type { UserSettings } from "@shared/types/user-settings";
 import type { WorkflowState } from "@shared/types/workflow";
@@ -69,6 +69,7 @@ declare global {
         getConfig: () => Promise<LLMConfigV2 | null>;
         clearConfig: () => Promise<{ success: boolean }>;
         checkHealth: () => Promise<HealthStatusInfo>;
+        checkOrchestratorReadiness: () => Promise<OrchestratorReadiness>;
       };
       auth: {
         microsoft: {


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Claude Code Opus 4.8

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ PR #917 was merged into the old feat/915 stack but never reached main — when #915 was rebased onto main as #923, #917's orchestration-indicator work was dropped, so it had to be rebase onto current main.

> 2. What was changed?

✏️ Added a Claude Code readiness check (CLI installed + signed-in) that warns in Settings before a run fails, plus an orchestrator badge and a guaranteed first "start" step so the Executing Task stage is never blank under the local-claude backend.


<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
