### PR TITLE
S✔ ◾ fix: require a healthy GitHub token before listing/selecting/downloading PR releases

### DIFF
--- a/src/backend/ipc/github-token-handlers.ts
+++ b/src/backend/ipc/github-token-handlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from "electron";
+import type { GitHubTokenVerification } from "../services/github/github-token-verifier";
+import { verifyGitHubToken } from "../services/github/github-token-verifier";
 import { GitHubTokenStorage } from "../services/storage/github-token-storage";
-import { formatAndReportError } from "../utils/error-utils";
 import { IPC_CHANNELS } from "./channels";
 
 export class GitHubTokenIPCHandlers {
@@ -30,66 +31,8 @@ export class GitHubTokenIPCHandlers {
     return await this.store.hasToken();
   }
 
-  private async verifyToken(): Promise<{
-    isValid: boolean;
-    username?: string;
-    scopes?: string[];
-    rateLimitRemaining?: number;
-    error?: string;
-  }> {
-    try {
-      const token = await this.store.getToken();
-      if (!token) {
-        return { isValid: false, error: "No token configured" };
-      }
-
-      const response = await fetch("https://api.github.com/user", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "User-Agent": "SSW-YakShaver-Desktop",
-        },
-      });
-
-      // Extract scopes and rate limit info from headers even on non-200
-      const scopesHeader = response.headers.get("x-oauth-scopes") || "";
-      const scopes = scopesHeader
-        .split(",")
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-      const rateLimitRemainingHeader = response.headers.get("x-ratelimit-remaining");
-      const rateLimitRemaining = rateLimitRemainingHeader
-        ? Number.parseInt(rateLimitRemainingHeader, 10)
-        : undefined;
-
-      if (!response.ok) {
-        let errorMessage = response.statusText;
-        if (response.status === 401) {
-          errorMessage = "Invalid or expired token";
-        } else if (response.status === 403) {
-          if (rateLimitRemaining === 0) {
-            errorMessage = "Rate limit exceeded";
-          }
-        }
-        return {
-          isValid: false,
-          scopes,
-          rateLimitRemaining,
-          error: errorMessage,
-        };
-      }
-
-      const userData = await response.json();
-      const username: string | undefined = userData?.login;
-
-      return {
-        isValid: true,
-        username,
-        scopes,
-        rateLimitRemaining,
-      };
-    } catch (error) {
-      return { isValid: false, error: formatAndReportError(error, "github_token") };
-    }
+  private async verifyToken(): Promise<GitHubTokenVerification> {
+    const token = await this.store.getToken();
+    return verifyGitHubToken(token);
   }
 }

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -178,6 +178,54 @@ describe("ReleaseChannelIPCHandlers — PR releases require a healthy GitHub tok
     expect(result).toEqual({ available: true, version: "beta.42.1" });
   });
 
