### PR TITLE
XS✔ ◾ fix: disable Developers menu and shortcuts in production release

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { config as dotenvConfig } from "dotenv";
-import { app, BrowserWindow, dialog, Menu, session, shell } from "electron";
+import { app, type BrowserWindow, dialog, Menu, session, shell } from "electron";
 import { initMain as initAudioLoopback } from "electron-audio-loopback";
 import { autoUpdater } from "electron-updater";
 import tmp from "tmp";
@@ -39,7 +39,7 @@ import { ScreenFrameWindow } from "./services/recording/screen-frame-window";
 import { HotkeyManager } from "./services/settings/hotkey-manager";
 import { TelemetryService } from "./services/telemetry/telemetry-service";
 import { TrayManager } from "./services/tray/tray-manager";
-import { applyDevToolsGuard, isProductionBuild } from "./utils/devtools-guard";
+import { createGuardedBrowserWindow } from "./utils/devtools-guard";
 import { getIconPath } from "./utils/path-utils";
 
 const isDev = process.env.NODE_ENV === "development" || process.argv.includes("--dev-protocol");
@@ -179,7 +179,7 @@ const createWindow = (): BrowserWindow | null => {
 
   const title = `YakShaver`;
 
-  const window = new BrowserWindow({
+  const window = createGuardedBrowserWindow({
     width: 1200,
     height: 800,
     title,
@@ -189,12 +189,10 @@ const createWindow = (): BrowserWindow | null => {
       nodeIntegration: false,
       contextIsolation: true,
       preload: join(__dirname, "preload.js"),
-      devTools: !isProductionBuild(),
     },
   });
 
   mainWindow = window;
-  applyDevToolsGuard(window);
 
   // URLs - by default, open in default browser. Deny everything else outright
   // (rather than falling through to `allow`) so no popup window can ever be

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -39,6 +39,7 @@ import { ScreenFrameWindow } from "./services/recording/screen-frame-window";
 import { HotkeyManager } from "./services/settings/hotkey-manager";
 import { TelemetryService } from "./services/telemetry/telemetry-service";
 import { TrayManager } from "./services/tray/tray-manager";
+import { applyDevToolsGuard } from "./utils/devtools-guard";
 import { getIconPath } from "./utils/path-utils";
 
 const isDev = process.env.NODE_ENV === "development" || process.argv.includes("--dev-protocol");
@@ -188,10 +189,12 @@ const createWindow = (): BrowserWindow | null => {
       nodeIntegration: false,
       contextIsolation: true,
       preload: join(__dirname, "preload.js"),
+      devTools: !app.isPackaged,
     },
   });
 
   mainWindow = window;
+  applyDevToolsGuard(window);
 
   // URLs - by default, open in default browser
   window.webContents.setWindowOpenHandler(({ url }) => {

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -39,7 +39,7 @@ import { ScreenFrameWindow } from "./services/recording/screen-frame-window";
 import { HotkeyManager } from "./services/settings/hotkey-manager";
 import { TelemetryService } from "./services/telemetry/telemetry-service";
 import { TrayManager } from "./services/tray/tray-manager";
-import { applyDevToolsGuard } from "./utils/devtools-guard";
+import { applyDevToolsGuard, isProductionBuild } from "./utils/devtools-guard";
 import { getIconPath } from "./utils/path-utils";
 
 const isDev = process.env.NODE_ENV === "development" || process.argv.includes("--dev-protocol");
@@ -189,20 +189,21 @@ const createWindow = (): BrowserWindow | null => {
       nodeIntegration: false,
       contextIsolation: true,
       preload: join(__dirname, "preload.js"),
-      devTools: !app.isPackaged,
+      devTools: !isProductionBuild(),
     },
   });
 
   mainWindow = window;
   applyDevToolsGuard(window);
 
-  // URLs - by default, open in default browser
+  // URLs - by default, open in default browser. Deny everything else outright
+  // (rather than falling through to `allow`) so no popup window can ever be
+  // spawned without the DevTools guard applied above (#942 review thread).
   window.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith("http://") || url.startsWith("https://")) {
       shell.openExternal(url);
-      return { action: "deny" };
     }
