### PR TITLE
XS✔ ◾ fix: YouTube download fails when local file path contains spaces (#931)

### DIFF
--- a/src/backend/services/video/youtube-service.test.ts
+++ b/src/backend/services/video/youtube-service.test.ts
@@ -1,0 +1,195 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IProcessSpawner } from "../process/process-spawner";
+import { YouTubeDownloadService } from "./youtube-service";
+
+// Electron is only used for `app.isPackaged` in this module — stub it so the module imports
+// cleanly under vitest's node environment.
+vi.mock("electron", () => ({
+  app: { isPackaged: false },
+}));
+
+vi.mock("tmp", () => ({
+  default: {
+    tmpNameSync: vi.fn(() => "/tmp/mock-output.mp4"),
+  },
+}));
+
+function createMockChildProcess(): ChildProcess {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child as ChildProcess;
+}
+
+describe("YouTubeDownloadService — #931 paths containing spaces", () => {
+  let mockChildProcess: ReturnType<typeof createMockChildProcess>;
+  let mockProcessSpawner: IProcessSpawner;
+
+  beforeEach(() => {
+    mockChildProcess = createMockChildProcess();
+    mockProcessSpawner = {
+      spawn: vi.fn().mockReturnValue(mockChildProcess),
+    };
+  });
+
+  describe("downloadVideoToFile", () => {
+    it("passes a binary path containing spaces (e.g. Windows profile path) straight through as the spawn command, unmodified", async () => {
+      // Regression for #931: a naive implementation that builds a single command-line string
+      // (or that re-splits the binary path on whitespace, as the previous `youtube-dl-exec` ->
+      // `tinyspawn` dependency chain did internally) would corrupt this path and never spawn
+      // the real binary.
+      const binaryPathWithSpaces =
+        "C:\\Users\\First Last\\AppData\\Local\\Programs\\yakshaver\\resources\\app.asar.unpacked\\node_modules\\youtube-dl-exec\\bin\\yt-dlp.exe";
+      const service = new YouTubeDownloadService(binaryPathWithSpaces, mockProcessSpawner);
+
+      const outputPathWithSpaces = "C:\\Users\\First Last\\AppData\\Local\\Temp\\video.mp4";
+      const resultPromise = service.downloadVideoToFile(
+        "https://www.youtube.com/watch?v=abc123",
+        outputPathWithSpaces,
+      );
+
+      setImmediate(() => mockChildProcess.emit("close", 0));
+      const result = await resultPromise;
+
+      expect(result).toBe(outputPathWithSpaces);
+      // The binary path is passed as `command`, untouched — never split, never re-parsed.
+      expect(mockProcessSpawner.spawn).toHaveBeenCalledWith(
+        binaryPathWithSpaces,
+        expect.any(Array),
+      );
+    });
+
+    it("passes an output path containing spaces as a single argv element (not split into multiple tokens)", async () => {
+      const service = new YouTubeDownloadService("/usr/local/bin/yt-dlp", mockProcessSpawner);
+      const outputPathWithSpaces = "/Users/First Last/Downloads/my video.mp4";
+
+      const resultPromise = service.downloadVideoToFile(
+        "https://www.youtube.com/watch?v=abc123",
+        outputPathWithSpaces,
+      );
+      setImmediate(() => mockChildProcess.emit("close", 0));
+      await resultPromise;
+
+      const [, args] = (mockProcessSpawner.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+      const outputFlagIndex = args.indexOf("--output");
+      expect(outputFlagIndex).toBeGreaterThanOrEqual(0);
+      // The full path with its embedded space is exactly one argv element, immediately after
+      // `--output` — never split across two array entries.
+      expect(args[outputFlagIndex + 1]).toBe(outputPathWithSpaces);
+      expect(args).not.toContain("First");
+      expect(args).not.toContain("Last/Downloads/my");
+    });
+
+    it("builds the yt-dlp invocation as an argument array, never a concatenated command string", async () => {
+      const service = new YouTubeDownloadService("/usr/local/bin/yt-dlp", mockProcessSpawner);
+      const resultPromise = service.downloadVideoToFile(
+        "https://www.youtube.com/watch?v=abc123",
+        "/tmp/out with space.mp4",
+      );
+      setImmediate(() => mockChildProcess.emit("close", 0));
+      await resultPromise;
+
+      const [command, args] = (mockProcessSpawner.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(typeof command).toBe("string");
+      expect(Array.isArray(args)).toBe(true);
+      expect(args).toEqual([
+        "--output",
+        "/tmp/out with space.mp4",
+        "--format",
+        "mp4",
+        "--restrict-filenames",
+        "--no-warnings",
+        "--quiet",
+        "https://www.youtube.com/watch?v=abc123",
+      ]);
+    });
+
+    it("logs the resolved download path and the exact command invocation", async () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const service = new YouTubeDownloadService("/usr/local/bin/yt-dlp", mockProcessSpawner);
+      const outputPath = "/Users/First Last/video.mp4";
+
+      const resultPromise = service.downloadVideoToFile(
+        "https://www.youtube.com/watch?v=abc123",
+        outputPath,
+      );
+      setImmediate(() => mockChildProcess.emit("close", 0));
+      await resultPromise;
+
+      const loggedCalls = consoleSpy.mock.calls.flat().join("\n");
+      expect(loggedCalls).toContain(outputPath);
+      expect(loggedCalls).toContain("/usr/local/bin/yt-dlp");
+      expect(loggedCalls).toContain("--output");
+
+      consoleSpy.mockRestore();
+    });
+
+    it("rejects with the process stderr when yt-dlp exits non-zero", async () => {
+      const service = new YouTubeDownloadService("/usr/local/bin/yt-dlp", mockProcessSpawner);
+      const resultPromise = service.downloadVideoToFile(
+        "https://www.youtube.com/watch?v=abc123",
+        "/tmp/out.mp4",
+      );
+
+      setImmediate(() => {
+        mockChildProcess.stderr?.emit("data", Buffer.from("ERROR: video unavailable"));
+        mockChildProcess.emit("close", 1);
+      });
+
+      await expect(resultPromise).rejects.toThrow(/video unavailable/);
+    });
+
+    it("rejects when youtubeUrl is empty", async () => {
+      const service = new YouTubeDownloadService("/usr/local/bin/yt-dlp", mockProcessSpawner);
+      await expect(service.downloadVideoToFile("   ")).rejects.toThrow("YouTube URL is required");
+      expect(mockProcessSpawner.spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getVideoMetadata", () => {
+    it("parses JSON metadata from stdout and returns success", async () => {
+      const service = new YouTubeDownloadService("/usr/local/bin/yt-dlp", mockProcessSpawner);
+      const resultPromise = service.getVideoMetadata("https://www.youtube.com/watch?v=abc123");
+
+      setImmediate(() => {
+        mockChildProcess.stdout?.emit(
+          "data",
+          Buffer.from(
+            JSON.stringify({
+              id: "abc123",
+              title: "Test Video",
+              description: "desc",
+              webpage_url: "https://www.youtube.com/watch?v=abc123",
+              duration: 35,
+            }),
+          ),
+        );
+        mockChildProcess.emit("close", 0);
+      });
+
+      const result = await resultPromise;
+      expect(result.success).toBe(true);
+      expect(result.data?.videoId).toBe("abc123");
+      expect(result.data?.title).toBe("Test Video");
+    });
+
+    it("returns a failure result when yt-dlp fails", async () => {
+      const service = new YouTubeDownloadService("/usr/local/bin/yt-dlp", mockProcessSpawner);
+      const resultPromise = service.getVideoMetadata("https://www.youtube.com/watch?v=abc123");
+
+      setImmediate(() => {
+        mockChildProcess.stderr?.emit("data", Buffer.from("ERROR: unavailable"));
+        mockChildProcess.emit("close", 1);
+      });
+
+      const result = await resultPromise;
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("unavailable");
+    });
+  });
+});

--- a/src/backend/services/video/youtube-service.ts
+++ b/src/backend/services/video/youtube-service.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 import { app } from "electron";
 import tmp from "tmp";
-import youtubedl, { type Flags } from "youtube-dl-exec";
 import type { VideoUploadResult } from "../auth/types";
+import { defaultProcessSpawner, type IProcessSpawner } from "../process/process-spawner";
 
 const YT_DLP_EXECUTABLE = process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp";
 
@@ -36,15 +36,30 @@ function formatYtDlpError(error: unknown): string {
   return message;
 }
 
+/**
+ * Renders a yt-dlp invocation as a human-readable string for logging purposes only — it is
+ * never used to actually run the command. The real invocation always spawns with an argument
+ * *array* (see `runYtDlp`), so this string can never reintroduce the quoting/escaping bug it
+ * is describing; it only wraps values containing whitespace in quotes so the logged line reads
+ * the way a shell command would.
+ */
+function describeInvocationForLogging(binaryPath: string, args: string[]): string {
+  const quoteIfNeeded = (value: string) => (/\s/.test(value) ? `"${value}"` : value);
+  return [quoteIfNeeded(binaryPath), ...args.map(quoteIfNeeded)].join(" ");
+}
+
+interface YtDlpRunResult {
+  stdout: string;
+  stderr: string;
+}
+
 export class YouTubeDownloadService {
   private static instance: YouTubeDownloadService;
-  private downloadClient: ReturnType<typeof youtubedl.create>;
-  private binaryPath: string;
 
-  private constructor() {
-    this.binaryPath = getYtDlpPath();
-    this.downloadClient = youtubedl.create(this.binaryPath);
-  }
+  constructor(
+    private readonly binaryPath: string = getYtDlpPath(),
+    private readonly processSpawner: IProcessSpawner = defaultProcessSpawner,
+  ) {}
 
   public static getInstance(): YouTubeDownloadService {
     if (!YouTubeDownloadService.instance) {
@@ -53,21 +68,67 @@ export class YouTubeDownloadService {
     return YouTubeDownloadService.instance;
   }
 
+  /**
+   * Spawns yt-dlp with an explicit argument *array* — never a concatenated command-line string
+   * — so that paths containing spaces (e.g. Windows profile paths like
+   * `C:\Users\First Last\...`) survive intact all the way to the child process. Node's
+   * `child_process.spawn(command, args[])` (via `IProcessSpawner`, the same seam
+   * `FFmpegService` uses) hands each argument to the OS process-creation API as a discrete
+   * token; nothing here builds a single string that a shell — or a naive `string.split(" ")`
+   * like the one inside the `tinyspawn` dependency `youtube-dl-exec` used to pull in — could
+   * re-split on whitespace and corrupt.
+   */
+  private runYtDlp(args: string[]): Promise<YtDlpRunResult> {
+    // Log the resolved binary path and the exact arguments before spawning (acceptance
+    // criterion: visibility into the resolved download path + command). Neither the binary
+    // path nor these yt-dlp flags/URLs/paths carry secrets on this code path (no auth tokens or
+    // cookies are ever passed to yt-dlp here), so nothing needs to be redacted.
+    console.log(
+      `[YouTubeDownloadService] Resolved yt-dlp binary: ${this.binaryPath}`,
+      `\n[YouTubeDownloadService] Running: ${describeInvocationForLogging(this.binaryPath, args)}`,
+    );
+
+    return new Promise((resolve, reject) => {
+      let child: ReturnType<IProcessSpawner["spawn"]>;
+      try {
+        child = this.processSpawner.spawn(this.binaryPath, args);
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout?.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
+      child.stderr?.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      child.on("error", (error: Error) => {
+        reject(error);
+      });
+
+      child.on("close", (code: number | null) => {
+        if (code === 0) {
+          resolve({ stdout, stderr });
+          return;
+        }
+        reject(new Error(stderr.trim() || `yt-dlp exited with code ${code ?? "unknown"}`));
+      });
+    });
+  }
+
   public async getVideoMetadata(youtubeUrl: string): Promise<VideoUploadResult> {
-    const flags: Flags = {
-      skipDownload: true,
-      dumpSingleJson: true,
-      noWarnings: true,
-      quiet: true,
-    };
+    const args = ["--skip-download", "--dump-single-json", "--no-warnings", "--quiet", youtubeUrl];
+
     try {
-      const metadata = await this.downloadClient(youtubeUrl, flags);
-      if (
-        typeof metadata !== "string" &&
-        metadata &&
-        typeof metadata === "object" &&
-        "id" in metadata
-      ) {
+      const { stdout } = await this.runYtDlp(args);
+      const metadata = JSON.parse(stdout);
+
+      if (metadata && typeof metadata === "object" && "id" in metadata) {
         return {
           success: true,
           data: {
@@ -79,12 +140,12 @@ export class YouTubeDownloadService {
           },
           origin: "external",
         };
-      } else {
-        return {
-          success: false,
-          error: `Failed to retrieve video metadata: ${metadata}`,
-        };
       }
+
+      return {
+        success: false,
+        error: `Failed to retrieve video metadata: ${stdout}`,
+      };
     } catch (error) {
       return {
         success: false,
@@ -100,16 +161,20 @@ export class YouTubeDownloadService {
 
     outputPath ??= tmp.tmpNameSync({ postfix: ".mp4" });
     console.log("[YouTubeDownloadService] Downloading video to:", outputPath);
-    const flags: Flags = {
-      output: outputPath,
-      format: "mp4",
-      restrictFilenames: true,
-      noWarnings: true,
-      quiet: true,
-    };
+
+    const args = [
+      "--output",
+      outputPath,
+      "--format",
+      "mp4",
+      "--restrict-filenames",
+      "--no-warnings",
+      "--quiet",
+      youtubeUrl,
+    ];
 
     try {
-      await this.downloadClient(youtubeUrl, flags);
+      await this.runYtDlp(args);
       return outputPath;
     } catch (error) {
       throw new Error(`Failed to download video: ${formatYtDlpError(error)}`);


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Claude Code (Claude Sonnet 5), via ARMADA shipwright

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ #931 — YouTube downloads fail (task ends in **Failed** state) whenever the resolved yt-dlp binary path or output path contains a space, e.g. Windows profile paths like `C:\Users\First Last\...`.

> 2. What was changed?

✏️

## Summary

`YouTubeDownloadService` invoked yt-dlp through the `youtube-dl-exec` npm wrapper, which internally pipes the call through its `tinyspawn` dependency. `tinyspawn` builds the child-process command with `input.split(' ').concat(args)` — i.e. it re-splits the **binary path** on whitespace before spawning. Any yt-dlp binary path containing a space (common on Windows, e.g. `C:\Users\First Last\AppData\...`) gets corrupted into multiple bogus argv tokens, so `spawn` is invoked against a nonexistent executable and the download fails immediately, leaving the task in **Failed** state.

Closes #931

## What changed

| File | Change |
|------|--------|
| `src/backend/services/video/youtube-service.ts` | Replaced the `youtube-dl-exec` wrapper with a direct `child_process.spawn` invocation via the existing `IProcessSpawner` seam (the same one `FFmpegService` already uses). yt-dlp's arguments are now built as an explicit array end-to-end — the binary path is passed straight through as `command` and every flag/URL/path is a discrete array element — so nothing re-splits on whitespace. Added logging of the resolved yt-dlp binary path and the exact argv before every spawn. |
| `src/backend/services/video/youtube-service.test.ts` | New regression test file covering the space-in-path bug (binary path with spaces, output path with spaces, argv-array shape, invocation logging, error/success paths for both `downloadVideoToFile` and `getVideoMetadata`). |

## Decisions

- **Decision:** Stop routing yt-dlp invocations through `youtube-dl-exec`'s JS wrapper; call the same bundled binary directly via `child_process.spawn` with an explicit argument array.
  - **Why:** The bug lives one dependency layer down, inside `youtube-dl-exec`'s `tinyspawn` dependency (`input.split(' ')` on the binary path) — not in this repo's own code, and not fixable by changing how `youtube-dl-exec` is called. Bypassing the vulnerable call path avoids depending on an upstream fix and matches the existing safe pattern the repo already uses for ffmpeg (`IProcessSpawner`).
  - **Alternatives considered:** Patching/forking `tinyspawn`, or working around it by avoiding spaces in install paths — rejected because paths with spaces (Windows usernames, "Program Files") are a normal, unavoidable case the app must support.
- **Decision:** Keep `youtube-dl-exec` as an installed dependency (its `postinstall`/`scripts/install-yt-dlp.mjs` still downloads the standalone yt-dlp binary into `node_modules/youtube-dl-exec/bin/`).
  - **Why:** Keeps the binary-download/install mechanism unchanged and the diff scoped to the actual bug; only the *invocation* path changes, not binary provisioning.

## Acceptance criteria

- [x] Download + processing succeeds when paths contain spaces — verified via regression test with a Windows-style binary path (`C:\Users\First Last\...`) and output path both containing spaces, asserting they reach `spawn` as a single, unmodified argv element each.
- [x] Automated test covers a path with spaces — see `youtube-service.test.ts`.
- [x] Command invocation correctly quotes/escapes all paths on Windows — arguments are now passed as an array to `child_process.spawn`, never concatenated into a shell string, so no quoting/escaping is needed (or possible to get wrong) regardless of platform.
- [x] Logging shows the resolved download path and exact command arguments (no secrets) — `console.log` now emits the resolved yt-dlp binary path and the full argv before every invocation; no auth tokens/cookies are ever passed to yt-dlp on this path.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npx vitest run` — 604 tests / 59 files, no regressions)
- [x] Lint / format clean (`npm run lint`, `npm run format`)

Ran the pre-fix (`tinyspawn`) split logic against the reported Windows path to confirm the exact failure mode before writing the fix:

```
input:  C:\Users\First Last\AppData\Local\Programs\yakshaver\resources\app.asar.unpacked\node_modules\youtube-dl-exec\bin\yt-dlp.exe
BEFORE FIX: cmd = "C:\Users\First"   <- garbage executable path, spawn fails immediately
```

## Bug repro evidence

- **Symptom (pinned):** Task ends in **Failed** state when the resolved yt-dlp binary path or the download output path contains a space (per #931, e.g. `C:\Users\First Last\...`).
- **Repro method:** Logic/data bug — reproduced by running the exact pre-fix argument-building logic (`tinyspawn`'s `input.split(' ').concat(args)`, the code `youtube-dl-exec` calls internally) against a Windows-style path with a space, and via a new regression test exercising the same scenario through `YouTubeDownloadService`.
- **Before (unpatched):** Feeding `C:\Users\First Last\...\yt-dlp.exe` through the pre-fix logic yields `cmd = "C:\Users\First"` — a nonexistent executable — which `spawn` would reject with `ENOENT`, exactly matching the reported Failed-task symptom.
- **After (patched):** The new `downloadVideoToFile`/`getVideoMetadata` implementation passes the same binary path and output path straight through as discrete array elements; the regression test `youtube-service.test.ts` asserts `processSpawner.spawn` is called with the full, unmodified path (not split on the embedded space) and passes.

## Follow-up items

- None — the fix is scoped to the yt-dlp invocation path reported in #931. `FFmpegService`'s own spawn path was already safe (array-based `child_process.spawn`, no shell-string concatenation) and required no change.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