+  it("caches a healthy token-health result within the 60s TTL — a second call within the window does not re-verify", async () => {
+    vi.useFakeTimers();
+    try {
+      verifyGitHubTokenMock.mockResolvedValue({ isValid: true, username: "octocat" });
+
+      const { ipcMain } = await import("electron");
+      new ReleaseChannelIPCHandlers();
+      const listReleases = getRegisteredHandler(
+        ipcMain.handle as Mock,
+        "release-channel:list-releases",
+      );
+
+      await listReleases();
+      expect(verifyGitHubTokenMock).toHaveBeenCalledTimes(1);
+
+      // Still within the 60s cache TTL — must reuse the cached result, not re-verify.
+      vi.advanceTimersByTime(30 * 1000);
+      await listReleases();
+      expect(verifyGitHubTokenMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-verifies the token after the 60s cache TTL expires", async () => {
+    vi.useFakeTimers();
+    try {
+      verifyGitHubTokenMock.mockResolvedValue({ isValid: true, username: "octocat" });
+
+      const { ipcMain } = await import("electron");
+      new ReleaseChannelIPCHandlers();
+      const listReleases = getRegisteredHandler(
+        ipcMain.handle as Mock,
+        "release-channel:list-releases",
+      );
+
+      await listReleases();
+      expect(verifyGitHubTokenMock).toHaveBeenCalledTimes(1);
+
+      // Past the 60s cache TTL — must re-verify against GitHub rather than serve a stale result.
+      vi.advanceTimersByTime(61 * 1000);
+      await listReleases();
+      expect(verifyGitHubTokenMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not require a token at all for the latest stable channel", async () => {
     getChannelMock.mockResolvedValue({ type: "latest" });
     getTokenMock.mockResolvedValue(undefined);

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -226,6 +226,104 @@ describe("ReleaseChannelIPCHandlers — PR releases require a healthy GitHub tok
     }
   });
 
+  it("listReleases distinguishes 'no token configured' from 'invalid token' — no misleading invalid-token error", async () => {
+    // Regression coverage (review on #939): a user who has never configured a GitHub token must
+    // not see the same "invalid or expired" wording as someone whose saved token failed
+    // verification — isGitHubTokenHealthy() must never even reach verifyGitHubToken() in this case.
+    getTokenMock.mockResolvedValue(undefined);
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const listReleases = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:list-releases",
+    );
+
+    const result = await listReleases();
+
+    expect(verifyGitHubTokenMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      releases: [],
+      error: expect.not.stringMatching(/invalid or expired/i),
+    });
+  });
+
+  it("checkForUpdates on a PR channel distinguishes 'no token configured' from 'invalid token'", async () => {
+    getTokenMock.mockResolvedValue(undefined);
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const checkForUpdates = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:check-updates",
+    );
+
+    const result = await checkForUpdates();
+
+    expect(verifyGitHubTokenMock).not.toHaveBeenCalled();
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      available: false,
+      error: expect.not.stringMatching(/invalid or expired/i),
+    });
+  });
+
+  it("does not report a rate-limited token as invalid — distinguishes 403 rate-limit from 401 invalid", async () => {
+    // Regression coverage (review on #939): verifyGitHubToken() already distinguishes a rate-limit
+    // (403) from an actually-invalid token (401) in its `error` field; isGitHubTokenHealthy() must
+    // propagate that distinction rather than reporting both as "invalid or expired".
+    verifyGitHubTokenMock.mockResolvedValue({ isValid: false, error: "Rate limit exceeded" });
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const listReleases = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:list-releases",
+    );
+
+    const result = await listReleases();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      releases: [],
+      error: expect.stringMatching(/rate limit/i),
+    });
+    expect((result as { error?: string }).error).toEqual(
+      expect.not.stringMatching(/invalid or expired/i),
+    );
+  });
+
+  it("configureAutoUpdater still (re)starts periodic checks on the unhealthy-token early-return path", async () => {
+    // Regression coverage (review on #939): configureAutoUpdater() used to return early on an
+    // unhealthy token without reaching the startPeriodicUpdateChecks() call at the end of the
+    // method — meaning periodic checks would never (re)start later if the token became healthy
+    // again without another explicit reconfigure call. Assert the timer gets armed even on this
+    // early-return path by advancing past one interval and observing a checkForUpdates-driven call.
+    vi.useFakeTimers();
+    try {
+      verifyGitHubTokenMock.mockResolvedValue({
+        isValid: false,
+        error: "Invalid or expired token",
+      });
+      getChannelMock.mockResolvedValue({ type: "pr", channel: "beta.42" });
+
+      const handlers = new ReleaseChannelIPCHandlers();
+      await handlers.configureAutoUpdater({ type: "pr", channel: "beta.42" });
+
+      // The unhealthy token blocked configuration itself (no feed URL set)...
+      expect(setFeedURLMock).not.toHaveBeenCalled();
+
+      // ...but the periodic timer must still be armed: advancing past one interval should invoke
+      // the gated checkForUpdates() path, which re-verifies the token via verifyGitHubToken().
+      const callsBefore = verifyGitHubTokenMock.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
+      expect(verifyGitHubTokenMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not require a token at all for the latest stable channel", async () => {
     getChannelMock.mockResolvedValue({ type: "latest" });
     getTokenMock.mockResolvedValue(undefined);

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+// Keep Electron, the real autoUpdater, and encrypted storage out of this unit test — we're
+// exercising the token-health gating logic in ReleaseChannelIPCHandlers (#919), not Electron
+// itself.
+vi.mock("electron", () => ({
+  app: {
+    getName: () => "YakShaver",
+    getVersion: () => "1.2.3",
+    isPackaged: true,
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+  dialog: { showMessageBox: vi.fn().mockResolvedValue({ response: 1 }) },
+  ipcMain: { handle: vi.fn() },
+}));
+
+const checkForUpdatesMock = vi.fn();
+const setFeedURLMock = vi.fn();
+vi.mock("electron-updater", () => ({
+  autoUpdater: {
+    autoDownload: false,
+    autoInstallOnAppQuit: false,
+    channel: undefined,
+    allowPrerelease: false,
+    allowDowngrade: false,
+    requestHeaders: {},
+    on: vi.fn(),
+    setFeedURL: (...args: unknown[]) => setFeedURLMock(...args),
+    checkForUpdates: (...args: unknown[]) => checkForUpdatesMock(...args),
+  },
+}));
+
+vi.mock("../index", () => ({ setIsQuitting: vi.fn() }));
+vi.mock("../config/env", () => ({ config: { commitHash: () => null } }));
+
+const verifyGitHubTokenMock = vi.fn();
+vi.mock("../services/github/github-token-verifier", () => ({
+  verifyGitHubToken: (...args: unknown[]) => verifyGitHubTokenMock(...args),
+}));
+
+const getTokenMock = vi.fn();
+vi.mock("../services/storage/github-token-storage", () => ({
+  GitHubTokenStorage: { getInstance: () => ({ getToken: getTokenMock }) },
+}));
+
+const getChannelMock = vi.fn();
+const setChannelMock = vi.fn();
+vi.mock("../services/storage/release-channel-storage", () => ({
+  ReleaseChannelStorage: {
+    getInstance: () => ({ getChannel: getChannelMock, setChannel: setChannelMock }),
+  },
+}));
+
+import { ReleaseChannelIPCHandlers } from "./release-channel-handlers";
+
+function releasesResponse(): Response {
+  const releases = [
+    {
+      id: 1,
+      tag_name: "beta.42.1",
+      name: "PR #42 build",
+      body: "PR #42",
+      prerelease: true,
+      published_at: "2026-01-01T00:00:00Z",
+      html_url: "https://example.com",
+    },
+  ];
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => releases,
+    text: async () => JSON.stringify(releases),
+  } as unknown as Response;
+}
+
+// Reach into the private IPC-handler methods the same way the constructor wires them — via the
+// ipcMain.handle mock calls — so the test exercises exactly what the renderer would trigger.
+function getRegisteredHandler(ipcMainHandleMock: Mock, channelName: string) {
+  const call = ipcMainHandleMock.mock.calls.find(([channel]) => channel === channelName);
+  if (!call) throw new Error(`No handler registered for ${channelName}`);
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+describe("ReleaseChannelIPCHandlers — PR releases require a healthy GitHub token (#919)", () => {
+  let fetchMock: Mock;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getTokenMock.mockResolvedValue("some-token");
+    getChannelMock.mockResolvedValue({ type: "pr", channel: "beta.42" });
+    fetchMock = vi.fn().mockResolvedValue(releasesResponse());
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("listReleases refuses to call the GitHub API and surfaces a clear error when the token is invalid", async () => {
+    verifyGitHubTokenMock.mockResolvedValue({ isValid: false, error: "Invalid or expired token" });
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const listReleases = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:list-releases",
+    );
+
+    const result = await listReleases();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      releases: [],
+      error: expect.stringMatching(/invalid|expired/i),
+    });
+  });
+
+  it("listReleases succeeds and calls the GitHub API when the token is healthy", async () => {
+    verifyGitHubTokenMock.mockResolvedValue({ isValid: true, username: "octocat" });
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const listReleases = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:list-releases",
+    );
+
+    const result = (await listReleases()) as {
+      releases: Array<{ prNumber: string }>;
+      error?: string;
+    };
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(result.error).toBeUndefined();
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0].prNumber).toBe("42");
+  });
+
+  it("checkForUpdates on a PR channel refuses to download when the token is invalid — the reported bug", async () => {
+    verifyGitHubTokenMock.mockResolvedValue({ isValid: false, error: "Invalid or expired token" });
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const checkForUpdates = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:check-updates",
+    );
+
+    const result = await checkForUpdates();
+
+    // The core regression this issue is about: an invalid token must never reach the autoUpdater
+    // or trigger a download.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+    expect(setFeedURLMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      available: false,
+      error: expect.stringMatching(/invalid|expired/i),
+    });
+  });
+
+  it("checkForUpdates on a PR channel proceeds to the autoUpdater when the token is healthy", async () => {
+    verifyGitHubTokenMock.mockResolvedValue({ isValid: true, username: "octocat" });
+    checkForUpdatesMock.mockResolvedValue({ updateInfo: { version: "beta.42.1" } });
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const checkForUpdates = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:check-updates",
+    );
+
+    const result = await checkForUpdates();
+
+    expect(setFeedURLMock).toHaveBeenCalled();
+    expect(checkForUpdatesMock).toHaveBeenCalled();
+    expect(result).toEqual({ available: true, version: "beta.42.1" });
+  });
+
+  it("does not require a token at all for the latest stable channel", async () => {
+    getChannelMock.mockResolvedValue({ type: "latest" });
+    getTokenMock.mockResolvedValue(undefined);
+    checkForUpdatesMock.mockResolvedValue(null);
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const checkForUpdates = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:check-updates",
+    );
+
+    const result = await checkForUpdates();
+
+    // verifyGitHubToken is never even consulted for the stable channel.
+    expect(verifyGitHubTokenMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ available: false });
+  });
+});

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -294,6 +294,32 @@ describe("ReleaseChannelIPCHandlers — PR releases require a healthy GitHub tok
     );
   });
 