-    return { action: "allow" };
+    return { action: "deny" };
   });
 
   window.once("ready-to-show", () => {

--- a/src/backend/services/recording/camera-window.ts
+++ b/src/backend/services/recording/camera-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { BrowserWindow, ipcMain, screen } from "electron";
-import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
+import { type BrowserWindow, ipcMain, screen } from "electron";
+import { createGuardedBrowserWindow } from "../../utils/devtools-guard";
 
 const WINDOW_SIZE = { width: 400, height: 225 }; // 16:9 aspect ratio
 const MARGIN = 20;
@@ -32,7 +32,7 @@ export class CameraWindow {
       ? `http://localhost:3000/camera.html?deviceId=${encodeURIComponent(cameraDeviceId)}`
       : join(process.resourcesPath, "app.asar.unpacked/src/ui/dist/camera.html");
 
-    this.window = new BrowserWindow({
+    this.window = createGuardedBrowserWindow({
       ...WINDOW_SIZE,
       x,
       y,
@@ -45,11 +45,8 @@ export class CameraWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !isProductionBuild(),
       },
     });
-
-    applyDevToolsGuard(this.window);
 
     this.window.on("closed", () => {
       this.window = null;

--- a/src/backend/services/recording/camera-window.ts
+++ b/src/backend/services/recording/camera-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { app, BrowserWindow, ipcMain, screen } from "electron";
-import { applyDevToolsGuard } from "../../utils/devtools-guard";
+import { BrowserWindow, ipcMain, screen } from "electron";
+import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
 
 const WINDOW_SIZE = { width: 400, height: 225 }; // 16:9 aspect ratio
 const MARGIN = 20;
@@ -45,7 +45,7 @@ export class CameraWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !app.isPackaged,
+        devTools: !isProductionBuild(),
       },
     });
 

--- a/src/backend/services/recording/camera-window.ts
+++ b/src/backend/services/recording/camera-window.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
-import { BrowserWindow, ipcMain, screen } from "electron";
+import { app, BrowserWindow, ipcMain, screen } from "electron";
+import { applyDevToolsGuard } from "../../utils/devtools-guard";
 
 const WINDOW_SIZE = { width: 400, height: 225 }; // 16:9 aspect ratio
 const MARGIN = 20;
@@ -44,8 +45,11 @@ export class CameraWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
+        devTools: !app.isPackaged,
       },
     });
