### PR TITLE
XS✔ ◾ test(workflow): cover WorkflowStepCard status rendering, close #645

### DIFF
--- a/src/ui/src/components/workflow/WorkflowStepCard.test.tsx
+++ b/src/ui/src/components/workflow/WorkflowStepCard.test.tsx
@@ -1,0 +1,79 @@
+import { ProgressStage, type WorkflowStep } from "@shared/types/workflow";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { WorkflowStepCard } from "./WorkflowStepCard";
+
+/**
+ * #645: "Updating metadata" never showed a green tick after it actually completed.
+ * WorkflowProgressPanel.test.tsx mocks WorkflowStepCard entirely (it only asserts the
+ * panel's live/hydrated wiring), so nothing in the suite exercised the real status ->
+ * icon mapping this component renders. This file closes that gap: it asserts the
+ * completed/failed/in_progress/not_started/skipped contract directly against
+ * WorkflowStepCard, for the updating_metadata stage specifically (the one the issue
+ * reports) and, for completeness, a couple of other stages.
+ */
+function makeStep(
+  status: WorkflowStep["status"],
+  stage = ProgressStage.UPDATING_METADATA,
+): WorkflowStep {
+  return { stage, status };
+}
+
+describe("WorkflowStepCard status rendering (#645)", () => {
+  it("renders a green completed indicator for updating_metadata once it has completed", () => {
+    const step = makeStep("completed");
+    step.payload = JSON.stringify({ title: "My Video", description: "desc" });
+
+    render(<WorkflowStepCard step={step} label="Updating Metadata" shaveId="shave-1" />);
+
+    expect(screen.getByText("Updating Metadata")).toBeInTheDocument();
+    expect(document.querySelector(".text-green-400")).not.toBeNull();
+  });
+
+  it("renders the spinner (in_progress) for updating_metadata while the YouTube update is running", () => {
+    const step = makeStep("in_progress");
+
+    render(<WorkflowStepCard step={step} label="Updating Metadata" shaveId="shave-1" />);
+
+    expect(document.querySelector(".animate-spin")).not.toBeNull();
+    expect(document.querySelector(".text-green-400")).toBeNull();
+  });
+
+  it("renders a red failed indicator with the error when updating_metadata fails", () => {
+    const step = makeStep("failed");
+    step.payload = JSON.stringify({ error: "YouTube metadata update failed: quota exceeded" });
+
+    render(<WorkflowStepCard step={step} label="Updating Metadata" shaveId="shave-1" />);
+
+    expect(document.querySelector(".text-red-400")).not.toBeNull();
+    expect(screen.getByText(/quota exceeded/)).toBeInTheDocument();
+  });
+
+  it("renders an empty (not_started) indicator before updating_metadata has run", () => {
+    const step = makeStep("not_started");
+
+    render(<WorkflowStepCard step={step} label="Updating Metadata" shaveId="shave-1" />);
+
+    expect(screen.getByText("Updating Metadata")).toBeInTheDocument();
+    expect(document.querySelector(".text-green-400")).toBeNull();
+    expect(document.querySelector(".text-red-400")).toBeNull();
+  });
+
+  it("renders nothing when updating_metadata is skipped (external link / failed upload, #798)", () => {
+    const step = makeStep("skipped");
+
+    const { container } = render(
+      <WorkflowStepCard step={step} label="Updating Metadata" shaveId="shave-1" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("also ticks green for other stages once completed (executing_task)", () => {
+    const step = makeStep("completed", ProgressStage.EXECUTING_TASK);
+
+    render(<WorkflowStepCard step={step} label="Executing Task" shaveId="shave-1" />);
+
+    expect(document.querySelector(".text-green-400")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Issue #645 reports that the "Updating metadata" step in the workflow progress panel never shows a green completion tick, even though the underlying YouTube metadata update actually succeeds.

Closes #645

## Root cause

This is a case where the underlying bug was already fixed by a prior merge, but the issue was never closed because of how the fixing PR referenced it:

- PR #874 ("Fix YouTube upload/metadata honesty (#672, #861, #798, #645)", merged 2026-06-26) rewired the `UPDATING_METADATA` stage so it honestly reports `completed` (green tick) on a real success, `failed` (red X + warning banner) on a real failure, and `skipped` (hidden, with the failure/skip reason surfaced elsewhere) when it doesn't apply (external link / failed upload) — replacing the old ambiguous "ticks green unconditionally" / "gets stuck" behavior the maintainer's comment on #645 described.
- That PR's body used a single line — `Closes #672, #861, #798, #645.` — to close four issues at once. GitHub's closing-keyword parser only recognizes the **first** issue number immediately after a closing keyword, so only **#672** was actually linked and auto-closed on merge (confirmed via `gh pr view 874 --json closingIssuesReferences`, which lists only #672). #861 and #798 were subsequently closed by hand; #645 was missed and stayed open despite its fix having shipped five months after it was originally reported (issue created 2026-01-30, PR #874 merged 2026-06-26).
- I verified this by tracing the current `main` code end-to-end: `WorkflowStateManager.completeStage()` (`src/backend/services/workflow/workflow-state-manager.ts`) synchronously sets `status: "completed"` and broadcasts over `WORKFLOW_PROGRESS_NEO`; `process-video-handlers.ts`'s `UPDATING_METADATA` block calls it on a successful `youtube.updateVideoMetadata()`; `WorkflowStepCard.tsx`'s `STATUS_CONFIG.completed` renders the green `CheckCircle2` icon for that status. No defect remains in this path today.

## What this PR adds

The gap that let this ship silently in the first place: **`WorkflowStepCard.tsx` — the component that actually maps a step's status to its icon — had zero test coverage.** `WorkflowProgressPanel.test.tsx` mocks `WorkflowStepCard` out entirely (it only proves the panel's live/hydrated wiring), and `FinalResultPanel.test.tsx` only exercises the warning-banner logic, not the per-step icon.

Added `src/ui/src/components/workflow/WorkflowStepCard.test.tsx`, asserting the status → rendering contract directly, for the `updating_metadata` stage specifically (the one #645 reports) and for completeness one other stage:

- `completed` → green check (`.text-green-400`) — the exact assertion #645 needed.
- `in_progress` → spinner (`.animate-spin`), no green check yet.
- `failed` → red X (`.text-red-400`) with the error message rendered.
- `not_started` → neither green nor red (empty ring placeholder).
- `skipped` → renders nothing (per #798's "hide skipped stages" fix).
- `completed` on `executing_task` → green check, proving the mapping isn't special-cased to one stage.

## Bug repro evidence

**Before:** no test in the suite asserted a green tick renders for `updating_metadata: "completed"` (or for any step, directly against `WorkflowStepCard`) — so a regression in this exact mapping could ship unnoticed, which is effectively what #645 originally reported.

**After:** ran the new test file against current `main` — all 6 tests pass:

```
✓ src/components/workflow/WorkflowStepCard.test.tsx (6 tests)
  ✓ renders a green completed indicator for updating_metadata once it has completed
  ✓ renders the spinner (in_progress) for updating_metadata while the YouTube update is running
  ✓ renders a red failed indicator with the error when updating_metadata fails
  ✓ renders an empty (not_started) indicator before updating_metadata has run
  ✓ renders nothing when updating_metadata is skipped (external link / failed upload, #798)
  ✓ also ticks green for other stages once completed (executing_task)
```

This confirms, with a durable regression guard, that the green tick renders correctly today for a genuinely completed "Updating metadata" step.

## Testing performed

- `cd src/ui && npx vitest run` — 20 files / 129 tests passed (includes the 6 new tests).
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run` (root suite) — 57 files / 595 tests passed.
- `npm run build` — clean (`tsc`, no errors).
- `npm run lint` — clean (`biome check --write .`, no fixes needed).

## Risks / notes

- No production code changed — the fix for the reported symptom was already on `main` via #874. This PR is a verification + regression-coverage change plus closing the issue-reference gap.
- If, after this ships, the "not ticked" symptom is somehow still observed live (e.g. a code path not covered by the trace above), that would point to a *new*, different defect worth its own issue — the evidence here is specific to the `WorkflowStepCard` status→icon mapping, which is confirmed correct.
