### PR TITLE
XS⚠️ ◾ fix(ui): stop hover-glow on non-interactive status badges

### DIFF
--- a/src/ui/src/components/ui/badge.tsx
+++ b/src/ui/src/components/ui/badge.tsx
@@ -15,7 +15,7 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         success:
-          "bg-green-400/20 text-green-400 border-green-400/30 hover:bg-green-400/30",
+          "bg-green-400/20 text-green-400 border-green-400/30 [a&]:hover:bg-green-400/30",
         outline: "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },
     },


### PR DESCRIPTION
## Summary

Investigated GitHub issue #494 ("My Shaves - UX Improvements"), which reported several problems with a narrow, non-resizable "My Shave" side blade opened from a top-right button: titles not clickable, a "View Backlog" link opening a specific item instead of the backlog list, and hover states implying clickability that doesn't exist.

**Most of the reported UI surface no longer exists.** A prior UI overhaul (the homepage/navigation rework referenced by `#821`/`#815` in this codebase) replaced the narrow side blade entirely with a full-width `HomePage` ("My Shaves") reached via a permanent left-sidebar link — not a drawer/blade toggled from the top-right. A repo maintainer also commented on the issue that it's stale and the UI has since updated. Concretely, on the current `main`:

- There is no side blade/panel component left at all (the `Drawer` primitive in `src/ui/src/components/ui/drawer.tsx` is unused dead scaffold code) — so "too narrow" / "not resizable" doesn't apply to anything that exists today.
- List item titles **are already** clickable `<Link>` elements (`shave-columns.tsx`, `ShaveCards.tsx`), linking to the shave's in-app Workflow Progress page (a deliberate decision from #821, not a regression).
- There is no generic "View Backlog" link anymore; the current per-row action is a "View work item" icon button (`ShaveAction.tsx`) that opens the *specific* work item — which is the expected behavior for a per-row action, not a bug.
- The tooltip-icon hover/cursor mismatch described in a follow-up comment doesn't map onto anything in the current codebase — there's no `Tooltip` component at all.

**One concretely reproducible defect from the issue remains true today**, and this PR fixes it:

- The `success` badge variant (used for the "Completed" status pill throughout My Shaves) applied `hover:bg-green-400/30` unconditionally on a plain, non-interactive `<span>` with no `onClick` and no `cursor-pointer` — a real "glows like it's clickable but isn't" affordance mismatch, exactly as described in the issue and its follow-up comment.

### Approach

Every other variant in `src/ui/src/components/ui/badge.tsx` (`default`, `secondary`, `destructive`, `outline`) already scopes its hover treatment to the `[a&]:hover:...` selector, which only applies when the badge is rendered `asChild` as an anchor — i.e. only when it's actually clickable. `success` was the one variant that didn't follow this convention. Bringing it in line fixes the defect with a minimal, convention-matching one-line change, with no risk to the (non-existent) other UI surfaces the issue describes.

### Files changed

- `src/ui/src/components/ui/badge.tsx` — scope the `success` variant's hover background to `[a&]:hover:bg-green-400/30` (anchor-only), matching every other variant.

### Acceptance criteria mapping

- Wider default blade / resizable edge — **not applicable**: the side blade no longer exists; My Shaves is now a full-width page.
- List titles clickable to open the PBI — **already true** on `main` (titles link to the workflow progress page; not a regression from this issue).
- "View Backlog" opens the backlog, not an item — **not applicable**: no such link exists anymore; the per-row link intentionally opens the specific work item.
- Hover states shouldn't imply clickability that doesn't exist — **fixed** for the "Completed"/`success` status badge in this PR.

### Testing strategy

- `npm run build` — passes.
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run` — 577/577 tests pass (no existing badge test to update; no behavioral test coverage exists for hover-only CSS states).
- `npm run lint` — clean.
- Manually verified via code inspection that `success` is only ever rendered as a plain `<span>` (never `asChild`/anchor) across its current usages (`shave-columns.tsx`, `ShaveCards.tsx`, `PlatformConnectionCard.tsx`), so the hover class was dead/misleading in every current usage and removing it changes no intended-clickable surface.

### Risks / open questions

- The bulk of issue #494's original report (blade width/resizability, title-click-to-PBI, "View Backlog" target) is superseded by an unrelated prior UI overhaul and doesn't apply to the current codebase — recommend closing #494 as stale/superseded once this narrower fix lands, per the maintainer's own comment on the issue.

Relates to #494