+
+    applyDevToolsGuard(this.window);
 
     this.window.on("closed", () => {
       this.window = null;

--- a/src/backend/services/recording/control-bar-window.test.ts
+++ b/src/backend/services/recording/control-bar-window.test.ts
@@ -24,6 +24,7 @@ const { mockWebContents, mockWindow } = vi.hoisted(() => {
 });
 
 vi.mock("electron", () => ({
+  app: { isPackaged: false },
   BrowserWindow: class MockBrowserWindow {
     webContents = mockWindow.webContents;
     isDestroyed = mockWindow.isDestroyed;

--- a/src/backend/services/recording/control-bar-window.ts
+++ b/src/backend/services/recording/control-bar-window.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
-import { BrowserWindow, screen } from "electron";
+import { app, BrowserWindow, screen } from "electron";
+import { applyDevToolsGuard } from "../../utils/devtools-guard";
 import { formatRecordingTime } from "./format-recording-time";
 
 const WINDOW_SIZE = { width: 300, height: 80 };
@@ -62,8 +63,11 @@ export class RecordingControlBarWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
+        devTools: !app.isPackaged,
       },
     });
+
+    applyDevToolsGuard(this.window);
 
     this.window.on("closed", () => {
       this.window = null;

--- a/src/backend/services/recording/control-bar-window.ts
+++ b/src/backend/services/recording/control-bar-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { BrowserWindow, screen } from "electron";
-import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
+import { createGuardedBrowserWindow } from "../../utils/devtools-guard";
 import { formatRecordingTime } from "./format-recording-time";
 
 const WINDOW_SIZE = { width: 300, height: 80 };
@@ -50,7 +50,7 @@ export class RecordingControlBarWindow {
       ? "http://localhost:3000/control-bar.html"
       : join(process.resourcesPath, "app.asar.unpacked/src/ui/dist/control-bar.html");
 
-    this.window = new BrowserWindow({
+    this.window = createGuardedBrowserWindow({
       ...WINDOW_SIZE,
       x,
       y,
@@ -63,11 +63,8 @@ export class RecordingControlBarWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !isProductionBuild(),
       },
     });
-
-    applyDevToolsGuard(this.window);
 
     this.window.on("closed", () => {
       this.window = null;

--- a/src/backend/services/recording/control-bar-window.ts
+++ b/src/backend/services/recording/control-bar-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { app, BrowserWindow, screen } from "electron";
-import { applyDevToolsGuard } from "../../utils/devtools-guard";
+import { BrowserWindow, screen } from "electron";
+import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
 import { formatRecordingTime } from "./format-recording-time";
 
 const WINDOW_SIZE = { width: 300, height: 80 };
@@ -63,7 +63,7 @@ export class RecordingControlBarWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !app.isPackaged,
+        devTools: !isProductionBuild(),
       },
     });
 

--- a/src/backend/services/recording/countdown-window.ts
+++ b/src/backend/services/recording/countdown-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { BrowserWindow, screen } from "electron";
-import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
+import { type BrowserWindow, screen } from "electron";
+import { createGuardedBrowserWindow } from "../../utils/devtools-guard";
 
 export class CountdownWindow {
   private static instance: CountdownWindow;
@@ -26,7 +26,7 @@ export class CountdownWindow {
       ? "http://localhost:3000/countdown.html"
       : join(process.resourcesPath, "app.asar.unpacked/src/ui/dist/countdown.html");
 
-    this.window = new BrowserWindow({
+    this.window = createGuardedBrowserWindow({
       x,
       y,
       width,
@@ -43,11 +43,8 @@ export class CountdownWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !isProductionBuild(),
       },
     });
-
-    applyDevToolsGuard(this.window);
 
     // NOTE: there is a bug where the above code doesn't set the correct size and it always ends up
     //       with the size of the primary display, even if a different display is selected.

--- a/src/backend/services/recording/countdown-window.ts
+++ b/src/backend/services/recording/countdown-window.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
-import { BrowserWindow, screen } from "electron";
+import { app, BrowserWindow, screen } from "electron";
+import { applyDevToolsGuard } from "../../utils/devtools-guard";
 
 export class CountdownWindow {
   private static instance: CountdownWindow;
@@ -42,8 +43,11 @@ export class CountdownWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
+        devTools: !app.isPackaged,
       },
     });
+
+    applyDevToolsGuard(this.window);
 
     // NOTE: there is a bug where the above code doesn't set the correct size and it always ends up
     //       with the size of the primary display, even if a different display is selected.

--- a/src/backend/services/recording/countdown-window.ts
+++ b/src/backend/services/recording/countdown-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { app, BrowserWindow, screen } from "electron";
-import { applyDevToolsGuard } from "../../utils/devtools-guard";
+import { BrowserWindow, screen } from "electron";
+import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
 
 export class CountdownWindow {
   private static instance: CountdownWindow;
@@ -43,7 +43,7 @@ export class CountdownWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !app.isPackaged,
+        devTools: !isProductionBuild(),
       },
     });
 

--- a/src/backend/services/recording/screen-frame-window.ts
+++ b/src/backend/services/recording/screen-frame-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { app, BrowserWindow, desktopCapturer, screen } from "electron";
-import { applyDevToolsGuard } from "../../utils/devtools-guard";
+import { BrowserWindow, desktopCapturer, screen } from "electron";
+import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
 
 export class ScreenFrameWindow {
   private static instance: ScreenFrameWindow;
@@ -54,7 +54,7 @@ export class ScreenFrameWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !app.isPackaged,
+        devTools: !isProductionBuild(),
       },
     });
 

--- a/src/backend/services/recording/screen-frame-window.ts
+++ b/src/backend/services/recording/screen-frame-window.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { BrowserWindow, desktopCapturer, screen } from "electron";
-import { applyDevToolsGuard, isProductionBuild } from "../../utils/devtools-guard";
+import { type BrowserWindow, desktopCapturer, screen } from "electron";
+import { createGuardedBrowserWindow } from "../../utils/devtools-guard";
 
 export class ScreenFrameWindow {
   private static instance: ScreenFrameWindow;
@@ -37,7 +37,7 @@ export class ScreenFrameWindow {
       ? "http://localhost:3000/frame-overlay.html"
       : join(process.resourcesPath, "app.asar.unpacked/src/ui/dist/frame-overlay.html");
 
-    this.window = new BrowserWindow({
+    this.window = createGuardedBrowserWindow({
       x,
       y,
       width,
@@ -54,11 +54,8 @@ export class ScreenFrameWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
-        devTools: !isProductionBuild(),
       },
     });
-
-    applyDevToolsGuard(this.window);
 
     // Don't include this window in the recording
     this.window.setContentProtection(true);

--- a/src/backend/services/recording/screen-frame-window.ts
+++ b/src/backend/services/recording/screen-frame-window.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
-import { BrowserWindow, desktopCapturer, screen } from "electron";
+import { app, BrowserWindow, desktopCapturer, screen } from "electron";
+import { applyDevToolsGuard } from "../../utils/devtools-guard";
 
 export class ScreenFrameWindow {
   private static instance: ScreenFrameWindow;
@@ -53,8 +54,11 @@ export class ScreenFrameWindow {
         preload: join(__dirname, "../../preload.js"),
         contextIsolation: true,
         nodeIntegration: false,
+        devTools: !app.isPackaged,
       },
     });
+
+    applyDevToolsGuard(this.window);
 
     // Don't include this window in the recording
     this.window.setContentProtection(true);

--- a/src/backend/utils/devtools-guard.test.ts
+++ b/src/backend/utils/devtools-guard.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mirrors the mocking pattern used by control-bar-window.test.ts: electron
+// isn't available under vitest's node environment, so `app.isPackaged` and a
+// minimal BrowserWindow-shaped webContents are mocked directly.
+const { mockApp } = vi.hoisted(() => ({
+  mockApp: { isPackaged: false },
+}));
+
+vi.mock("electron", () => ({
+  app: mockApp,
+}));
+
+import { applyDevToolsGuard, isProductionBuild } from "./devtools-guard";
+
+type Handler = (...args: unknown[]) => void;
+
+function createMockWindow() {
+  const handlers = new Map<string, Handler>();
+  const closeDevTools = vi.fn();
+  const webContents = {
+    on: vi.fn((event: string, handler: Handler) => {
+      handlers.set(event, handler);
+    }),
+    closeDevTools,
+  };
+  return {
+    window: { webContents } as unknown as Electron.BrowserWindow,
+    handlers,
+    closeDevTools,
+  };
+}
+
+describe("isProductionBuild", () => {
+  it("mirrors app.isPackaged rather than NODE_ENV", () => {
+    mockApp.isPackaged = false;
+    expect(isProductionBuild()).toBe(false);
+
+    mockApp.isPackaged = true;
+    expect(isProductionBuild()).toBe(true);
+  });
+});
+
+describe("applyDevToolsGuard", () => {
+  beforeEach(() => {
+    mockApp.isPackaged = false;
+  });
+
+  it("does nothing outside production (development stays unaffected)", () => {
+    mockApp.isPackaged = false;
+    const { window, handlers } = createMockWindow();
+
+    applyDevToolsGuard(window);
+
+    expect(handlers.size).toBe(0);
+  });
+
+  it.each([
+    { key: "F12", control: false, meta: false, shift: false },
+    { key: "i", control: true, meta: false, shift: true },
+    { key: "I", control: true, meta: false, shift: true },
+    { key: "j", control: true, meta: false, shift: true },
+    { key: "c", control: true, meta: false, shift: true },
+    { key: "i", control: false, meta: true, shift: true }, // macOS Cmd+Shift+I
+  ])("blocks the $key devtools shortcut in production regardless of the app Menu", ({
+    key,
+    control,
+    meta,
+    shift,
+  }) => {
+    mockApp.isPackaged = true;
+    const { window, handlers } = createMockWindow();
+
+    applyDevToolsGuard(window);
+
+    const beforeInputEvent = handlers.get("before-input-event");
+    expect(beforeInputEvent).toBeDefined();
+
+    const preventDefault = vi.fn();
+    beforeInputEvent?.(
+      { preventDefault },
+      { type: "keyDown", key, control, meta, shift, alt: false },
+    );
+
+    // This is the crux of #455: the app's Menu can omit "Toggle DevTools"
+    // entirely, but Chromium's default accelerators still fire unless
+    // explicitly intercepted here.
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block unrelated keys in production", () => {
+    mockApp.isPackaged = true;
+    const { window, handlers } = createMockWindow();
+
+    applyDevToolsGuard(window);
+
+    const beforeInputEvent = handlers.get("before-input-event");
+    const preventDefault = vi.fn();
+    beforeInputEvent?.(
+      { preventDefault },
+      { type: "keyDown", key: "a", control: true, meta: false, shift: true, alt: false },
+    );
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores keyUp events (only intercepts keyDown)", () => {
+    mockApp.isPackaged = true;
+    const { window, handlers } = createMockWindow();
+
+    applyDevToolsGuard(window);
+
+    const beforeInputEvent = handlers.get("before-input-event");
+    const preventDefault = vi.fn();
+    beforeInputEvent?.(
+      { preventDefault },
+      { type: "keyUp", key: "F12", control: false, meta: false, shift: false, alt: false },
+    );
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("force-closes DevTools if it is ever opened in production (belt-and-suspenders)", () => {
+    mockApp.isPackaged = true;
+    const { window, handlers, closeDevTools } = createMockWindow();
+
+    applyDevToolsGuard(window);
+
+    const devtoolsOpened = handlers.get("devtools-opened");
+    expect(devtoolsOpened).toBeDefined();
+
+    devtoolsOpened?.();
+
+    expect(closeDevTools).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/backend/utils/devtools-guard.test.ts
+++ b/src/backend/utils/devtools-guard.test.ts
@@ -56,17 +56,21 @@ describe("applyDevToolsGuard", () => {
   });
 
   it.each([
-    { key: "F12", control: false, meta: false, shift: false },
-    { key: "i", control: true, meta: false, shift: true },
-    { key: "I", control: true, meta: false, shift: true },
-    { key: "j", control: true, meta: false, shift: true },
-    { key: "c", control: true, meta: false, shift: true },
-    { key: "i", control: false, meta: true, shift: true }, // macOS Cmd+Shift+I
+    { key: "F12", control: false, meta: false, shift: false, alt: false },
+    { key: "i", control: true, meta: false, shift: true, alt: false },
+    { key: "I", control: true, meta: false, shift: true, alt: false },
+    { key: "j", control: true, meta: false, shift: true, alt: false },
+    { key: "c", control: true, meta: false, shift: true, alt: false },
+    { key: "i", control: false, meta: true, shift: true, alt: false }, // Cmd+Shift+I alias
+    { key: "i", control: false, meta: true, shift: false, alt: true }, // macOS Cmd+Option+I (Chromium's real default)
+    { key: "j", control: false, meta: true, shift: false, alt: true }, // macOS Cmd+Option+J
+    { key: "c", control: false, meta: true, shift: false, alt: true }, // macOS Cmd+Option+C
   ])("blocks the $key devtools shortcut in production regardless of the app Menu", ({
     key,
     control,
     meta,
     shift,
+    alt,
   }) => {
     mockApp.isPackaged = true;
     const { window, handlers } = createMockWindow();
@@ -77,10 +81,7 @@ describe("applyDevToolsGuard", () => {
     expect(beforeInputEvent).toBeDefined();
 
     const preventDefault = vi.fn();
-    beforeInputEvent?.(
-      { preventDefault },
-      { type: "keyDown", key, control, meta, shift, alt: false },
-    );
+    beforeInputEvent?.({ preventDefault }, { type: "keyDown", key, control, meta, shift, alt });
 
     // This is the crux of #455: the app's Menu can omit "Toggle DevTools"
     // entirely, but Chromium's default accelerators still fire unless

--- a/src/backend/utils/devtools-guard.test.ts
+++ b/src/backend/utils/devtools-guard.test.ts
@@ -3,15 +3,38 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mirrors the mocking pattern used by control-bar-window.test.ts: electron
 // isn't available under vitest's node environment, so `app.isPackaged` and a
 // minimal BrowserWindow-shaped webContents are mocked directly.
-const { mockApp } = vi.hoisted(() => ({
-  mockApp: { isPackaged: false },
-}));
+const { mockApp, mockBrowserWindowConstructor, mockBrowserWindowState, MockBrowserWindow } =
+  vi.hoisted(() => {
+    const mockBrowserWindowConstructor = vi.fn();
+    const mockBrowserWindowState: { webContents: unknown } = { webContents: null };
+
+    class MockBrowserWindow {
+      webContents: unknown;
+
+      constructor(options: unknown) {
+        mockBrowserWindowConstructor(options);
+        this.webContents = mockBrowserWindowState.webContents;
+      }
+    }
+
+    return {
+      mockApp: { isPackaged: false },
+      mockBrowserWindowConstructor,
+      mockBrowserWindowState,
+      MockBrowserWindow,
+    };
+  });
 
 vi.mock("electron", () => ({
   app: mockApp,
+  BrowserWindow: MockBrowserWindow,
 }));
 
-import { applyDevToolsGuard, isProductionBuild } from "./devtools-guard";
+import {
+  applyDevToolsGuard,
+  createGuardedBrowserWindow,
+  isProductionBuild,
+} from "./devtools-guard";
 
 type Handler = (...args: unknown[]) => void;
 
@@ -133,5 +156,59 @@ describe("applyDevToolsGuard", () => {
     devtoolsOpened?.();
 
     expect(closeDevTools).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createGuardedBrowserWindow", () => {
+  beforeEach(() => {
+    mockApp.isPackaged = false;
+    mockBrowserWindowConstructor.mockReset();
+    mockBrowserWindowState.webContents = null;
+  });
+
+  it("creates a window with DevTools enabled outside production and applies no guard", () => {
+    const { window, handlers } = createMockWindow();
+    mockBrowserWindowState.webContents = window.webContents;
+
+    const created = createGuardedBrowserWindow({
+      width: 100,
+      webPreferences: {
+        contextIsolation: true,
+      },
+    });
+
+    expect((created as unknown as { webContents: unknown }).webContents).toBe(window.webContents);
+    expect(mockBrowserWindowConstructor).toHaveBeenCalledWith({
+      width: 100,
+      webPreferences: {
+        contextIsolation: true,
+        devTools: true,
+      },
+    });
+    expect(handlers.size).toBe(0);
+  });
+
+  it("creates a window with DevTools disabled in production and applies the guard", () => {
+    mockApp.isPackaged = true;
+    const { window, handlers } = createMockWindow();
+    mockBrowserWindowState.webContents = window.webContents;
+
+    createGuardedBrowserWindow({
+      height: 100,
+      webPreferences: {
+        devTools: true,
+        nodeIntegration: false,
+      },
+    });
+
+    expect(mockBrowserWindowConstructor).toHaveBeenCalledWith({
+      height: 100,
+      webPreferences: {
+        devTools: false,
+        nodeIntegration: false,
+      },
+    });
+    expect(handlers.has("before-input-event")).toBe(true);
+    expect(handlers.has("devtools-opened")).toBe(true);
   });
 });

--- a/src/backend/utils/devtools-guard.ts
+++ b/src/backend/utils/devtools-guard.ts
@@ -39,12 +39,14 @@ function isDevToolsShortcut(input: Input): boolean {
 /**
  * Locks a window's DevTools access down for production builds.
  *
- * Defense in depth: `webPreferences.devTools: false` (set at window creation)
- * already prevents `webContents.openDevTools()` from doing anything, but this
- * adds a belt-and-suspenders guard against DevTools being reachable through
- * accelerators or being opened by other means (e.g. a future regression that
- * drops the webPreferences flag) — it intercepts the shortcut before Chromium
- * acts on it, and force-closes DevTools if it ever ends up open regardless.
+ * `webPreferences.devTools: false` (set at window creation) disables the
+ * `webContents.openDevTools()` API surface, but Chromium wires its DevTools
+ * keyboard accelerators (F12, Ctrl/Cmd+Shift+I/J/C) independently of that
+ * flag — so for the shortcut vector this `before-input-event` interception is
+ * the actual mechanism that blocks it, not a redundant second layer. The
+ * `devtools-opened` force-close is the true belt-and-suspenders half: a
+ * fallback in case DevTools ever ends up open through some other path (e.g. a
+ * future regression that drops the webPreferences flag).
  *
  * No-op outside production so development workflows are unaffected.
  */

--- a/src/backend/utils/devtools-guard.ts
+++ b/src/backend/utils/devtools-guard.ts
@@ -26,8 +26,12 @@ function isDevToolsShortcut(input: Input): boolean {
   const key = input.key.toLowerCase();
   if (key === "f12") return true;
 
-  const modifier = input.control || input.meta;
-  if (!modifier || !input.shift) return false;
+  // Windows/Linux: Ctrl+Shift+I/J/C. macOS: Cmd+Option+I/J/C (Chromium's
+  // actual default accelerators there use Option/Alt, not Shift) — also
+  // accept Cmd+Shift as a belt-and-suspenders alias.
+  const ctrlShift = input.control && input.shift;
+  const metaAltOrShift = input.meta && (input.alt || input.shift);
+  if (!ctrlShift && !metaAltOrShift) return false;
 
   return key === "i" || key === "j" || key === "c";
 }

--- a/src/backend/utils/devtools-guard.ts
+++ b/src/backend/utils/devtools-guard.ts
@@ -1,0 +1,59 @@
+import { app, type BrowserWindow, type Input } from "electron";
+
+/**
+ * Whether this process is running as a packaged production build.
+ *
+ * Prefer this over `NODE_ENV`-based checks: `NODE_ENV` is only set explicitly
+ * by the `npm run dev` script (via `cross-env NODE_ENV=development`) and can
+ * be left unset, or leak an unexpected value from whatever shell/CI/installer
+ * launched the process. `app.isPackaged` is Electron-native and reflects
+ * whether the app is actually running from a packaged asar, independent of
+ * the environment — the same reasoning `getIconPath` already relies on.
+ */
+export function isProductionBuild(): boolean {
+  return app.isPackaged;
+}
+
+/**
+ * Keyboard shortcuts Chromium wires up by default to open DevTools,
+ * regardless of whether the app's own Menu exposes a "Toggle DevTools" item.
+ * Removing the menu entry alone does not disable these accelerators (see
+ * #455) — they have to be intercepted explicitly.
+ */
+function isDevToolsShortcut(input: Input): boolean {
+  if (input.type !== "keyDown") return false;
+
+  const key = input.key.toLowerCase();
+  if (key === "f12") return true;
+
+  const modifier = input.control || input.meta;
+  if (!modifier || !input.shift) return false;
+
+  return key === "i" || key === "j" || key === "c";
+}
+
+/**
+ * Locks a window's DevTools access down for production builds.
+ *
+ * Defense in depth: `webPreferences.devTools: false` (set at window creation)
+ * already prevents `webContents.openDevTools()` from doing anything, but this
+ * adds a belt-and-suspenders guard against DevTools being reachable through
+ * accelerators or being opened by other means (e.g. a future regression that
+ * drops the webPreferences flag) — it intercepts the shortcut before Chromium
+ * acts on it, and force-closes DevTools if it ever ends up open regardless.
+ *
+ * No-op outside production so development workflows are unaffected.
+ */
+export function applyDevToolsGuard(window: BrowserWindow): void {
+  if (!isProductionBuild()) return;
+
+  window.webContents.on("before-input-event", (event, input) => {
+    if (isDevToolsShortcut(input)) {
+      event.preventDefault();
+    }
+  });
+
+  window.webContents.on("devtools-opened", () => {
+    window.webContents.closeDevTools();
+  });
+}

--- a/src/backend/utils/devtools-guard.ts
+++ b/src/backend/utils/devtools-guard.ts
@@ -1,4 +1,4 @@
-import { app, type BrowserWindow, type Input } from "electron";
+import { app, BrowserWindow, type BrowserWindowConstructorOptions, type Input } from "electron";
 
 /**
  * Whether this process is running as a packaged production build.
@@ -62,4 +62,20 @@ export function applyDevToolsGuard(window: BrowserWindow): void {
   window.webContents.on("devtools-opened", () => {
     window.webContents.closeDevTools();
   });
+}
+
+export function createGuardedBrowserWindow(
+  options: BrowserWindowConstructorOptions,
+): BrowserWindow {
+  const window = new BrowserWindow({
+    ...options,
+    webPreferences: {
+      ...options.webPreferences,
+      devTools: !isProductionBuild(),
+    },
+  });
+
+  applyDevToolsGuard(window);
+
+  return window;
 }


### PR DESCRIPTION
## Summary

Developer tools (menu item, `openDevTools()`, and default Chromium keyboard shortcuts like F12 / Ctrl+Shift+I) were reachable in production builds. Closing the visible menu item alone was not enough — Chromium wires up DevTools-opening accelerators independently of the app's `Menu` template, and every `BrowserWindow` in the app left `webPreferences.devTools` unset (which defaults to enabled).

Closes #455

## Root cause

- `src/backend/index.ts` already gated the "Toggle DevTools" **menu entry** and the initial `openDevTools()` call on an `isDev` flag — but that only hides the menu item, it does not disable the underlying DevTools capability or Chromium's built-in keyboard shortcuts (F12, Ctrl/Cmd+Shift+I, Ctrl/Cmd+Shift+J, Ctrl/Cmd+Shift+C).
- No window in the codebase (main window, recording control bar, camera, countdown, screen-frame overlay) set `webPreferences.devTools`, so it stayed at Electron's default of `true` everywhere, including packaged production builds.
- The existing `isDev` flag is derived from `NODE_ENV === "development"`, which is only set explicitly by the `npm run dev` script. It's a reasonable check for *load URL* purposes, but relying on an environment variable for a security-relevant gate is fragile — a leaked/misconfigured `NODE_ENV` in some launch context would silently re-enable dev-only behavior. `app.isPackaged` (already used elsewhere in the codebase, e.g. `getIconPath()`) is the Electron-native, environment-independent signal for "is this a packaged/production build," so the new guard uses that instead.

## Approach

Added `src/backend/utils/devtools-guard.ts` with two exports:

- `isProductionBuild()` — wraps `app.isPackaged`.
- `applyDevToolsGuard(window)` — no-op outside production; in production it:
  1. Intercepts `before-input-event` on the window's `webContents` and calls `event.preventDefault()` for F12 / Ctrl-or-Cmd+Shift+I/J/C, before Chromium acts on them.
  2. Listens for `devtools-opened` and force-closes DevTools if it's ever opened through any other path — belt-and-suspenders in case a future change drops the `webPreferences.devTools` flag.

Applied consistently to every window construction site:
- `src/backend/index.ts` (main window) — also sets `webPreferences.devTools: !app.isPackaged`.
- `src/backend/services/recording/control-bar-window.ts`
- `src/backend/services/recording/camera-window.ts`
- `src/backend/services/recording/countdown-window.ts`
- `src/backend/services/recording/screen-frame-window.ts`

Each now also sets `webPreferences.devTools: !app.isPackaged` at window creation, which is the primary fix (Electron respects this by making `webContents.openDevTools()` a no-op); the `applyDevToolsGuard` call is the defense-in-depth layer for the keyboard shortcuts and any accidental future regression.

Development workflows (`npm run dev` / `npm run start`) are unaffected — the guard is a no-op whenever `app.isPackaged` is `false`, and the existing "Toggle DevTools" menu item still appears in dev builds exactly as before.

## Acceptance criteria mapping

- [x] Disable developer tools in production builds → `webPreferences.devTools: !app.isPackaged` on every `BrowserWindow`.
- [x] Remove/conditionally render the Developers menu block for non-development environment → already gated on `isDev` prior to this change; now backed by an actual disabled capability rather than just a hidden menu item.
- [x] Disable keyboard shortcuts that open developer tools in production → `before-input-event` interception in `devtools-guard.ts`, plus a `devtools-opened` force-close fallback.

## Testing performed

- `npm run build` — clean, no type errors.
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run` — all 58 test files / 606 tests pass, including 11 new tests in `src/backend/utils/devtools-guard.test.ts` covering: `isProductionBuild` mirroring `app.isPackaged`; the guard being a no-op in development; each blocked shortcut (F12, Ctrl+Shift+I/J/C, Cmd+Shift+I) being intercepted in production; unrelated keys and `keyUp` events passing through untouched; and the `devtools-opened` force-close fallback.
- `npm run lint` — clean.
- `npm run format` — clean, no diff.
- Fixed an existing test (`control-bar-window.test.ts`) whose `electron` mock didn't export `app`, which the new `webPreferences.devTools: !app.isPackaged` line now depends on.

### Bug repro evidence

This is a static/logic gap rather than a UI runtime bug (no exception, no visible crash) — the code paths that create every `BrowserWindow` never set `webPreferences.devTools`, so it silently defaulted to `true` in every build. I confirmed via code inspection (grep across `src/backend/`) that:
- No window construction set `devTools` in `webPreferences` before this change.
- No handler intercepted `before-input-event` anywhere in the codebase before this change.

The new `devtools-guard.test.ts` file is itself the regression evidence: since `devtools-guard.ts` did not exist before this change, these tests could not exist/pass against the unpatched code. They now assert the shortcut-blocking behavior directly (rather than requiring a full Electron runtime), and all 11 pass against the patched code.

## Risks / follow-ups

- `webPreferences.devTools: false` and shortcut-blocking only apply to windows created by this app's own code. This does not change anything about `--remote-debugging-port` / `--inspect` flags, which aren't passed anywhere in this repo's packaging config as far as I found.
- Scope was kept to the DevTools menu/shortcut/capability gap described in the issue; the pre-existing `isDev`-based menu-item gating and `NODE_ENV`-based `isDev` computation for dev server URLs were left untouched since they weren't part of the reported bug.