+  it("does not report a network/transport failure as an invalid token — distinguishes offline/DNS/TLS errors from 401 invalid", async () => {
+    // Regression coverage (muster review on #939): verifyGitHubToken()'s catch block surfaces the
+    // raw fetch/DNS/TLS error text (e.g. "fetch failed") rather than "Invalid or expired token" —
+    // isGitHubTokenHealthy() must not collapse that into the generic invalid-token message, since a
+    // user who is simply offline has no evidence their token is actually bad.
+    verifyGitHubTokenMock.mockResolvedValue({ isValid: false, error: "fetch failed" });
+
+    const { ipcMain } = await import("electron");
+    new ReleaseChannelIPCHandlers();
+    const listReleases = getRegisteredHandler(
+      ipcMain.handle as Mock,
+      "release-channel:list-releases",
+    );
+
+    const result = await listReleases();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      releases: [],
+      error: expect.stringMatching(/couldn't verify|network/i),
+    });
+    expect((result as { error?: string }).error).toEqual(
+      expect.not.stringMatching(/invalid or expired/i),
+    );
+  });
+
   it("configureAutoUpdater still (re)starts periodic checks on the unhealthy-token early-return path", async () => {
     // Regression coverage (review on #939): configureAutoUpdater() used to return early on an
     // unhealthy token without reaching the startPeriodicUpdateChecks() call at the end of the

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -41,6 +41,13 @@ const RELEASES_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const TOKEN_HEALTH_CACHE_TTL = 60 * 1000; // 1 minute
 const INVALID_TOKEN_ERROR =
   "GitHub token is invalid or expired. Update it in Settings | GitHub Token to use PR releases.";
+// Distinct from INVALID_TOKEN_ERROR (review on #919) — "no token saved" and "saved but invalid"
+// are different states and must not share the same "invalid or expired" wording, otherwise a user
+// who never configured a token gets a misleading "invalid" error on every Settings load.
+const NO_TOKEN_ERROR =
+  "A GitHub token is required to list, select, or download PR releases. Add one in Settings | GitHub Token.";
+const RATE_LIMITED_ERROR =
+  "GitHub API rate limit exceeded while verifying your token. Your token is fine — try again shortly.";
 
 export class ReleaseChannelIPCHandlers {
   private store = ReleaseChannelStorage.getInstance();
@@ -50,7 +57,13 @@ export class ReleaseChannelIPCHandlers {
     fetchedAt: number;
     etag?: string;
   } | null = null;
-  private tokenHealthCache: { isValid: boolean; checkedAt: number; token: string } | null = null;
+  private tokenHealthCache: {
+    isValid: boolean;
+    checkedAt: number;
+    token: string;
+    isRateLimited: boolean;
+    error?: string;
+  } | null = null;
   private updateCheckInterval: NodeJS.Timeout | null = null;
   private readonly UPDATE_CHECK_INTERVAL = 10 * 60 * 1000; // Check every 10 minutes
   private updateDialogDismissedInSession = false; // Track if user dismissed update dialog this session
@@ -141,11 +154,20 @@ export class ReleaseChannelIPCHandlers {
    *
    * Cached briefly per-token so repeated list/select/download calls in quick succession don't each
    * re-verify against the GitHub API.
+   *
+   * Returns a small status object rather than a bare boolean (review on #919) so callers can tell
+   * apart three distinct states that all render as "not healthy" but need different treatment:
+   *   - no token saved at all — not an error, just an unconfigured feature (NO_TOKEN_ERROR)
+   *   - a rate-limited check — the token itself may be fine, GitHub is just throttling us
+   *     (RATE_LIMITED_ERROR)
+   *   - an actually invalid/expired token (INVALID_TOKEN_ERROR)
    */
-  private async isGitHubTokenHealthy(forceRefresh = false): Promise<boolean> {
+  private async isGitHubTokenHealthy(
+    forceRefresh = false,
+  ): Promise<{ healthy: boolean; noToken: boolean; isRateLimited: boolean; error?: string }> {
     const token = await this.tokenStore.getToken();
     if (!token) {
-      return false;
+      return { healthy: false, noToken: true, isRateLimited: false };
     }
 
     if (
@@ -154,18 +176,54 @@ export class ReleaseChannelIPCHandlers {
       this.tokenHealthCache.token === token &&
       Date.now() - this.tokenHealthCache.checkedAt < TOKEN_HEALTH_CACHE_TTL
     ) {
-      return this.tokenHealthCache.isValid;
+      return {
+        healthy: this.tokenHealthCache.isValid,
+        noToken: false,
+        isRateLimited: this.tokenHealthCache.isRateLimited,
+        error: this.tokenHealthCache.error,
+      };
     }
 
     const verification = await verifyGitHubToken(token);
-    this.tokenHealthCache = { isValid: verification.isValid, checkedAt: Date.now(), token };
-    return verification.isValid;
+    // verifyGitHubToken() already distinguishes a 401 ("Invalid or expired token") from a 403
+    // rate-limit ("Rate limit exceeded") in its `error` field — key off that same text rather than
+    // re-deriving it, so this stays in sync with the shared helper without duplicating its logic.
+    const isRateLimited = !verification.isValid && verification.error === "Rate limit exceeded";
+    this.tokenHealthCache = {
+      isValid: verification.isValid,
+      checkedAt: Date.now(),
+      token,
+      isRateLimited,
+      error: verification.error,
+    };
+    return {
+      healthy: verification.isValid,
+      noToken: false,
+      isRateLimited,
+      error: verification.error,
+    };
+  }
+
+  /**
+   * Map an isGitHubTokenHealthy() result to the user-facing error string for the three unhealthy
+   * states (review on #919) — kept in one place so listReleases/checkForUpdates/configureAutoUpdater
+   * all report the same distinction consistently.
+   */
+  private tokenHealthErrorMessage(health: { noToken: boolean; isRateLimited: boolean }): string {
+    if (health.noToken) {
+      return NO_TOKEN_ERROR;
+    }
+    if (health.isRateLimited) {
+      return RATE_LIMITED_ERROR;
+    }
+    return INVALID_TOKEN_ERROR;
   }
 
   private async listReleases(forceRefresh = false): Promise<GitHubReleaseResponse> {
     try {
-      if (!(await this.isGitHubTokenHealthy())) {
-        return { releases: [], error: INVALID_TOKEN_ERROR };
+      const tokenHealth = await this.isGitHubTokenHealthy();
+      if (!tokenHealth.healthy) {
+        return { releases: [], error: this.tokenHealthErrorMessage(tokenHealth) };
       }
 
       if (
@@ -326,8 +384,9 @@ export class ReleaseChannelIPCHandlers {
         // download. This is the explicit, user-initiated "Check for Updates" action, so bypass the
         // 60s token-health cache: a user who just fixed their token shouldn't be stuck seeing
         // "invalid" for up to a minute after retrying.
-        if (!(await this.isGitHubTokenHealthy(true))) {
-          return { available: false, error: INVALID_TOKEN_ERROR };
+        const tokenHealth = await this.isGitHubTokenHealthy(true);
+        if (!tokenHealth.healthy) {
+          return { available: false, error: this.tokenHealthErrorMessage(tokenHealth) };
         }
 
         // Get raw releases for update checking (not processed)
@@ -495,8 +554,18 @@ export class ReleaseChannelIPCHandlers {
     } else if (channel.type === "pr" && channel.channel) {
       // PR channels are token-gated (#919) — don't configure the autoUpdater feed (and never
       // trigger a background download) unless the token is currently valid.
-      if (!(await this.isGitHubTokenHealthy())) {
-        console.warn("Skipping PR release channel configuration: GitHub token is invalid.");
+      const tokenHealth = await this.isGitHubTokenHealthy();
+      if (!tokenHealth.healthy) {
+        console.warn(
+          tokenHealth.noToken
+            ? "Skipping PR release channel configuration: no GitHub token configured."
+            : "Skipping PR release channel configuration: GitHub token is invalid.",
+        );
+        // Still (re)start the periodic timer (review on #919): the timer itself re-checks token
+        // health via checkForUpdates() every tick, so if the token becomes healthy later without
+        // another explicit reconfigure call, periodic checks are already running to pick it up
+        // rather than staying stopped forever.
+        this.startPeriodicUpdateChecks();
         return;
       }
 

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -142,13 +142,14 @@ export class ReleaseChannelIPCHandlers {
    * Cached briefly per-token so repeated list/select/download calls in quick succession don't each
    * re-verify against the GitHub API.
    */
-  private async isGitHubTokenHealthy(): Promise<boolean> {
+  private async isGitHubTokenHealthy(forceRefresh = false): Promise<boolean> {
     const token = await this.tokenStore.getToken();
     if (!token) {
       return false;
     }
 
     if (
+      !forceRefresh &&
       this.tokenHealthCache &&
       this.tokenHealthCache.token === token &&
       Date.now() - this.tokenHealthCache.checkedAt < TOKEN_HEALTH_CACHE_TTL
@@ -322,8 +323,10 @@ export class ReleaseChannelIPCHandlers {
       if (channel.type === "pr" && channel.channel) {
         // PR releases require a healthy GitHub token (#919) — block before touching the releases
         // cache, the GitHub API, or the autoUpdater so an invalid token can never trigger a
-        // download.
-        if (!(await this.isGitHubTokenHealthy())) {
+        // download. This is the explicit, user-initiated "Check for Updates" action, so bypass the
+        // 60s token-health cache: a user who just fixed their token shouldn't be stuck seeing
+        // "invalid" for up to a minute after retrying.
+        if (!(await this.isGitHubTokenHealthy(true))) {
           return { available: false, error: INVALID_TOKEN_ERROR };
         }
 
@@ -429,9 +432,13 @@ export class ReleaseChannelIPCHandlers {
       return;
     }
 
-    // Set up periodic checks
+    // Set up periodic checks — routed through this.checkForUpdates() (not the autoUpdater
+    // directly) so the same token-health gate that guards the manual "Check for Updates" button
+    // and listReleases() also covers this background timer (#919). Without this, a PR channel
+    // configured while the token was healthy would keep polling the PR feed unguarded every 10
+    // minutes after the token later expired or was revoked.
     this.updateCheckInterval = setInterval(() => {
-      autoUpdater.checkForUpdates().catch((err) => {
+      this.checkForUpdates().catch((err) => {
         console.error("Periodic update check failed:", err);
       });
     }, this.UPDATE_CHECK_INTERVAL);

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -48,6 +48,13 @@ const NO_TOKEN_ERROR =
   "A GitHub token is required to list, select, or download PR releases. Add one in Settings | GitHub Token.";
 const RATE_LIMITED_ERROR =
   "GitHub API rate limit exceeded while verifying your token. Your token is fine — try again shortly.";
+// Distinct from INVALID_TOKEN_ERROR (review on #939) — a transport failure (offline, DNS, TLS,
+// timeout, GitHub outage) while calling the GitHub API is not evidence the token itself is bad, so
+// it must not be reported as "invalid or expired" either. verifyGitHubToken()'s catch block is the
+// only path that produces an error string other than "Invalid or expired token" / "Rate limit
+// exceeded", so that's what isNetworkError below keys off.
+const VERIFICATION_UNAVAILABLE_ERROR =
+  "Couldn't verify your GitHub token right now (network error). Check your connection and try again.";
 
 export class ReleaseChannelIPCHandlers {
   private store = ReleaseChannelStorage.getInstance();
@@ -62,6 +69,7 @@ export class ReleaseChannelIPCHandlers {
     checkedAt: number;
     token: string;
     isRateLimited: boolean;
+    isNetworkError: boolean;
     error?: string;
   } | null = null;
   private updateCheckInterval: NodeJS.Timeout | null = null;
@@ -156,18 +164,25 @@ export class ReleaseChannelIPCHandlers {
    * re-verify against the GitHub API.
    *
    * Returns a small status object rather than a bare boolean (review on #919) so callers can tell
-   * apart three distinct states that all render as "not healthy" but need different treatment:
+   * apart four distinct states that all render as "not healthy" but need different treatment:
    *   - no token saved at all — not an error, just an unconfigured feature (NO_TOKEN_ERROR)
    *   - a rate-limited check — the token itself may be fine, GitHub is just throttling us
    *     (RATE_LIMITED_ERROR)
+   *   - a transport failure (offline/DNS/TLS/timeout/GitHub outage) verifying the token — the token
+   *     itself was never actually checked, so this must not read as "invalid" either
+   *     (VERIFICATION_UNAVAILABLE_ERROR, review on #939)
    *   - an actually invalid/expired token (INVALID_TOKEN_ERROR)
    */
-  private async isGitHubTokenHealthy(
-    forceRefresh = false,
-  ): Promise<{ healthy: boolean; noToken: boolean; isRateLimited: boolean; error?: string }> {
+  private async isGitHubTokenHealthy(forceRefresh = false): Promise<{
+    healthy: boolean;
+    noToken: boolean;
+    isRateLimited: boolean;
+    isNetworkError: boolean;
+    error?: string;
+  }> {
     const token = await this.tokenStore.getToken();
     if (!token) {
-      return { healthy: false, noToken: true, isRateLimited: false };
+      return { healthy: false, noToken: true, isRateLimited: false, isNetworkError: false };
     }
 
     if (
@@ -180,41 +195,58 @@ export class ReleaseChannelIPCHandlers {
         healthy: this.tokenHealthCache.isValid,
         noToken: false,
         isRateLimited: this.tokenHealthCache.isRateLimited,
+        isNetworkError: this.tokenHealthCache.isNetworkError,
         error: this.tokenHealthCache.error,
       };
     }
 
     const verification = await verifyGitHubToken(token);
-    // verifyGitHubToken() already distinguishes a 401 ("Invalid or expired token") from a 403
-    // rate-limit ("Rate limit exceeded") in its `error` field — key off that same text rather than
-    // re-deriving it, so this stays in sync with the shared helper without duplicating its logic.
+    // verifyGitHubToken() distinguishes a 401 ("Invalid or expired token") and a 403 rate-limit
+    // ("Rate limit exceeded") from a transport failure — its catch block is the only path that
+    // produces any other error string (the raw fetch/DNS/TLS error text) — key off that same text
+    // rather than re-deriving it, so this stays in sync with the shared helper without duplicating
+    // its logic.
     const isRateLimited = !verification.isValid && verification.error === "Rate limit exceeded";
+    const isNetworkError =
+      !verification.isValid &&
+      !isRateLimited &&
+      verification.error !== undefined &&
+      verification.error !== "Invalid or expired token";
     this.tokenHealthCache = {
       isValid: verification.isValid,
       checkedAt: Date.now(),
       token,
       isRateLimited,
+      isNetworkError,
       error: verification.error,
     };
     return {
       healthy: verification.isValid,
       noToken: false,
       isRateLimited,
+      isNetworkError,
       error: verification.error,
     };
   }
 
   /**
-   * Map an isGitHubTokenHealthy() result to the user-facing error string for the three unhealthy
-   * states (review on #919) — kept in one place so listReleases/checkForUpdates/configureAutoUpdater
-   * all report the same distinction consistently.
+   * Map an isGitHubTokenHealthy() result to the user-facing error string for the four unhealthy
+   * states (review on #919, #939) — kept in one place so listReleases/checkForUpdates/
+   * configureAutoUpdater all report the same distinction consistently.
    */
-  private tokenHealthErrorMessage(health: { noToken: boolean; isRateLimited: boolean }): string {
+  private tokenHealthErrorMessage(health: {
+    noToken: boolean;
+    isRateLimited: boolean;
+    isNetworkError: boolean;
+  }): string {
     if (health.noToken) {
       return NO_TOKEN_ERROR;
     }
     if (health.isRateLimited) {
       return RATE_LIMITED_ERROR;
+    }
+    if (health.isNetworkError) {
+      return VERIFICATION_UNAVAILABLE_ERROR;
     }
     return INVALID_TOKEN_ERROR;
   }

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain } from "electron";
 import { autoUpdater } from "electron-updater";
 import { config } from "../config/env";
 import { setIsQuitting } from "../index";
+import { verifyGitHubToken } from "../services/github/github-token-verifier";
 import { GitHubTokenStorage } from "../services/storage/github-token-storage";
 import type { ReleaseChannel } from "../services/storage/release-channel-storage";
 import { ReleaseChannelStorage } from "../services/storage/release-channel-storage";
@@ -34,6 +35,12 @@ const GITHUB_API_BASE = "https://api.github.com";
 const REPO_OWNER = "SSWConsulting";
 const REPO_NAME = "SSW.YakShaver.Desktop";
 const RELEASES_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+// PR releases are gated on the configured GitHub token being valid (#919): an invalid/expired
+// token must not be usable to list, select, or download PR builds. Cache the verification briefly
+// so every list/select/download call doesn't re-hit the GitHub /user endpoint.
+const TOKEN_HEALTH_CACHE_TTL = 60 * 1000; // 1 minute
+const INVALID_TOKEN_ERROR =
+  "GitHub token is invalid or expired. Update it in Settings | GitHub Token to use PR releases.";
 
 export class ReleaseChannelIPCHandlers {
   private store = ReleaseChannelStorage.getInstance();
@@ -43,6 +50,7 @@ export class ReleaseChannelIPCHandlers {
     fetchedAt: number;
     etag?: string;
   } | null = null;
+  private tokenHealthCache: { isValid: boolean; checkedAt: number; token: string } | null = null;
   private updateCheckInterval: NodeJS.Timeout | null = null;
   private readonly UPDATE_CHECK_INTERVAL = 10 * 60 * 1000; // Check every 10 minutes
   private updateDialogDismissedInSession = false; // Track if user dismissed update dialog this session
@@ -126,8 +134,39 @@ export class ReleaseChannelIPCHandlers {
     this.startPeriodicUpdateChecks();
   }
 
+  /**
+   * PR release channels require a healthy (valid, non-expired) GitHub token (#919) — invalid
+   * tokens must not be usable to list/select/download PR builds. The "latest" stable channel is
+   * unaffected: it doesn't need a token at all.
+   *
+   * Cached briefly per-token so repeated list/select/download calls in quick succession don't each
+   * re-verify against the GitHub API.
+   */
+  private async isGitHubTokenHealthy(): Promise<boolean> {
+    const token = await this.tokenStore.getToken();
+    if (!token) {
+      return false;
+    }
+
+    if (
+      this.tokenHealthCache &&
+      this.tokenHealthCache.token === token &&
+      Date.now() - this.tokenHealthCache.checkedAt < TOKEN_HEALTH_CACHE_TTL
+    ) {
+      return this.tokenHealthCache.isValid;
+    }
+
+    const verification = await verifyGitHubToken(token);
+    this.tokenHealthCache = { isValid: verification.isValid, checkedAt: Date.now(), token };
+    return verification.isValid;
+  }
+
   private async listReleases(forceRefresh = false): Promise<GitHubReleaseResponse> {
     try {
+      if (!(await this.isGitHubTokenHealthy())) {
+        return { releases: [], error: INVALID_TOKEN_ERROR };
+      }
+
       if (
         !forceRefresh &&
         this.releasesCache &&
@@ -281,6 +320,13 @@ export class ReleaseChannelIPCHandlers {
 
       // For PR channels
       if (channel.type === "pr" && channel.channel) {
+        // PR releases require a healthy GitHub token (#919) — block before touching the releases
+        // cache, the GitHub API, or the autoUpdater so an invalid token can never trigger a
+        // download.
+        if (!(await this.isGitHubTokenHealthy())) {
+          return { available: false, error: INVALID_TOKEN_ERROR };
+        }
+
         // Get raw releases for update checking (not processed)
         if (!this.releasesCache || Date.now() - this.releasesCache.fetchedAt > RELEASES_CACHE_TTL) {
           await this.listReleases(true);
@@ -440,6 +486,13 @@ export class ReleaseChannelIPCHandlers {
         }, 2000);
       }
     } else if (channel.type === "pr" && channel.channel) {
+      // PR channels are token-gated (#919) — don't configure the autoUpdater feed (and never
+      // trigger a background download) unless the token is currently valid.
+      if (!(await this.isGitHubTokenHealthy())) {
+        console.warn("Skipping PR release channel configuration: GitHub token is invalid.");
+        return;
+      }
+
       // For PR channels, we need to find the latest release tag first
       const prNumber = this.extractPRNumberFromChannel(channel.channel);
       if (prNumber) {

--- a/src/backend/services/github/github-token-verifier.test.ts
+++ b/src/backend/services/github/github-token-verifier.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { verifyGitHubToken } from "./github-token-verifier";
+
+function headerResponse(
+  status: number,
+  headers: Record<string, string>,
+  body: unknown = {},
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? "Unauthorized" : status === 403 ? "Forbidden" : "Error",
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("verifyGitHubToken (#919 — shared token health check)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("reports invalid with no network call when there is no token", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await verifyGitHubToken(undefined);
+
+    expect(result).toEqual({ isValid: false, error: "No token configured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports valid with username/scopes/rate-limit on a healthy token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          headerResponse(
+            200,
+            { "x-oauth-scopes": "repo, read:user", "x-ratelimit-remaining": "4999" },
+            { login: "octocat" },
+          ),
+        ),
+    );
+
+    const result = await verifyGitHubToken("ghp_valid");
+
+    expect(result).toEqual({
+      isValid: true,
+      username: "octocat",
+      scopes: ["repo", "read:user"],
+      rateLimitRemaining: 4999,
+    });
+  });
+
+  it("classifies a 401 as an invalid/expired token — the exact bug in #919", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(headerResponse(401, {})));
+
+    const result = await verifyGitHubToken("bad-random-string");
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe("Invalid or expired token");
+  });
+
+  it("classifies a rate-limited 403 distinctly from an invalid token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(headerResponse(403, { "x-ratelimit-remaining": "0" })),
+    );
+
+    const result = await verifyGitHubToken("ghp_ratelimited");
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe("Rate limit exceeded");
+  });
+
+  it("returns isValid: false when the fetch itself throws (offline/network error)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("network error")));
+
+    const result = await verifyGitHubToken("ghp_valid");
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/src/backend/services/github/github-token-verifier.ts
+++ b/src/backend/services/github/github-token-verifier.ts
@@ -1,0 +1,75 @@
+import { formatAndReportError } from "../../utils/error-utils";
+
+export interface GitHubTokenVerification {
+  isValid: boolean;
+  username?: string;
+  scopes?: string[];
+  rateLimitRemaining?: number;
+  error?: string;
+}
+
+/**
+ * Verify a GitHub personal access token against the GitHub API.
+ *
+ * Shared by the GitHub Token settings health-check (`GitHubTokenIPCHandlers.verifyToken`) and the
+ * release-channel handlers (#919) — PR release channels are token-gated (see
+ * `ReleaseChannelIPCHandlers`), so both call sites must agree on what "healthy" means rather than
+ * each re-implementing the GitHub API call.
+ */
+export async function verifyGitHubToken(
+  token: string | undefined,
+): Promise<GitHubTokenVerification> {
+  try {
+    if (!token) {
+      return { isValid: false, error: "No token configured" };
+    }
+
+    const response = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "SSW-YakShaver-Desktop",
+      },
+    });
+
+    // Extract scopes and rate limit info from headers even on non-200
+    const scopesHeader = response.headers.get("x-oauth-scopes") || "";
+    const scopes = scopesHeader
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const rateLimitRemainingHeader = response.headers.get("x-ratelimit-remaining");
+    const rateLimitRemaining = rateLimitRemainingHeader
+      ? Number.parseInt(rateLimitRemainingHeader, 10)
+      : undefined;
+
+    if (!response.ok) {
+      let errorMessage = response.statusText;
+      if (response.status === 401) {
+        errorMessage = "Invalid or expired token";
+      } else if (response.status === 403) {
+        if (rateLimitRemaining === 0) {
+          errorMessage = "Rate limit exceeded";
+        }
+      }
+      return {
+        isValid: false,
+        scopes,
+        rateLimitRemaining,
+        error: errorMessage,
+      };
+    }
+
+    const userData = await response.json();
+    const username: string | undefined = userData?.login;
+
+    return {
+      isValid: true,
+      username,
+      scopes,
+      rateLimitRemaining,
+    };
+  } catch (error) {
+    return { isValid: false, error: formatAndReportError(error, "github_token") };
+  }
+}

--- a/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
@@ -68,7 +68,18 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     }
   }, []);
 
-  const loadReleases = useCallback(async () => {
+  const loadReleases = useCallback(async (hasToken: boolean) => {
+    // listReleases() always requires a healthy GitHub token on the backend (#919) — a user who
+    // has never configured one will always get a "token required" error here, which the
+    // dedicated no-token banner below already communicates. Skip the network call (and the
+    // redundant toast) entirely in that case rather than spending rate-limit budget and noise on
+    // every Settings-tab mount (review on #919); still call it once a token exists so PR release
+    // data loads normally.
+    if (!hasToken) {
+      setReleases([]);
+      return;
+    }
+
     setIsLoadingReleases(true);
     try {
       const response = await ipcClient.releaseChannel.listReleases();
@@ -93,7 +104,10 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     }
   }, []);
 
-  const checkGitHubToken = useCallback(async () => {
+  // Returns whether a token exists so callers can decide whether it's worth calling
+  // loadReleases() at all (review on #919) — the caller awaits this before loadReleases() rather
+  // than firing both in parallel, so the no-token skip in loadReleases() has an answer to check.
+  const checkGitHubToken = useCallback(async (): Promise<boolean> => {
     setIsCheckingToken(true);
     try {
       const tokenExists = await ipcClient.githubToken.has();
@@ -102,7 +116,7 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
       if (!tokenExists) {
         setIsTokenHealthy(false);
         setTokenHealthError(undefined);
-        return;
+        return false;
       }
 
       // A saved token isn't necessarily a *valid* one (#919) — verify it against GitHub before
@@ -110,11 +124,13 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
       const verification = await ipcClient.githubToken.verify();
       setIsTokenHealthy(verification.isValid);
       setTokenHealthError(verification.isValid ? undefined : verification.error);
+      return true;
     } catch (error) {
       console.error("Failed to check GitHub token:", error);
       setHasGitHubToken(false);
       setIsTokenHealthy(false);
       setTokenHealthError(undefined);
+      return false;
     } finally {
       setIsCheckingToken(false);
     }
@@ -126,9 +142,11 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     }
 
     void loadChannel();
-    void loadReleases();
     void loadCurrentVersion();
-    void checkGitHubToken();
+    // Resolve token state first so loadReleases() knows whether it's worth calling at all —
+    // avoids spending rate-limit budget and a redundant error toast for a never-configured token
+    // (review on #919).
+    void checkGitHubToken().then((hasToken) => loadReleases(hasToken));
   }, [isActive, loadChannel, loadReleases, loadCurrentVersion, checkGitHubToken]);
 
   useEffect(() => {
@@ -137,8 +155,7 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     }
 
     const handleGitHubTokenUpdate = () => {
-      void checkGitHubToken();
-      void loadReleases();
+      void checkGitHubToken().then((hasToken) => loadReleases(hasToken));
     };
 
     window.addEventListener(GITHUB_TOKEN_UPDATED_EVENT, handleGitHubTokenUpdate);

--- a/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
@@ -37,6 +37,9 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
   const [isLoadingReleases, setIsLoadingReleases] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<string>("");
   const [hasGitHubToken, setHasGitHubToken] = useState<boolean>(false);
+  // #919 — PR releases require a *valid* (healthy) token, not merely a saved one. An invalid or
+  // expired token must not allow listing/selecting/downloading PR builds.
+  const [isTokenHealthy, setIsTokenHealthy] = useState<boolean>(false);
   const [isCheckingToken, setIsCheckingToken] = useState<boolean>(true);
 
   const getChannelDisplay = useCallback((currentChannel: ReleaseChannel) => {
@@ -91,9 +94,20 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     try {
       const tokenExists = await ipcClient.githubToken.has();
       setHasGitHubToken(tokenExists);
+
+      if (!tokenExists) {
+        setIsTokenHealthy(false);
+        return;
+      }
+
+      // A saved token isn't necessarily a *valid* one (#919) — verify it against GitHub before
+      // treating PR releases as usable.
+      const verification = await ipcClient.githubToken.verify();
+      setIsTokenHealthy(verification.isValid);
     } catch (error) {
       console.error("Failed to check GitHub token:", error);
       setHasGitHubToken(false);
+      setIsTokenHealthy(false);
     } finally {
       setIsCheckingToken(false);
     }
@@ -125,6 +139,13 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
   }, [isActive, checkGitHubToken, loadReleases]);
 
   const handleCheckUpdates = useCallback(async () => {
+    if (channel.type === "pr" && !isTokenHealthy) {
+      // Belt-and-braces: the button is already disabled in this state, but guard the handler too
+      // in case it's ever reachable another way (#919).
+      toast.error("A valid GitHub token is required to check for PR releases.");
+      return;
+    }
+
     setIsLoading(true);
     setUpdateStatus("Checking for updates...");
 
@@ -157,7 +178,7 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     } finally {
       setIsLoading(false);
     }
-  }, [channel, currentVersion, getChannelDisplay]);
+  }, [channel, currentVersion, getChannelDisplay, isTokenHealthy]);
 
   const selectValue = useMemo(() => {
     if (channel.type === "latest") {
@@ -172,18 +193,28 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     return "";
   }, [channel]);
 
-  const handleSelectionChange = useCallback((value: string) => {
-    if (value === "__loading" || value === "__empty") {
-      return;
-    }
+  const handleSelectionChange = useCallback(
+    (value: string) => {
+      if (value === "__loading" || value === "__empty") {
+        return;
+      }
 
-    if (value === SELECT_LATEST) {
-      setChannel({ type: "latest" });
-      return;
-    }
+      if (value === SELECT_LATEST) {
+        setChannel({ type: "latest" });
+        return;
+      }
 
-    setChannel({ type: "pr", channel: `beta.${value}` });
-  }, []);
+      // PR channels require a healthy token (#919) — refuse the selection rather than letting the
+      // user pick a channel that can't actually be checked/downloaded.
+      if (!isTokenHealthy) {
+        toast.error("A valid GitHub token is required to select a PR release.");
+        return;
+      }
+
+      setChannel({ type: "pr", channel: `beta.${value}` });
+    },
+    [isTokenHealthy],
+  );
 
   const dropdownOptions = useMemo<DropdownOption[]>(() => {
     return releases.map((release) => ({
@@ -194,6 +225,11 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     }));
   }, [releases]);
 
+  const showInvalidTokenBanner = !isCheckingToken && hasGitHubToken && !isTokenHealthy;
+  const showNoTokenBanner = !isCheckingToken && !hasGitHubToken;
+  // Only "Latest Stable" is selectable without a healthy token; PR entries are disabled below.
+  const prSelectionDisabled = !isCheckingToken && !isTokenHealthy;
+
   return (
     <Card className="w-full gap-4 border-white/10 py-4">
       <CardHeader className="px-4">
@@ -203,11 +239,21 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 px-4">
-        {!isCheckingToken && !hasGitHubToken && (
+        {showNoTokenBanner && (
           <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
             <h3 className="mb-1 font-medium text-yellow-200">GitHub Token Required</h3>
             <p className="text-sm text-yellow-100">
               A GitHub token is required to view and download PR releases. Add one below.
+            </p>
+          </div>
+        )}
+
+        {showInvalidTokenBanner && (
+          <div className="rounded-md border border-ssw-red/30 bg-ssw-red/10 p-3">
+            <h3 className="mb-1 font-medium text-red-200">GitHub Token Invalid</h3>
+            <p className="text-sm text-red-100">
+              Your GitHub token is invalid or expired, so PR releases can&apos;t be listed,
+              selected, or downloaded. Update it below.
             </p>
           </div>
         )}
@@ -239,29 +285,35 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
                     No PR releases available
                   </SelectItem>
                 )}
-                {dropdownOptions.map((option) => (
-                  <SelectItem
-                    key={option.value}
-                    value={option.value}
-                    className="text-white"
-                    textValue={option.label}
-                  >
-                    <div className="flex flex-col">
-                      <span>{option.label}</span>
-                      <span className="text-xs">{option.version}</span>
-                      <span className="text-xs">
-                        {new Date(option.publishedAt).toLocaleString()}
-                      </span>
-                    </div>
-                  </SelectItem>
-                ))}
+                {!isLoadingReleases &&
+                  dropdownOptions.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      className="text-white"
+                      textValue={option.label}
+                      disabled={prSelectionDisabled}
+                    >
+                      <div className="flex flex-col">
+                        <span>{option.label}</span>
+                        <span className="text-xs">{option.version}</span>
+                        <span className="text-xs">
+                          {new Date(option.publishedAt).toLocaleString()}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
               </SelectContent>
             </Select>
           </div>
 
           <Button
             onClick={handleCheckUpdates}
-            disabled={isLoading || !hasGitHubToken || !selectValue}
+            disabled={
+              isLoading ||
+              !selectValue ||
+              (channel.type === "pr" ? !isTokenHealthy : !hasGitHubToken)
+            }
           >
             Check for Updates
           </Button>

--- a/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
@@ -41,6 +41,10 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
   // expired token must not allow listing/selecting/downloading PR builds.
   const [isTokenHealthy, setIsTokenHealthy] = useState<boolean>(false);
   const [isCheckingToken, setIsCheckingToken] = useState<boolean>(true);
+  // Reason the last verification failed (e.g. "Invalid or expired token", a network error message,
+  // "Rate limit exceeded") — used so the banner doesn't always say "invalid or expired" even when
+  // the real cause was a network/offline failure.
+  const [tokenHealthError, setTokenHealthError] = useState<string | undefined>(undefined);
 
   const getChannelDisplay = useCallback((currentChannel: ReleaseChannel) => {
     if (currentChannel.type === "latest") {
@@ -97,6 +101,7 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
 
       if (!tokenExists) {
         setIsTokenHealthy(false);
+        setTokenHealthError(undefined);
         return;
       }
 
@@ -104,10 +109,12 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
       // treating PR releases as usable.
       const verification = await ipcClient.githubToken.verify();
       setIsTokenHealthy(verification.isValid);
+      setTokenHealthError(verification.isValid ? undefined : verification.error);
     } catch (error) {
       console.error("Failed to check GitHub token:", error);
       setHasGitHubToken(false);
       setIsTokenHealthy(false);
+      setTokenHealthError(undefined);
     } finally {
       setIsCheckingToken(false);
     }
@@ -228,7 +235,9 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
   const showInvalidTokenBanner = !isCheckingToken && hasGitHubToken && !isTokenHealthy;
   const showNoTokenBanner = !isCheckingToken && !hasGitHubToken;
   // Only "Latest Stable" is selectable without a healthy token; PR entries are disabled below.
-  const prSelectionDisabled = !isCheckingToken && !isTokenHealthy;
+  // Fail closed while the check is in flight (isTokenHealthy starts false) rather than fail open —
+  // otherwise PR entries would briefly render enabled before the first verification completes.
+  const prSelectionDisabled = isCheckingToken || !isTokenHealthy;
 
   return (
     <Card className="w-full gap-4 border-white/10 py-4">
@@ -252,8 +261,9 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
           <div className="rounded-md border border-ssw-red/30 bg-ssw-red/10 p-3">
             <h3 className="mb-1 font-medium text-red-200">GitHub Token Invalid</h3>
             <p className="text-sm text-red-100">
-              Your GitHub token is invalid or expired, so PR releases can&apos;t be listed,
-              selected, or downloaded. Update it below.
+              {tokenHealthError
+                ? `GitHub token verification failed: ${tokenHealthError}. PR releases can't be listed, selected, or downloaded until this is resolved.`
+                : "Your GitHub token is invalid or expired, so PR releases can't be listed, selected, or downloaded. Update it below."}
             </p>
           </div>
         )}

--- a/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
@@ -84,11 +84,16 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
     try {
       const response = await ipcClient.releaseChannel.listReleases();
       if (response.error) {
+        // Clear any previously-loaded releases (review on #939) — otherwise a token that was
+        // healthy earlier and later becomes invalid/unreachable leaves stale, now-unselectable PR
+        // entries lingering in the dropdown instead of an empty list matching the error state.
+        setReleases([]);
         toast.error(`Failed to load releases: ${response.error}`);
       } else {
         setReleases(response.releases || []);
       }
     } catch (error) {
+      setReleases([]);
       toast.error(`Failed to load releases: ${formatErrorMessage(error)}`);
     } finally {
       setIsLoadingReleases(false);


### PR DESCRIPTION
## Summary

PR release channels only checked whether a GitHub token was *saved*, not whether it was *valid*. An invalid or expired token still let the app list PR releases from the GitHub API and trigger `autoUpdater` downloads, even though the token health check (Settings | GitHub Token) showed unhealthy — matching the video in the issue, where saving an obviously-invalid random-string token still let a PR build download.

Closes #919

## What changed

| File | Change |
|------|--------|
| `src/backend/services/github/github-token-verifier.ts` | New shared `verifyGitHubToken(token)` helper — the GitHub `/user` verification call, extracted so it has one implementation instead of being duplicated. |
| `src/backend/ipc/github-token-handlers.ts` | `GitHubTokenIPCHandlers.verifyToken()` now delegates to the shared helper (behavior unchanged). |
| `src/backend/ipc/release-channel-handlers.ts` | Added `isGitHubTokenHealthy()` (verifies + caches for 60s) and gated `listReleases()`, the PR-channel path of `checkForUpdates()`, and the PR-channel path of `configureAutoUpdater()` on it. An invalid token now short-circuits with a clear error *before* any GitHub API call or `autoUpdater` interaction — the "latest" stable channel is untouched, since it was never token-gated. |
| `src/backend/ipc/release-channel-handlers.test.ts` | New regression tests proving the GitHub API / `autoUpdater.checkForUpdates()` / `setFeedURL()` are never invoked when the token is invalid, and that the stable channel still works with no token at all. |
| `src/backend/services/github/github-token-verifier.test.ts` | Unit tests for the shared verifier (valid, 401, rate-limited 403, network error, no-token). |
| `src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx` | Now checks token *health* via `ipcClient.githubToken.verify()`, not just `has()`. Shows a distinct "GitHub Token Invalid" banner (separate from "No token saved"), disables PR entries in the channel selector, and disables "Check for Updates" for the PR channel when the token is unhealthy. |

## Decisions

- **Decision:** Keep the GitHub-token requirement for PR releases (rather than removing it), and fix the health check instead of the requirement.
  - **Why:** The existing code and copy make the intended design explicit — `GitHubTokenSetting.tsx`'s own description reads "Add a personal access token so YakShaver can list and download PR releases", and `settings-health.ts` already comments "the GitHub token gates GitHub release-channel/token-backed actions". A token is also functionally useful here: unauthenticated GitHub API calls are limited to 60 requests/hour per IP, so a valid token meaningfully avoids `listReleases()` rate-limiting during PR testing. So this is a case of the *acceptance criteria's* first option (require a valid token), not the second (remove the requirement) — the requirement was already intended, just not actually enforced past "does a string exist".
  - **Alternatives considered:** Removing the token requirement entirely and hitting the public releases endpoint unauthenticated. Rejected: it's a real, if soft, requirement given the rate limit, and the existing UI copy commits to "token needed for PR releases" as the product's stated behavior.
- **Decision:** Verify token health with a short (60s) in-memory cache in `ReleaseChannelIPCHandlers`, rather than re-verifying on every call.
  - **Why:** `listReleases()`/`checkForUpdates()`/`configureAutoUpdater()` can all fire in quick succession (e.g. loading the Settings page calls `loadReleases()` right after `checkGitHubToken()`); re-hitting `GET /user` for every one would waste rate limit budget for no user-visible benefit.
  - **Alternatives considered:** No caching (simplest, but wastes API calls) or a global/shared cache across `GitHubTokenIPCHandlers` and `ReleaseChannelIPCHandlers` (adds coupling between the two handler classes for a minor optimization) — went with the smallest, contained change.

## Acceptance criteria

- [x] When the GitHub token health check is unhealthy, PR release channels cannot be listed — `listReleases()` short-circuits with an error before calling the GitHub API.
- [x] When the GitHub token health check is unhealthy, PR release channels cannot be selected — the release-channel `<Select>` disables PR entries and the selection handler refuses the change with a toast.
- [x] When the GitHub token health check is unhealthy, PR releases cannot be downloaded — `checkForUpdates()`'s PR-channel path (and `configureAutoUpdater()`'s startup/background path) both refuse before reaching `autoUpdater`.
- [x] (Alternative from the AC, not taken — see Decisions above for why the token requirement was kept rather than removed.)

## Testing

- [x] Unit tests added/updated (`release-channel-handlers.test.ts`, `github-token-verifier.test.ts` — 10 new tests)
- [ ] Integration tests added/updated (no existing IPC integration harness for this area; unit-level coverage matches the existing test style for these handlers)
- [ ] Manual testing performed (no running Electron UI in this sandboxed environment; validated via the automated repro below instead)
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npx vitest run` — 605/605, up from 595/595 on `main`)
- [x] Lint / format clean (`npm run lint` — no fixes applied)

## Bug repro evidence

- **Symptom (pinned):** With an invalid/expired GitHub token, selecting a PR release channel and clicking "Check Update" still triggers a download (the issue's video shows the download progress bar increasing) — i.e. `ReleaseChannelIPCHandlers.checkForUpdates()`'s PR-channel path reaches `autoUpdater.checkForUpdates()` / `setFeedURL()` despite the token being unhealthy.
- **Repro method:** A regression test (`release-channel-handlers.test.ts`) that mocks `electron-updater` and `fetch`, sets an invalid-token verification result, and asserts the GitHub releases `fetch` and `autoUpdater.checkForUpdates()`/`setFeedURL()` are never called.
- **Before (unpatched):** Ran the new regression test file against the unpatched `origin/main` version of `release-channel-handlers.ts` (token-existence check only). Result: **2 tests failed** — `fetchMock` was called (GitHub releases API hit) and `checkForUpdates`'s PR path proceeded, confirming the exact bug: an invalid token doesn't block listing or the update check that triggers the download.
- **After (patched):** Same test file against the patched code: **all 5 tests pass** — `fetchMock`, `checkForUpdatesMock`, and `setFeedURLMock` are asserted `not.toHaveBeenCalled()` when the token is invalid, and the handler returns a clear `"GitHub token is invalid or expired…"` error instead.

## Follow-up items

- No running Electron/Playwright environment was available in this sandbox to manually click through Settings → GitHub Token → Release Channel, so verification relied on the before/after unit-test evidence above rather than a live UI screenshot. A human reviewer with the app running can confirm the "GitHub Token Invalid" banner and disabled PR selector visually as a final check.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)