### PR TITLE
M✔ ◾ Add sidebar status dashboard for login, MCP, and language model connection health (#948)

### DIFF
--- a/src/backend/services/mcp/claude-readiness.test.ts
+++ b/src/backend/services/mcp/claude-readiness.test.ts
@@ -125,4 +125,23 @@ describe("checkClaudeReadiness", () => {
     );
     expect(r.ready).toBe(true);
   });
+
+  it("reports not-installed (and kills the child) when `claude --version` never closes (address review #949)", async () => {
+    vi.useFakeTimers();
+    try {
+      const kill = vi.fn();
+      const spawn = vi.fn((_cmd: string, _args: string[]) => {
+        const child = new EventEmitter() as unknown as ChildProcess;
+        (child as unknown as { kill: typeof kill }).kill = kill;
+        return child; // never emits "close" or "error" — a wedged process
+      });
+      const promise = checkClaudeReadiness(makeDeps({ spawner: { spawn } }));
+      await vi.advanceTimersByTimeAsync(5000);
+      const r = await promise;
+      expect(r.state).toBe("not-installed");
+      expect(kill).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/backend/services/mcp/claude-readiness.ts
+++ b/src/backend/services/mcp/claude-readiness.ts
@@ -75,7 +75,11 @@ export function detectClaudeAuth(env: NodeJS.ProcessEnv, deps: ClaudeReadinessDe
   return deps.fileExists(resolveCredentialsPath(env, deps.homeDir));
 }
 
-/** Spawn `claude --version` and resolve true iff it exits 0. Never rejects. */
+/** Bound on how long `claude --version` may run before we give up and report not-installed
+ * (address review #949: a hung/wedged CLI must not freeze readiness checks forever). */
+const VERSION_CHECK_TIMEOUT_MS = 5000;
+
+/** Spawn `claude --version` and resolve true iff it exits 0 within the timeout. Never rejects. */
 function detectClaudeInstalled(deps: ClaudeReadinessDeps): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     let child: ChildProcess;
@@ -85,8 +89,31 @@ function detectClaudeInstalled(deps: ClaudeReadinessDeps): Promise<boolean> {
       resolve(false);
       return;
     }
-    child.on("error", () => resolve(false));
-    child.on("close", (code) => resolve(code === 0));
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill?.();
+      } catch {
+        // best-effort — resolving false is what matters
+      }
+      resolve(false);
+    }, VERSION_CHECK_TIMEOUT_MS);
+
+    child.on("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(false);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(code === 0);
+    });
   });
 }
 

--- a/src/ui/src/components/auth/IdentityServerAuthManager.tsx
+++ b/src/ui/src/components/auth/IdentityServerAuthManager.tsx
@@ -1,5 +1,6 @@
 import { LogOut } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { STATUS_DASHBOARD_REFRESH_EVENT } from "@/components/layout/status-dashboard";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -54,6 +55,8 @@ export function IdentityServerAuthManager() {
     const res = await ipcClient.auth.identityServer.login();
     if (res.success) {
       await refresh();
+      // #948 — tell the sidebar status dashboard to re-check now that sign-in succeeded.
+      window.dispatchEvent(new CustomEvent(STATUS_DASHBOARD_REFRESH_EVENT));
     } else {
       setError(res.error || "Authentication failed");
     }
@@ -65,6 +68,8 @@ export function IdentityServerAuthManager() {
     setError(null);
     await ipcClient.auth.identityServer.logout();
     await refresh();
+    // #948 — reflect the sign-out immediately in the sidebar status dashboard.
+    window.dispatchEvent(new CustomEvent(STATUS_DASHBOARD_REFRESH_EVENT));
     setLoading(false);
   };
 

--- a/src/ui/src/components/home/HomeMcpStatusBanner.tsx
+++ b/src/ui/src/components/home/HomeMcpStatusBanner.tsx
@@ -1,11 +1,9 @@
 import { AlertTriangle } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { ipcClient } from "@/services/ipc-client";
-import type { HealthStatusInfo } from "@/types";
 import {
   type DisconnectedProvider,
-  isBacklogProvider,
+  fetchBacklogProviderHealth,
   MCP_HEALTH_REFRESH_EVENT,
   selectDisconnectedProviders,
 } from "./mcp-status";
@@ -21,18 +19,7 @@ function useDisconnectedBacklogProviders(): DisconnectedProvider[] {
 
   const check = useCallback(async () => {
     try {
-      const servers = await ipcClient.mcp.listServers();
-      const providers = servers.filter(isBacklogProvider);
-      const healthById: Record<string, HealthStatusInfo | undefined> = {};
-      await Promise.all(
-        providers.map(async (server) => {
-          try {
-            healthById[server.id] = await ipcClient.mcp.checkServerHealthAsync(server.id);
-          } catch {
-            healthById[server.id] = { isHealthy: false, isChecking: false };
-          }
-        }),
-      );
+      const { servers, healthById } = await fetchBacklogProviderHealth();
       setDisconnected(selectDisconnectedProviders(servers, healthById));
     } catch {
       // Couldn't list servers — say nothing rather than show a misleading warning.

--- a/src/ui/src/components/home/mcp-status.test.ts
+++ b/src/ui/src/components/home/mcp-status.test.ts
@@ -1,6 +1,16 @@
 import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { selectDisconnectedProviders } from "./mcp-status";
+
+// vi.hoisted so the mock factory (hoisted above the import) can reference these.
+const { listServers, checkServerHealthAsync } = vi.hoisted(() => ({
+  listServers: vi.fn(),
+  checkServerHealthAsync: vi.fn(),
+}));
+
+vi.mock("@/services/ipc-client", () => ({
+  ipcClient: { mcp: { listServers, checkServerHealthAsync } },
+}));
 
 type Server = { id: string; name: string; builtin?: boolean; enabled?: boolean };
 
@@ -63,5 +73,30 @@ describe("selectDisconnectedProviders (#869)", () => {
       [ADO]: { isHealthy: false },
     });
     expect(result.map((p) => p.name)).toEqual(["GitHub", "Azure DevOps"]);
+  });
+});
+
+describe("fetchBacklogProviderHealth (address review #949: hung-server timeout)", () => {
+  beforeEach(() => {
+    listServers.mockReset();
+    checkServerHealthAsync.mockReset();
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves a wedged (never-settling) health probe to isHealthy:false instead of hanging forever", async () => {
+    vi.useFakeTimers();
+    const { fetchBacklogProviderHealth } = await import("./mcp-status");
+
+    listServers.mockResolvedValue([{ id: GITHUB, name: "GitHub", enabled: true }]);
+    checkServerHealthAsync.mockImplementation(() => new Promise(() => {})); // never resolves
+
+    const resultPromise = fetchBacklogProviderHealth();
+    await vi.advanceTimersByTimeAsync(8000);
+    const result = await resultPromise;
+
+    expect(result.healthById[GITHUB]).toEqual({ isHealthy: false, isChecking: false });
   });
 });

--- a/src/ui/src/components/home/mcp-status.ts
+++ b/src/ui/src/components/home/mcp-status.ts
@@ -66,6 +66,39 @@ let inFlightHealthFetch: Promise<{
   healthById: Record<string, HealthStatusInfo | undefined>;
 }> | null = null;
 
+/** Bound on a single server's health probe (address review #949): a wedged MCP server must
+ * resolve to a confirmed "disconnected" row rather than freezing the dashboard on stale state
+ * forever — the same "unconfirmed = not connected" policy already applied to a thrown probe. */
+const HEALTH_CHECK_TIMEOUT_MS = 8000;
+
+function checkServerHealthWithTimeout(serverId: string): Promise<HealthStatusInfo> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ isHealthy: false, isChecking: false });
+    }, HEALTH_CHECK_TIMEOUT_MS);
+
+    ipcClient.mcp
+      .checkServerHealthAsync(serverId)
+      .then((result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      })
+      .catch(() => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        // A failed probe is a confirmed-disconnected, not "connected" (mirrors the
+        // convention already used here for a `false`-health server).
+        resolve({ isHealthy: false, isChecking: false });
+      });
+  });
+}
+
 export function fetchBacklogProviderHealth(): Promise<{
   servers: MCPServerConfig[];
   healthById: Record<string, HealthStatusInfo | undefined>;
@@ -79,13 +112,7 @@ export function fetchBacklogProviderHealth(): Promise<{
       const healthById: Record<string, HealthStatusInfo | undefined> = {};
       await Promise.all(
         backlog.map(async (server) => {
-          try {
-            healthById[server.id] = await ipcClient.mcp.checkServerHealthAsync(server.id);
-          } catch {
-            // A failed probe is a confirmed-disconnected, not "connected" (mirrors the
-            // convention already used here for a `false`-health server).
-            healthById[server.id] = { isHealthy: false, isChecking: false };
-          }
+          healthById[server.id] = await checkServerHealthWithTimeout(server.id);
         }),
       );
       return { servers, healthById };

--- a/src/ui/src/components/home/mcp-status.ts
+++ b/src/ui/src/components/home/mcp-status.ts
@@ -1,5 +1,6 @@
 import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
 import type { MCPServerConfig } from "@shared/types/mcp";
+import { ipcClient } from "@/services/ipc-client";
 import type { HealthStatusInfo } from "@/types";
 
 /** Window event the Home banner listens for to re-check provider health
@@ -44,4 +45,54 @@ export function selectDisconnectedProviders(
     .filter(isBacklogProvider)
     .filter((server) => healthById[server.id]?.isHealthy === false)
     .map((server) => ({ id: server.id, name: server.name }));
+}
+
+/**
+ * Fetches the configured MCP servers plus health for the backlog-provider subset,
+ * de-duplicating concurrent callers into a single in-flight round.
+ *
+ * Both `HomeMcpStatusBanner` and the sidebar `StatusDashboard` (#948) need this same
+ * "list servers, then probe health for backlog providers" data, and both re-check on
+ * the same triggers (window focus, the health-refresh event). Before #948, only the
+ * Home banner ran this — always on a single mounted instance. #948 mounts a second,
+ * always-on consumer (the sidebar dashboard is rendered on every route via Layout),
+ * so a naive second copy of this loop would fire a second, fully independent round of
+ * live `checkServerHealthAsync` probes on every focus event whenever Home is also
+ * mounted — doubling MCP health IO for no benefit. Caching the in-flight promise here
+ * means concurrent callers within the same tick share one underlying fetch.
+ */
+let inFlightHealthFetch: Promise<{
+  servers: MCPServerConfig[];
+  healthById: Record<string, HealthStatusInfo | undefined>;
+}> | null = null;
+
+export function fetchBacklogProviderHealth(): Promise<{
+  servers: MCPServerConfig[];
+  healthById: Record<string, HealthStatusInfo | undefined>;
+}> {
+  if (inFlightHealthFetch) return inFlightHealthFetch;
+
+  inFlightHealthFetch = (async () => {
+    try {
+      const servers = await ipcClient.mcp.listServers();
+      const backlog = servers.filter(isBacklogProvider);
+      const healthById: Record<string, HealthStatusInfo | undefined> = {};
+      await Promise.all(
+        backlog.map(async (server) => {
+          try {
+            healthById[server.id] = await ipcClient.mcp.checkServerHealthAsync(server.id);
+          } catch {
+            // A failed probe is a confirmed-disconnected, not "connected" (mirrors the
+            // convention already used here for a `false`-health server).
+            healthById[server.id] = { isHealthy: false, isChecking: false };
+          }
+        }),
+      );
+      return { servers, healthById };
+    } finally {
+      inFlightHealthFetch = null;
+    }
+  })();
+
+  return inFlightHealthFetch;
 }

--- a/src/ui/src/components/home/mcp-status.ts
+++ b/src/ui/src/components/home/mcp-status.ts
@@ -68,10 +68,16 @@ let inFlightHealthFetch: Promise<{
 
 /** Bound on a single server's health probe (address review #949): a wedged MCP server must
  * resolve to a confirmed "disconnected" row rather than freezing the dashboard on stale state
- * forever — the same "unconfirmed = not connected" policy already applied to a thrown probe. */
-const HEALTH_CHECK_TIMEOUT_MS = 8000;
+ * forever — the same "unconfirmed = not connected" policy already applied to a thrown probe.
+ * Exported so other callers that probe backlog-provider health per-server (e.g.
+ * settings-health.ts's useSettingsTabHealth) share the same bound instead of re-implementing an
+ * unguarded `checkServerHealthAsync` call (address review #949 follow-up). */
+export const HEALTH_CHECK_TIMEOUT_MS = 8000;
 
-function checkServerHealthWithTimeout(serverId: string): Promise<HealthStatusInfo> {
+/** Probe a single MCP server's health, bounded by `HEALTH_CHECK_TIMEOUT_MS` so a wedged
+ * (hung, not crashed) server resolves to a confirmed-unhealthy result instead of leaving the
+ * caller's `Promise.all` — and whatever UI state it feeds — permanently pending. */
+export function checkServerHealthWithTimeout(serverId: string): Promise<HealthStatusInfo> {
   return new Promise((resolve) => {
     let settled = false;
     const timer = setTimeout(() => {

--- a/src/ui/src/components/layout/StatusDashboard.test.tsx
+++ b/src/ui/src/components/layout/StatusDashboard.test.tsx
@@ -110,4 +110,17 @@ describe("StatusDashboard (#948)", () => {
     await waitFor(() => expect(checkOrchestratorReadiness).toHaveBeenCalled());
     expect(screen.getByText(/claude code cli not found/i)).toBeTruthy();
   });
+
+  it("address review #949: exposes the status row container as an aria-live region", async () => {
+    status.mockResolvedValue({ status: "authenticated" });
+    listServers.mockResolvedValue([]);
+    getConfig.mockResolvedValue(healthyLlm);
+
+    render(<StatusDashboard />);
+
+    await waitFor(() => expect(listServers).toHaveBeenCalled());
+
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+  });
 });

--- a/src/ui/src/components/layout/StatusDashboard.test.tsx
+++ b/src/ui/src/components/layout/StatusDashboard.test.tsx
@@ -5,23 +5,27 @@ import { StatusDashboard } from "./StatusDashboard";
 import { STATUS_DASHBOARD_REFRESH_EVENT } from "./status-dashboard";
 
 // vi.hoisted so the mock factory (hoisted above the imports) can reference these.
-const { status, listServers, checkServerHealthAsync, getConfig } = vi.hoisted(() => ({
-  status: vi.fn(),
-  listServers: vi.fn(),
-  checkServerHealthAsync: vi.fn(),
-  getConfig: vi.fn(),
-}));
+const { status, listServers, checkServerHealthAsync, getConfig, checkOrchestratorReadiness } =
+  vi.hoisted(() => ({
+    status: vi.fn(),
+    listServers: vi.fn(),
+    checkServerHealthAsync: vi.fn(),
+    getConfig: vi.fn(),
+    checkOrchestratorReadiness: vi.fn(),
+  }));
 
 vi.mock("@/services/ipc-client", () => ({
   ipcClient: {
     auth: { identityServer: { status } },
     mcp: { listServers, checkServerHealthAsync },
-    llm: { getConfig },
+    llm: { getConfig, checkOrchestratorReadiness },
   },
 }));
 
 const GITHUB = { id: PRESET_SERVER_IDS.GITHUB, name: "GitHub", builtin: false, enabled: true };
-const healthyLlm = { languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "sk-live" } };
+const healthyLlm = {
+  languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "test-api-key" },
+};
 
 describe("StatusDashboard (#948)", () => {
   beforeEach(() => {
@@ -29,10 +33,11 @@ describe("StatusDashboard (#948)", () => {
     listServers.mockReset();
     checkServerHealthAsync.mockReset();
     getConfig.mockReset();
+    checkOrchestratorReadiness.mockReset();
   });
   afterEach(() => vi.restoreAllMocks());
 
-  it("shows green login, red MCP and red language-model rows with the exact warning copy when nothing is configured", async () => {
+  it("shows a yellow login warning, red MCP and red language-model rows with the exact warning copy when nothing is configured", async () => {
     status.mockResolvedValue({ status: "not_authenticated" });
     listServers.mockResolvedValue([]);
     getConfig.mockResolvedValue(null);
@@ -83,5 +88,26 @@ describe("StatusDashboard (#948)", () => {
 
     await waitFor(() => expect(listServers).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByText(/not be synced with the portal/i)).toBeNull());
+  });
+
+  it("shows a red language-model row when the local-claude backend is configured but not ready", async () => {
+    status.mockResolvedValue({ status: "authenticated" });
+    listServers.mockResolvedValue([]);
+    getConfig.mockResolvedValue({
+      languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "test-api-key" },
+      orchestrationBackend: "local-claude",
+    });
+    checkOrchestratorReadiness.mockResolvedValue({
+      installed: false,
+      authenticated: false,
+      ready: false,
+      state: "not-installed",
+      message: "Claude Code CLI not found.",
+    });
+
+    render(<StatusDashboard />);
+
+    await waitFor(() => expect(checkOrchestratorReadiness).toHaveBeenCalled());
+    expect(screen.getByText(/claude code cli not found/i)).toBeTruthy();
   });
 });

--- a/src/ui/src/components/layout/StatusDashboard.test.tsx
+++ b/src/ui/src/components/layout/StatusDashboard.test.tsx
@@ -1,0 +1,87 @@
+import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StatusDashboard } from "./StatusDashboard";
+import { STATUS_DASHBOARD_REFRESH_EVENT } from "./status-dashboard";
+
+// vi.hoisted so the mock factory (hoisted above the imports) can reference these.
+const { status, listServers, checkServerHealthAsync, getConfig } = vi.hoisted(() => ({
+  status: vi.fn(),
+  listServers: vi.fn(),
+  checkServerHealthAsync: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock("@/services/ipc-client", () => ({
+  ipcClient: {
+    auth: { identityServer: { status } },
+    mcp: { listServers, checkServerHealthAsync },
+    llm: { getConfig },
+  },
+}));
+
+const GITHUB = { id: PRESET_SERVER_IDS.GITHUB, name: "GitHub", builtin: false, enabled: true };
+const healthyLlm = { languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "sk-live" } };
+
+describe("StatusDashboard (#948)", () => {
+  beforeEach(() => {
+    status.mockReset();
+    listServers.mockReset();
+    checkServerHealthAsync.mockReset();
+    getConfig.mockReset();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("shows green login, red MCP and red language-model rows with the exact warning copy when nothing is configured", async () => {
+    status.mockResolvedValue({ status: "not_authenticated" });
+    listServers.mockResolvedValue([]);
+    getConfig.mockResolvedValue(null);
+
+    render(<StatusDashboard />);
+
+    await waitFor(() => expect(listServers).toHaveBeenCalled());
+
+    expect(
+      screen.getByText(
+        "You don't have any MCP server connected, so the shave or request might fail",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "You don't have any language model connected, so probably the shave will fail",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/not be synced with the portal/i)).toBeTruthy();
+  });
+
+  it("shows no warning text for a row once its config is healthy", async () => {
+    status.mockResolvedValue({ status: "authenticated" });
+    listServers.mockResolvedValue([GITHUB]);
+    checkServerHealthAsync.mockResolvedValue({ isHealthy: true, isChecking: false });
+    getConfig.mockResolvedValue(healthyLlm);
+
+    render(<StatusDashboard />);
+
+    await waitFor(() => expect(checkServerHealthAsync).toHaveBeenCalled());
+    expect(screen.queryByText(/might fail/i)).toBeNull();
+    expect(screen.queryByText(/probably the shave will fail/i)).toBeNull();
+    expect(screen.queryByText(/not be synced with the portal/i)).toBeNull();
+  });
+
+  it("re-checks on STATUS_DASHBOARD_REFRESH_EVENT (e.g. after Settings closes)", async () => {
+    status.mockResolvedValue({ status: "not_authenticated" });
+    listServers.mockResolvedValue([]);
+    getConfig.mockResolvedValue(null);
+
+    render(<StatusDashboard />);
+    await waitFor(() => expect(listServers).toHaveBeenCalledTimes(1));
+
+    status.mockResolvedValue({ status: "authenticated" });
+    await act(async () => {
+      window.dispatchEvent(new Event(STATUS_DASHBOARD_REFRESH_EVENT));
+    });
+
+    await waitFor(() => expect(listServers).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText(/not be synced with the portal/i)).toBeNull());
+  });
+});

--- a/src/ui/src/components/layout/StatusDashboard.tsx
+++ b/src/ui/src/components/layout/StatusDashboard.tsx
@@ -61,6 +61,13 @@ function StatusRow({ label, item }: StatusRowProps) {
  * silently until a shave breaks: login status, MCP server connection status, and
  * language model connection status. Updates automatically (mount, window focus,
  * and STATUS_DASHBOARD_REFRESH_EVENT) so it reflects changes made in Settings.
+ *
+ * Address review #949 follow-up — the container is an `<output>` element (implicit
+ * `role="status"`) with `aria-live="polite"` so a row flipping after mount (e.g. an MCP server
+ * drops) is announced to screen readers even when focus isn't inside the sidebar. `polite` (not
+ * `HomeMcpStatusBanner`'s `role="alert"`) is deliberate: this container can update repeatedly in
+ * the background (every focus/refresh event), and `alert`'s assertive interrupt is meant for a
+ * one-shot, attention-demanding message, not a recurring background status card.
  */
 export function StatusDashboard() {
   const dashboard = useStatusDashboard();
@@ -70,7 +77,10 @@ export function StatusDashboard() {
     dashboard.languageModel.level === "green";
 
   return (
-    <div className="flex flex-col gap-2 rounded-md border border-white/10 bg-white/[0.03] px-3 py-2.5">
+    <output
+      aria-live="polite"
+      className="flex flex-col gap-2 rounded-md border border-white/10 bg-white/[0.03] px-3 py-2.5"
+    >
       <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-white/50">
         {allHealthy ? (
           <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
@@ -82,6 +92,6 @@ export function StatusDashboard() {
       <StatusRow label="Login" item={dashboard.login} />
       <StatusRow label="MCP servers" item={dashboard.mcp} />
       <StatusRow label="Language model" item={dashboard.languageModel} />
-    </div>
+    </output>
   );
 }

--- a/src/ui/src/components/layout/StatusDashboard.tsx
+++ b/src/ui/src/components/layout/StatusDashboard.tsx
@@ -1,0 +1,78 @@
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import { type StatusItem, type StatusLevel, useStatusDashboard } from "./status-dashboard";
+
+const DOT_CLASSES: Record<StatusLevel, string> = {
+  green: "bg-emerald-500",
+  yellow: "bg-yellow-400",
+  red: "bg-red-500",
+};
+
+const TEXT_CLASSES: Record<StatusLevel, string> = {
+  green: "text-white/60",
+  yellow: "text-yellow-200",
+  red: "text-red-300",
+};
+
+interface StatusRowProps {
+  label: string;
+  item: StatusItem;
+}
+
+function StatusRow({ label, item }: StatusRowProps) {
+  const isWarning = item.level !== "green";
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className={`h-2 w-2 rounded-full shrink-0 ${DOT_CLASSES[item.level]}`}
+        />
+        <span className="text-xs font-medium text-white/80">
+          {label}
+          <span className="sr-only">: {item.level}</span>
+        </span>
+      </div>
+      {isWarning && (
+        <div className="flex items-start gap-1.5 pl-4">
+          <AlertTriangle
+            className={`h-3.5 w-3.5 shrink-0 mt-0.5 ${item.level === "red" ? "text-red-400" : "text-yellow-400"}`}
+          />
+          <span className={`text-[11px] leading-tight ${TEXT_CLASSES[item.level]}`}>
+            {item.message}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * #948 — sidebar status dashboard shown between "Projects" and "Settings". Gives
+ * an always-visible, at-a-glance signal for the three things that otherwise fail
+ * silently until a shave breaks: login status, MCP server connection status, and
+ * language model connection status. Updates automatically (mount, window focus,
+ * and STATUS_DASHBOARD_REFRESH_EVENT) so it reflects changes made in Settings.
+ */
+export function StatusDashboard() {
+  const dashboard = useStatusDashboard();
+  const allHealthy =
+    dashboard.login.level === "green" &&
+    dashboard.mcp.level === "green" &&
+    dashboard.languageModel.level === "green";
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-white/10 bg-white/[0.03] px-3 py-2.5">
+      <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-white/50">
+        {allHealthy ? (
+          <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+        ) : (
+          <AlertTriangle className="h-3.5 w-3.5 text-yellow-400" />
+        )}
+        Status
+      </div>
+      <StatusRow label="Login" item={dashboard.login} />
+      <StatusRow label="MCP servers" item={dashboard.mcp} />
+      <StatusRow label="Language model" item={dashboard.languageModel} />
+    </div>
+  );
+}

--- a/src/ui/src/components/layout/StatusDashboard.tsx
+++ b/src/ui/src/components/layout/StatusDashboard.tsx
@@ -13,6 +13,14 @@ const TEXT_CLASSES: Record<StatusLevel, string> = {
   red: "text-red-300",
 };
 
+/** Semantic (not just colour-name) status word for screen readers — "yellow"/"red" convey
+ * nothing meaningful to a screen-reader user, so announce what the colour means instead. */
+const SR_STATUS_WORD: Record<StatusLevel, string> = {
+  green: "OK",
+  yellow: "Warning",
+  red: "Problem",
+};
+
 interface StatusRowProps {
   label: string;
   item: StatusItem;
@@ -29,12 +37,13 @@ function StatusRow({ label, item }: StatusRowProps) {
         />
         <span className="text-xs font-medium text-white/80">
           {label}
-          <span className="sr-only">: {item.level}</span>
+          <span className="sr-only">: {SR_STATUS_WORD[item.level]}</span>
         </span>
       </div>
       {isWarning && (
         <div className="flex items-start gap-1.5 pl-4">
           <AlertTriangle
+            aria-hidden="true"
             className={`h-3.5 w-3.5 shrink-0 mt-0.5 ${item.level === "red" ? "text-red-400" : "text-yellow-400"}`}
           />
           <span className={`text-[11px] leading-tight ${TEXT_CLASSES[item.level]}`}>

--- a/src/ui/src/components/layout/StatusDashboardErrorBoundary.test.tsx
+++ b/src/ui/src/components/layout/StatusDashboardErrorBoundary.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StatusDashboardErrorBoundary } from "./StatusDashboardErrorBoundary";
+
+function Boom(): never {
+  throw new Error("boom");
+}
+
+describe("StatusDashboardErrorBoundary (#948 review follow-up)", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // React logs the caught error to console.error too; keep test output clean.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it("contains a render error from its child instead of crashing the tree", () => {
+    render(
+      <div>
+        <span>sidebar nav still here</span>
+        <StatusDashboardErrorBoundary>
+          <Boom />
+        </StatusDashboardErrorBoundary>
+      </div>,
+    );
+
+    expect(screen.getByText("sidebar nav still here")).toBeInTheDocument();
+  });
+
+  it("renders children normally when there is no error", () => {
+    render(
+      <StatusDashboardErrorBoundary>
+        <span>dashboard content</span>
+      </StatusDashboardErrorBoundary>,
+    );
+
+    expect(screen.getByText("dashboard content")).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/components/layout/StatusDashboardErrorBoundary.test.tsx
+++ b/src/ui/src/components/layout/StatusDashboardErrorBoundary.test.tsx
@@ -1,9 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusDashboardErrorBoundary } from "./StatusDashboardErrorBoundary";
+import { STATUS_DASHBOARD_REFRESH_EVENT } from "./status-dashboard";
 
 function Boom(): never {
   throw new Error("boom");
+}
+
+/** Throws while `shouldThrow.current` is true, renders normally once cleared — models a
+ * transient render error (e.g. one bad IPC payload tick) that clears up on the next retry,
+ * rather than a persistently broken child. */
+function FlakyChild({ shouldThrow }: { shouldThrow: { current: boolean } }) {
+  if (shouldThrow.current) {
+    throw new Error("transient boom");
+  }
+  return <span>dashboard content</span>;
 }
 
 describe("StatusDashboardErrorBoundary (#948 review follow-up)", () => {
@@ -34,6 +45,46 @@ describe("StatusDashboardErrorBoundary (#948 review follow-up)", () => {
         <span>dashboard content</span>
       </StatusDashboardErrorBoundary>,
     );
+
+    expect(screen.getByText("dashboard content")).toBeInTheDocument();
+  });
+
+  it("address review #949: self-heals on STATUS_DASHBOARD_REFRESH_EVENT instead of staying blanked forever", () => {
+    const shouldThrow = { current: true };
+    render(
+      <StatusDashboardErrorBoundary>
+        <FlakyChild shouldThrow={shouldThrow} />
+      </StatusDashboardErrorBoundary>,
+    );
+
+    // The transient error trips the boundary — the dashboard renders nothing.
+    expect(screen.queryByText("dashboard content")).not.toBeInTheDocument();
+
+    // The underlying cause has cleared (e.g. a fresh IPC read on the next tick); the same
+    // refresh trigger useStatusDashboard already re-checks on (Settings-close / auth-change)
+    // should let the boundary retry, and the child now renders cleanly.
+    shouldThrow.current = false;
+    act(() => {
+      window.dispatchEvent(new CustomEvent(STATUS_DASHBOARD_REFRESH_EVENT));
+    });
+
+    expect(screen.getByText("dashboard content")).toBeInTheDocument();
+  });
+
+  it("address review #949: self-heals on window focus too", () => {
+    const shouldThrow = { current: true };
+    render(
+      <StatusDashboardErrorBoundary>
+        <FlakyChild shouldThrow={shouldThrow} />
+      </StatusDashboardErrorBoundary>,
+    );
+
+    expect(screen.queryByText("dashboard content")).not.toBeInTheDocument();
+
+    shouldThrow.current = false;
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
 
     expect(screen.getByText("dashboard content")).toBeInTheDocument();
   });

--- a/src/ui/src/components/layout/StatusDashboardErrorBoundary.tsx
+++ b/src/ui/src/components/layout/StatusDashboardErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * #948 review follow-up — `StatusDashboard` is now mounted unconditionally on every route via
+ * the sidebar (previously the equivalent banner only lived on Home). A render error there
+ * (e.g. an IPC read returning a shape that doesn't match its `Pick<...>` contract) would
+ * otherwise propagate past this always-mounted component and crash the whole sidebar — nav,
+ * settings, sign-out included. This boundary contains that blast radius to the dashboard card
+ * itself; there's no app-wide error boundary elsewhere in `src/ui/src` to fall back on.
+ */
+export class StatusDashboardErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: unknown) {
+    console.error("StatusDashboard crashed; hiding it to protect the rest of the sidebar:", error);
+  }
+
+  override render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}

--- a/src/ui/src/components/layout/StatusDashboardErrorBoundary.tsx
+++ b/src/ui/src/components/layout/StatusDashboardErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode } from "react";
+import { STATUS_DASHBOARD_REFRESH_EVENT } from "./status-dashboard";
 
 interface Props {
   children: ReactNode;
@@ -15,6 +16,14 @@ interface State {
  * otherwise propagate past this always-mounted component and crash the whole sidebar — nav,
  * settings, sign-out included. This boundary contains that blast radius to the dashboard card
  * itself; there's no app-wide error boundary elsewhere in `src/ui/src` to fall back on.
+ *
+ * Address review #949 follow-up — `hasError` used to be a one-way trip: once tripped, the
+ * dashboard rendered `null` for the rest of the app session, since this boundary mounts once
+ * (wrapped high in the router) and nothing ever cleared the flag. A single transient render
+ * error (e.g. one bad IPC payload tick) would then permanently blank the always-on dashboard.
+ * This now self-heals on the same triggers `useStatusDashboard` already re-checks on — window
+ * focus and `STATUS_DASHBOARD_REFRESH_EVENT` (dispatched on Settings-close / auth changes) — by
+ * clearing `hasError` and letting the child remount and try again.
  */
 export class StatusDashboardErrorBoundary extends Component<Props, State> {
   state: State = { hasError: false };
@@ -26,6 +35,20 @@ export class StatusDashboardErrorBoundary extends Component<Props, State> {
   override componentDidCatch(error: unknown) {
     console.error("StatusDashboard crashed; hiding it to protect the rest of the sidebar:", error);
   }
+
+  override componentDidMount() {
+    window.addEventListener("focus", this.retry);
+    window.addEventListener(STATUS_DASHBOARD_REFRESH_EVENT, this.retry);
+  }
+
+  override componentWillUnmount() {
+    window.removeEventListener("focus", this.retry);
+    window.removeEventListener(STATUS_DASHBOARD_REFRESH_EVENT, this.retry);
+  }
+
+  private retry = () => {
+    if (this.state.hasError) this.setState({ hasError: false });
+  };
 
   override render() {
     if (this.state.hasError) return null;

--- a/src/ui/src/components/layout/sidebar.tsx
+++ b/src/ui/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import { IdentityServerAuthManager } from "../auth/IdentityServerAuthManager";
 import { ScreenRecorder } from "../recording/ScreenRecorder";
 import { SettingsDialog } from "../settings/SettingsDialog";
 import { SidebarLink } from "../ui/sidebar-link";
+import { StatusDashboard } from "./StatusDashboard";
 
 export default function Sidebar() {
   const [appVersion, setAppVersion] = useState<string>("");
@@ -40,6 +41,7 @@ export default function Sidebar() {
           Projects
         </SidebarLink>
       </nav>
+      <StatusDashboard />
       <div className="relative bottom-0 mt-auto flex flex-col gap-3 left-0">
         <SettingsDialog />
         <IdentityServerAuthManager />

--- a/src/ui/src/components/layout/sidebar.tsx
+++ b/src/ui/src/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import { ScreenRecorder } from "../recording/ScreenRecorder";
 import { SettingsDialog } from "../settings/SettingsDialog";
 import { SidebarLink } from "../ui/sidebar-link";
 import { StatusDashboard } from "./StatusDashboard";
+import { StatusDashboardErrorBoundary } from "./StatusDashboardErrorBoundary";
 
 export default function Sidebar() {
   const [appVersion, setAppVersion] = useState<string>("");
@@ -41,7 +42,9 @@ export default function Sidebar() {
           Projects
         </SidebarLink>
       </nav>
-      <StatusDashboard />
+      <StatusDashboardErrorBoundary>
+        <StatusDashboard />
+      </StatusDashboardErrorBoundary>
       <div className="relative bottom-0 mt-auto flex flex-col gap-3 left-0">
         <SettingsDialog />
         <IdentityServerAuthManager />

--- a/src/ui/src/components/layout/status-dashboard.test.ts
+++ b/src/ui/src/components/layout/status-dashboard.test.ts
@@ -1,5 +1,6 @@
 import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
 import { describe, expect, it } from "vitest";
+import { AuthStatus } from "@/types";
 import { deriveStatusDashboard, type StatusDashboardInputs } from "./status-dashboard";
 
 const GITHUB = PRESET_SERVER_IDS.GITHUB;
@@ -28,6 +29,15 @@ describe("deriveStatusDashboard (#948)", () => {
       const result = deriveStatusDashboard(inputs({ isAuthenticated: false }));
       expect(result.login.level).toBe("yellow");
       expect(result.login.message).toMatch(/not be synced with the portal/i);
+    });
+
+    it("shows a distinct signing-in message (not the portal-sync warning) while AUTHENTICATING", () => {
+      const result = deriveStatusDashboard(
+        inputs({ isAuthenticated: false, authStatus: AuthStatus.AUTHENTICATING }),
+      );
+      expect(result.login.level).toBe("yellow");
+      expect(result.login.message).not.toMatch(/not be synced with the portal/i);
+      expect(result.login.message).toMatch(/signing in/i);
     });
   });
 

--- a/src/ui/src/components/layout/status-dashboard.test.ts
+++ b/src/ui/src/components/layout/status-dashboard.test.ts
@@ -10,7 +10,9 @@ function inputs(overrides: Partial<StatusDashboardInputs> = {}): StatusDashboard
     isAuthenticated: true,
     mcpServers: [],
     mcpHealthById: {},
-    llmConfig: { languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "sk-live-123" } },
+    llmConfig: {
+      languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "test-api-key-123" },
+    },
     ...overrides,
   };
 }
@@ -110,6 +112,76 @@ describe("deriveStatusDashboard (#948)", () => {
     it("is red when llmConfig itself is null (never configured)", () => {
       const result = deriveStatusDashboard(inputs({ llmConfig: null }));
       expect(result.languageModel.level).toBe("red");
+    });
+
+    it("is green on local-claude backend when an api key is set and readiness wasn't checked", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          llmConfig: {
+            languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "test-api-key-123" },
+            orchestrationBackend: "local-claude",
+          },
+          orchestratorReadiness: null,
+        }),
+      );
+      expect(result.languageModel.level).toBe("green");
+    });
+
+    it("is red on local-claude backend when the CLI isn't ready, even with an api key set (#948 gap)", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          llmConfig: {
+            languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "test-api-key-123" },
+            orchestrationBackend: "local-claude",
+          },
+          orchestratorReadiness: {
+            installed: false,
+            authenticated: false,
+            ready: false,
+            state: "not-installed",
+            message: "Claude Code CLI not found.",
+          },
+        }),
+      );
+      expect(result.languageModel.level).toBe("red");
+      expect(result.languageModel.message).toMatch(/claude code cli not found/i);
+    });
+
+    it("is green on local-claude backend when the CLI is ready", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          llmConfig: {
+            languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "test-api-key-123" },
+            orchestrationBackend: "local-claude",
+          },
+          orchestratorReadiness: {
+            installed: true,
+            authenticated: true,
+            ready: true,
+            state: "ready",
+            message: "",
+          },
+        }),
+      );
+      expect(result.languageModel.level).toBe("green");
+    });
+
+    it("ignores orchestrator readiness when the backend isn't local-claude", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          llmConfig: {
+            languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "test-api-key-123" },
+          },
+          orchestratorReadiness: {
+            installed: false,
+            authenticated: false,
+            ready: false,
+            state: "not-installed",
+            message: "",
+          },
+        }),
+      );
+      expect(result.languageModel.level).toBe("green");
     });
   });
 

--- a/src/ui/src/components/layout/status-dashboard.test.ts
+++ b/src/ui/src/components/layout/status-dashboard.test.ts
@@ -82,6 +82,16 @@ describe("deriveStatusDashboard (#948)", () => {
       );
       expect(result.mcp.level).toBe("red");
     });
+
+    it("does NOT count a healthy non-backlog (custom) server as connected", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          mcpServers: [{ id: "custom-xyz", name: "Docs", enabled: true }],
+          mcpHealthById: { "custom-xyz": { isHealthy: true } },
+        }),
+      );
+      expect(result.mcp.level).toBe("red");
+    });
   });
 
   describe("language model status", () => {

--- a/src/ui/src/components/layout/status-dashboard.test.ts
+++ b/src/ui/src/components/layout/status-dashboard.test.ts
@@ -1,0 +1,127 @@
+import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
+import { describe, expect, it } from "vitest";
+import { deriveStatusDashboard, type StatusDashboardInputs } from "./status-dashboard";
+
+const GITHUB = PRESET_SERVER_IDS.GITHUB;
+const ADO = PRESET_SERVER_IDS.AZURE_DEVOPS;
+
+function inputs(overrides: Partial<StatusDashboardInputs> = {}): StatusDashboardInputs {
+  return {
+    isAuthenticated: true,
+    mcpServers: [],
+    mcpHealthById: {},
+    llmConfig: { languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "sk-live-123" } },
+    ...overrides,
+  };
+}
+
+describe("deriveStatusDashboard (#948)", () => {
+  describe("login status", () => {
+    it("is green when authenticated", () => {
+      const result = deriveStatusDashboard(inputs({ isAuthenticated: true }));
+      expect(result.login.level).toBe("green");
+    });
+
+    it("warns with the portal-sync message when not authenticated", () => {
+      const result = deriveStatusDashboard(inputs({ isAuthenticated: false }));
+      expect(result.login.level).toBe("yellow");
+      expect(result.login.message).toMatch(/not be synced with the portal/i);
+    });
+  });
+
+  describe("MCP server status", () => {
+    it("is red with the exact warning message when no MCP server is connected", () => {
+      const result = deriveStatusDashboard(inputs({ mcpServers: [], mcpHealthById: {} }));
+      expect(result.mcp.level).toBe("red");
+      expect(result.mcp.message).toBe(
+        "You don't have any MCP server connected, so the shave or request might fail",
+      );
+    });
+
+    it("is green when at least one backlog provider is confirmed connected", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          mcpServers: [{ id: GITHUB, name: "GitHub", enabled: true }],
+          mcpHealthById: { [GITHUB]: { isHealthy: true } },
+        }),
+      );
+      expect(result.mcp.level).toBe("green");
+    });
+
+    it("is red when servers are configured but all unhealthy", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          mcpServers: [
+            { id: GITHUB, name: "GitHub", enabled: true },
+            { id: ADO, name: "Azure DevOps", enabled: true },
+          ],
+          mcpHealthById: {
+            [GITHUB]: { isHealthy: false },
+            [ADO]: { isHealthy: false },
+          },
+        }),
+      );
+      expect(result.mcp.level).toBe("red");
+    });
+
+    it("does NOT report a disabled server as connected even if health looks healthy", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          mcpServers: [{ id: GITHUB, name: "GitHub", enabled: false }],
+          mcpHealthById: { [GITHUB]: { isHealthy: true } },
+        }),
+      );
+      expect(result.mcp.level).toBe("red");
+    });
+
+    it("does NOT report green while health is still unknown/loading", () => {
+      const result = deriveStatusDashboard(
+        inputs({ mcpServers: [{ id: GITHUB, name: "GitHub", enabled: true }], mcpHealthById: {} }),
+      );
+      expect(result.mcp.level).toBe("red");
+    });
+  });
+
+  describe("language model status", () => {
+    it("is red with the exact warning message when no language model is configured", () => {
+      const result = deriveStatusDashboard(inputs({ llmConfig: { languageModel: null } }));
+      expect(result.languageModel.level).toBe("red");
+      expect(result.languageModel.message).toBe(
+        "You don't have any language model connected, so probably the shave will fail",
+      );
+    });
+
+    it("is red when the config exists but the API key is blank", () => {
+      const result = deriveStatusDashboard(
+        inputs({
+          llmConfig: {
+            languageModel: { provider: "openai", model: "gpt-5.2", apiKey: "   " },
+          },
+        }),
+      );
+      expect(result.languageModel.level).toBe("red");
+    });
+
+    it("is green when a language model with an API key is configured", () => {
+      const result = deriveStatusDashboard(inputs());
+      expect(result.languageModel.level).toBe("green");
+    });
+
+    it("is red when llmConfig itself is null (never configured)", () => {
+      const result = deriveStatusDashboard(inputs({ llmConfig: null }));
+      expect(result.languageModel.level).toBe("red");
+    });
+  });
+
+  it("reports all three rows independently", () => {
+    const result = deriveStatusDashboard({
+      isAuthenticated: false,
+      mcpServers: [],
+      mcpHealthById: {},
+      llmConfig: null,
+    });
+    expect(result.login.level).toBe("yellow");
+    expect(result.mcp.level).toBe("red");
+    expect(result.languageModel.level).toBe("red");
+  });
+});

--- a/src/ui/src/components/layout/status-dashboard.ts
+++ b/src/ui/src/components/layout/status-dashboard.ts
@@ -1,7 +1,7 @@
 import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { MCPServerConfig } from "@shared/types/mcp";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchBacklogProviderHealth } from "@/components/home/mcp-status";
+import { fetchBacklogProviderHealth, isBacklogProvider } from "@/components/home/mcp-status";
 import { fetchOrchestratorReadiness } from "@/components/settings/settings-health";
 import { ipcClient } from "@/services/ipc-client";
 import { AuthStatus, type HealthStatusInfo } from "@/types";
@@ -66,8 +66,12 @@ export function deriveStatusDashboard(inputs: StatusDashboardInputs): StatusDash
         message: "Your shave will not be synced with the portal, etc.",
       };
 
+  // Filter to backlog providers explicitly (mirrors mcp-status.ts's own
+  // isBacklogProvider/enabled check) rather than relying on mcpHealthById only ever
+  // containing entries for backlog providers — an implicit invariant that would
+  // silently break if a caller ever passed health for non-backlog servers too.
   const connectedProviders = inputs.mcpServers
-    .filter((server) => server.enabled !== false)
+    .filter(isBacklogProvider)
     .filter((server) => inputs.mcpHealthById[server.id]?.isHealthy === true);
   const mcp: StatusItem =
     connectedProviders.length > 0

--- a/src/ui/src/components/layout/status-dashboard.ts
+++ b/src/ui/src/components/layout/status-dashboard.ts
@@ -1,9 +1,9 @@
-import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
-import type { LLMConfigV2 } from "@shared/types/llm";
+import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { MCPServerConfig } from "@shared/types/mcp";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchBacklogProviderHealth } from "@/components/home/mcp-status";
 import { ipcClient } from "@/services/ipc-client";
-import type { HealthStatusInfo } from "@/types";
+import { AuthStatus, type HealthStatusInfo } from "@/types";
 
 /**
  * #948 — a sidebar status dashboard (between "Projects" and "Settings") that
@@ -20,10 +20,6 @@ import type { HealthStatusInfo } from "@/types";
  * Settings dialog closes, mirroring MCP_HEALTH_REFRESH_EVENT / SETTINGS_HEALTH_REFRESH_EVENT). */
 export const STATUS_DASHBOARD_REFRESH_EVENT = "yakshaver:status-dashboard-refresh";
 
-/** The known backlog-provider MCP server ids (GitHub / Azure DevOps / Jira). Only
- * these count toward "at least one MCP server connected" — mirrors #869/#878. */
-const BACKLOG_PROVIDER_IDS = new Set<string>(Object.values(PRESET_SERVER_IDS));
-
 export type StatusLevel = "green" | "yellow" | "red";
 
 export interface StatusItem {
@@ -37,10 +33,6 @@ export interface StatusDashboard {
   languageModel: StatusItem;
 }
 
-function isEnabledBacklogProvider(server: Pick<MCPServerConfig, "id" | "enabled">) {
-  return server.enabled !== false && BACKLOG_PROVIDER_IDS.has(server.id);
-}
-
 export interface StatusDashboardInputs {
   /** Whether the user is signed in (`ipcClient.auth.identityServer.status()`). */
   isAuthenticated: boolean;
@@ -51,7 +43,13 @@ export interface StatusDashboardInputs {
    * green flash while checks are in flight). */
   mcpHealthById: Readonly<Record<string, Pick<HealthStatusInfo, "isHealthy"> | undefined>>;
   /** The persisted LLM config (`ipcClient.llm.getConfig()`), or null if unset. */
-  llmConfig: Pick<LLMConfigV2, "languageModel"> | null;
+  llmConfig: Pick<LLMConfigV2, "languageModel" | "orchestrationBackend"> | null;
+  /**
+   * Readiness of the Claude Code orchestration backend (`ipcClient.llm.checkOrchestratorReadiness()`).
+   * Only meaningful when `orchestrationBackend === "local-claude"`; null/undefined means "not
+   * checked / inconclusive" and never raises a warning — mirrors settings-health.ts (#878/#936).
+   */
+  orchestratorReadiness?: OrchestratorReadiness | null;
 }
 
 /**
@@ -68,7 +66,7 @@ export function deriveStatusDashboard(inputs: StatusDashboardInputs): StatusDash
       };
 
   const connectedProviders = inputs.mcpServers
-    .filter(isEnabledBacklogProvider)
+    .filter((server) => server.enabled !== false)
     .filter((server) => inputs.mcpHealthById[server.id]?.isHealthy === true);
   const mcp: StatusItem =
     connectedProviders.length > 0
@@ -82,16 +80,46 @@ export function deriveStatusDashboard(inputs: StatusDashboardInputs): StatusDash
         };
 
   const languageModel = inputs.llmConfig?.languageModel;
-  const hasLanguageModel = Boolean(languageModel && languageModel.apiKey.trim() !== "");
-  const languageModelItem: StatusItem = hasLanguageModel
-    ? { level: "green", message: `Connected: ${languageModel?.model ?? languageModel?.provider}.` }
-    : {
-        level: "red",
-        message: "You don't have any language model connected, so probably the shave will fail",
-      };
+  const hasApiKey = Boolean(languageModel && languageModel.apiKey.trim() !== "");
+  // The local-claude orchestration backend drives the backlog-creation step
+  // separately from the transcription/analysis `languageModel` above — a
+  // configured apiKey doesn't mean that backend is actually ready (CLI missing
+  // or not signed in), and settings-health.ts (#878/#936) already treats that as
+  // a distinct critical state. Reusing the same readiness signal here means this
+  // row can't silently report green while the orchestrator can't actually run.
+  const usesLocalClaude = inputs.llmConfig?.orchestrationBackend === "local-claude";
+  const readiness = inputs.orchestratorReadiness;
+  const orchestratorNotReady = usesLocalClaude && !!readiness && !readiness.ready;
+
+  const languageModelItem: StatusItem =
+    hasApiKey && !orchestratorNotReady
+      ? {
+          level: "green",
+          message: `Connected: ${languageModel?.model ?? languageModel?.provider}.`,
+        }
+      : orchestratorNotReady
+        ? {
+            level: "red",
+            message:
+              readiness?.state === "not-installed"
+                ? "Claude Code CLI not found, so probably the shave will fail"
+                : "Claude Code isn't signed in, so probably the shave will fail",
+          }
+        : {
+            level: "red",
+            message: "You don't have any language model connected, so probably the shave will fail",
+          };
 
   return { login, mcp, languageModel: languageModelItem };
 }
+
+const DEFAULT_INPUTS: StatusDashboardInputs = {
+  isAuthenticated: false,
+  mcpServers: [],
+  mcpHealthById: {},
+  llmConfig: null,
+  orchestratorReadiness: null,
+};
 
 /**
  * Reads the live auth/MCP/LLM state and returns the dashboard status. Re-checks on
@@ -100,57 +128,52 @@ export function deriveStatusDashboard(inputs: StatusDashboardInputs): StatusDash
  */
 export function useStatusDashboard(): StatusDashboard {
   const [dashboard, setDashboard] = useState<StatusDashboard>(() =>
-    deriveStatusDashboard({
-      isAuthenticated: false,
-      mcpServers: [],
-      mcpHealthById: {},
-      llmConfig: null,
-    }),
+    deriveStatusDashboard(DEFAULT_INPUTS),
   );
 
-  const check = useCallback(async () => {
-    try {
-      const [authState, mcpServers, llmConfig] = await Promise.all([
-        ipcClient.auth.identityServer
-          .status()
-          .catch(() => ({ status: "unauthenticated" as const })),
-        ipcClient.mcp.listServers().catch(() => [] as MCPServerConfig[]),
-        ipcClient.llm.getConfig().catch(() => null),
-      ]);
+  // Bumped on every check() call and on unmount, so a check() that resolves after a
+  // newer one started (or after unmount) is recognised as stale and its result is
+  // dropped instead of overwriting fresher state / setting state on an unmounted
+  // component.
+  const requestIdRef = useRef(0);
 
-      const backlog = mcpServers.filter(isEnabledBacklogProvider);
-      const mcpHealthById: Record<string, HealthStatusInfo | undefined> = {};
-      await Promise.all(
-        backlog.map(async (server) => {
-          try {
-            mcpHealthById[server.id] = await ipcClient.mcp.checkServerHealthAsync(server.id);
-          } catch {
-            // A failed probe is inconclusive, not "connected" — leave undefined so
-            // deriveStatusDashboard doesn't raise a false green.
-            mcpHealthById[server.id] = undefined;
-          }
-        }),
-      );
+  const check = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+
+    try {
+      const [authState, { servers: mcpServers, healthById: mcpHealthById }, llmConfig] =
+        await Promise.all([
+          ipcClient.auth.identityServer
+            .status()
+            .catch(() => ({ status: AuthStatus.NOT_AUTHENTICATED })),
+          fetchBacklogProviderHealth(),
+          ipcClient.llm.getConfig().catch(() => null),
+        ]);
+
+      // Only probe Claude Code readiness when it's the selected backend — otherwise
+      // it's irrelevant and we skip the spawn entirely (mirrors settings-health.ts).
+      const orchestratorReadiness =
+        llmConfig?.orchestrationBackend === "local-claude"
+          ? await ipcClient.llm.checkOrchestratorReadiness().catch(() => null)
+          : null;
+
+      if (requestIdRef.current !== requestId) return; // superseded or unmounted
 
       setDashboard(
         deriveStatusDashboard({
-          isAuthenticated: authState.status === "authenticated",
+          isAuthenticated: authState.status === AuthStatus.AUTHENTICATED,
           mcpServers,
           mcpHealthById,
           llmConfig,
+          orchestratorReadiness,
         }),
       );
     } catch {
+      if (requestIdRef.current !== requestId) return; // superseded or unmounted
+
       // Couldn't read state — fall back to the conservative all-warning defaults
       // rather than showing a misleading green.
-      setDashboard(
-        deriveStatusDashboard({
-          isAuthenticated: false,
-          mcpServers: [],
-          mcpHealthById: {},
-          llmConfig: null,
-        }),
-      );
+      setDashboard(deriveStatusDashboard(DEFAULT_INPUTS));
     }
   }, []);
 
@@ -160,6 +183,7 @@ export function useStatusDashboard(): StatusDashboard {
     window.addEventListener("focus", onRefresh);
     window.addEventListener(STATUS_DASHBOARD_REFRESH_EVENT, onRefresh);
     return () => {
+      requestIdRef.current++; // invalidate any in-flight check() so it can't setState post-unmount
       window.removeEventListener("focus", onRefresh);
       window.removeEventListener(STATUS_DASHBOARD_REFRESH_EVENT, onRefresh);
     };

--- a/src/ui/src/components/layout/status-dashboard.ts
+++ b/src/ui/src/components/layout/status-dashboard.ts
@@ -1,0 +1,169 @@
+import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
+import type { LLMConfigV2 } from "@shared/types/llm";
+import type { MCPServerConfig } from "@shared/types/mcp";
+import { useCallback, useEffect, useState } from "react";
+import { ipcClient } from "@/services/ipc-client";
+import type { HealthStatusInfo } from "@/types";
+
+/**
+ * #948 — a sidebar status dashboard (between "Projects" and "Settings") that
+ * surfaces the three things that silently cause a shave to fail: the user isn't
+ * logged in, no MCP server is connected, or no language model is configured.
+ * Today none of this is visible until a shave fails, so this dashboard gives an
+ * always-on, at-a-glance signal instead.
+ *
+ * `deriveStatusDashboard` is a pure function (unit-testable without IPC);
+ * `useStatusDashboard` wires it to the live `ipcClient` reads and keeps it fresh.
+ */
+
+/** Window event the dashboard listens for to re-check status (dispatched when the
+ * Settings dialog closes, mirroring MCP_HEALTH_REFRESH_EVENT / SETTINGS_HEALTH_REFRESH_EVENT). */
+export const STATUS_DASHBOARD_REFRESH_EVENT = "yakshaver:status-dashboard-refresh";
+
+/** The known backlog-provider MCP server ids (GitHub / Azure DevOps / Jira). Only
+ * these count toward "at least one MCP server connected" — mirrors #869/#878. */
+const BACKLOG_PROVIDER_IDS = new Set<string>(Object.values(PRESET_SERVER_IDS));
+
+export type StatusLevel = "green" | "yellow" | "red";
+
+export interface StatusItem {
+  level: StatusLevel;
+  message: string;
+}
+
+export interface StatusDashboard {
+  login: StatusItem;
+  mcp: StatusItem;
+  languageModel: StatusItem;
+}
+
+function isEnabledBacklogProvider(server: Pick<MCPServerConfig, "id" | "enabled">) {
+  return server.enabled !== false && BACKLOG_PROVIDER_IDS.has(server.id);
+}
+
+export interface StatusDashboardInputs {
+  /** Whether the user is signed in (`ipcClient.auth.identityServer.status()`). */
+  isAuthenticated: boolean;
+  /** Configured MCP servers (`ipcClient.mcp.listServers()`). */
+  mcpServers: ReadonlyArray<Pick<MCPServerConfig, "id" | "name" | "enabled">>;
+  /** Health by server id; only an explicit `isHealthy === true` counts as connected
+   * (an undefined/still-loading entry is NOT treated as connected, avoiding a false
+   * green flash while checks are in flight). */
+  mcpHealthById: Readonly<Record<string, Pick<HealthStatusInfo, "isHealthy"> | undefined>>;
+  /** The persisted LLM config (`ipcClient.llm.getConfig()`), or null if unset. */
+  llmConfig: Pick<LLMConfigV2, "languageModel"> | null;
+}
+
+/**
+ * Pure mapping from raw config/health reads to the three dashboard rows. Each rule
+ * only reports what it can positively confirm — an unknown/loading value never
+ * flips a row to green, so the dashboard doesn't flash a false "all good".
+ */
+export function deriveStatusDashboard(inputs: StatusDashboardInputs): StatusDashboard {
+  const login: StatusItem = inputs.isAuthenticated
+    ? { level: "green", message: "Signed in." }
+    : {
+        level: "yellow",
+        message: "Your shave will not be synced with the portal, etc.",
+      };
+
+  const connectedProviders = inputs.mcpServers
+    .filter(isEnabledBacklogProvider)
+    .filter((server) => inputs.mcpHealthById[server.id]?.isHealthy === true);
+  const mcp: StatusItem =
+    connectedProviders.length > 0
+      ? {
+          level: "green",
+          message: `Connected: ${connectedProviders.map((s) => s.name).join(", ")}.`,
+        }
+      : {
+          level: "red",
+          message: "You don't have any MCP server connected, so the shave or request might fail",
+        };
+
+  const languageModel = inputs.llmConfig?.languageModel;
+  const hasLanguageModel = Boolean(languageModel && languageModel.apiKey.trim() !== "");
+  const languageModelItem: StatusItem = hasLanguageModel
+    ? { level: "green", message: `Connected: ${languageModel?.model ?? languageModel?.provider}.` }
+    : {
+        level: "red",
+        message: "You don't have any language model connected, so probably the shave will fail",
+      };
+
+  return { login, mcp, languageModel: languageModelItem };
+}
+
+/**
+ * Reads the live auth/MCP/LLM state and returns the dashboard status. Re-checks on
+ * mount, when the window regains focus, and on STATUS_DASHBOARD_REFRESH_EVENT, so
+ * the sidebar stays in sync with changes made in Settings or via sign-in/out.
+ */
+export function useStatusDashboard(): StatusDashboard {
+  const [dashboard, setDashboard] = useState<StatusDashboard>(() =>
+    deriveStatusDashboard({
+      isAuthenticated: false,
+      mcpServers: [],
+      mcpHealthById: {},
+      llmConfig: null,
+    }),
+  );
+
+  const check = useCallback(async () => {
+    try {
+      const [authState, mcpServers, llmConfig] = await Promise.all([
+        ipcClient.auth.identityServer
+          .status()
+          .catch(() => ({ status: "unauthenticated" as const })),
+        ipcClient.mcp.listServers().catch(() => [] as MCPServerConfig[]),
+        ipcClient.llm.getConfig().catch(() => null),
+      ]);
+
+      const backlog = mcpServers.filter(isEnabledBacklogProvider);
+      const mcpHealthById: Record<string, HealthStatusInfo | undefined> = {};
+      await Promise.all(
+        backlog.map(async (server) => {
+          try {
+            mcpHealthById[server.id] = await ipcClient.mcp.checkServerHealthAsync(server.id);
+          } catch {
+            // A failed probe is inconclusive, not "connected" — leave undefined so
+            // deriveStatusDashboard doesn't raise a false green.
+            mcpHealthById[server.id] = undefined;
+          }
+        }),
+      );
+
+      setDashboard(
+        deriveStatusDashboard({
+          isAuthenticated: authState.status === "authenticated",
+          mcpServers,
+          mcpHealthById,
+          llmConfig,
+        }),
+      );
+    } catch {
+      // Couldn't read state — fall back to the conservative all-warning defaults
+      // rather than showing a misleading green.
+      setDashboard(
+        deriveStatusDashboard({
+          isAuthenticated: false,
+          mcpServers: [],
+          mcpHealthById: {},
+          llmConfig: null,
+        }),
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    void check();
+    const onRefresh = () => void check();
+    window.addEventListener("focus", onRefresh);
+    window.addEventListener(STATUS_DASHBOARD_REFRESH_EVENT, onRefresh);
+    return () => {
+      window.removeEventListener("focus", onRefresh);
+      window.removeEventListener(STATUS_DASHBOARD_REFRESH_EVENT, onRefresh);
+    };
+  }, [check]);
+
+  return dashboard;
+}

--- a/src/ui/src/components/layout/status-dashboard.ts
+++ b/src/ui/src/components/layout/status-dashboard.ts
@@ -37,6 +37,13 @@ export interface StatusDashboard {
 export interface StatusDashboardInputs {
   /** Whether the user is signed in (`ipcClient.auth.identityServer.status()`). */
   isAuthenticated: boolean;
+  /**
+   * The raw auth status, when known — lets the login row distinguish a brief
+   * in-progress sign-in (AUTHENTICATING) from a settled NOT_AUTHENTICATED/ERROR, so
+   * it doesn't show the "not synced" warning while a sign-in is actively underway.
+   * Optional/omitted falls back to the same two-state (`isAuthenticated`) behaviour.
+   */
+  authStatus?: AuthStatus;
   /** Configured MCP servers (`ipcClient.mcp.listServers()`). */
   mcpServers: ReadonlyArray<Pick<MCPServerConfig, "id" | "name" | "enabled">>;
   /** Health by server id; only an explicit `isHealthy === true` counts as connected
@@ -61,10 +68,12 @@ export interface StatusDashboardInputs {
 export function deriveStatusDashboard(inputs: StatusDashboardInputs): StatusDashboard {
   const login: StatusItem = inputs.isAuthenticated
     ? { level: "green", message: "Signed in." }
-    : {
-        level: "yellow",
-        message: "Your shave will not be synced with the portal, etc.",
-      };
+    : inputs.authStatus === AuthStatus.AUTHENTICATING
+      ? { level: "yellow", message: "Signing in…" }
+      : {
+          level: "yellow",
+          message: "Your shave will not be synced with the portal, etc.",
+        };
 
   // Filter to backlog providers explicitly (mirrors mcp-status.ts's own
   // isBacklogProvider/enabled check) rather than relying on mcpHealthById only ever
@@ -170,6 +179,7 @@ export function useStatusDashboard(): StatusDashboard {
       setDashboard(
         deriveStatusDashboard({
           isAuthenticated: authState.status === AuthStatus.AUTHENTICATED,
+          authStatus: authState.status,
           mcpServers,
           mcpHealthById,
           llmConfig,

--- a/src/ui/src/components/layout/status-dashboard.ts
+++ b/src/ui/src/components/layout/status-dashboard.ts
@@ -72,7 +72,7 @@ export function deriveStatusDashboard(inputs: StatusDashboardInputs): StatusDash
       ? { level: "yellow", message: "Signing in…" }
       : {
           level: "yellow",
-          message: "Your shave will not be synced with the portal, etc.",
+          message: "Your shave will not be synced with the portal.",
         };
 
   // Filter to backlog providers explicitly (mirrors mcp-status.ts's own

--- a/src/ui/src/components/layout/status-dashboard.ts
+++ b/src/ui/src/components/layout/status-dashboard.ts
@@ -2,6 +2,7 @@ import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { MCPServerConfig } from "@shared/types/mcp";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchBacklogProviderHealth } from "@/components/home/mcp-status";
+import { fetchOrchestratorReadiness } from "@/components/settings/settings-health";
 import { ipcClient } from "@/services/ipc-client";
 import { AuthStatus, type HealthStatusInfo } from "@/types";
 
@@ -151,10 +152,13 @@ export function useStatusDashboard(): StatusDashboard {
         ]);
 
       // Only probe Claude Code readiness when it's the selected backend — otherwise
-      // it's irrelevant and we skip the spawn entirely (mirrors settings-health.ts).
+      // it's irrelevant and we skip the spawn entirely. Shared/de-duped with
+      // settings-health.ts's useSettingsTabHealth via fetchOrchestratorReadiness (see its
+      // docstring) so a single window-focus event doesn't spawn the `claude --version`
+      // subprocess twice when Settings is also open.
       const orchestratorReadiness =
         llmConfig?.orchestrationBackend === "local-claude"
-          ? await ipcClient.llm.checkOrchestratorReadiness().catch(() => null)
+          ? await fetchOrchestratorReadiness()
           : null;
 
       if (requestIdRef.current !== requestId) return; // superseded or unmounted

--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MCP_HEALTH_REFRESH_EVENT } from "../home/mcp-status";
+import { STATUS_DASHBOARD_REFRESH_EVENT } from "../layout/status-dashboard";
 import { Button } from "../ui/button";
 import {
   Dialog,
@@ -81,11 +82,13 @@ export function SettingsDialog() {
   const leaveHandlerRef = useRef<LeaveHandler | null>(null);
   const wasOpenRef = useRef(false);
 
-  // #869 AC4: when the dialog closes (e.g. after reconnecting an MCP provider),
-  // tell the Home banner to re-check provider health so it stays accurate.
+  // #869 AC4 / #948: when the dialog closes (e.g. after reconnecting an MCP
+  // provider, signing in, or saving a language model), tell the Home banner and
+  // the sidebar status dashboard to re-check so they stay accurate.
   useEffect(() => {
     if (wasOpenRef.current && !open) {
       window.dispatchEvent(new CustomEvent(MCP_HEALTH_REFRESH_EVENT));
+      window.dispatchEvent(new CustomEvent(STATUS_DASHBOARD_REFRESH_EVENT));
     }
     wasOpenRef.current = open;
   }, [open]);

--- a/src/ui/src/components/settings/settings-health-hook.test.tsx
+++ b/src/ui/src/components/settings/settings-health-hook.test.tsx
@@ -1,0 +1,64 @@
+import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsTabHealth } from "./settings-health";
+
+// vi.hoisted so the mock factory (hoisted above the import) can reference these.
+const { getConfig, listServers, checkServerHealthAsync, checkOrchestratorReadiness, has } =
+  vi.hoisted(() => ({
+    getConfig: vi.fn(),
+    listServers: vi.fn(),
+    checkServerHealthAsync: vi.fn(),
+    checkOrchestratorReadiness: vi.fn(),
+    has: vi.fn(),
+  }));
+
+vi.mock("@/services/ipc-client", () => ({
+  ipcClient: {
+    llm: { getConfig, checkOrchestratorReadiness },
+    mcp: { listServers, checkServerHealthAsync },
+    githubToken: { has },
+  },
+}));
+
+const GITHUB = { id: PRESET_SERVER_IDS.GITHUB, name: "GitHub", enabled: true };
+
+/** Minimal harness — `useSettingsTabHealth` is a hook, so it needs a host component to render. */
+function Harness({ open }: { open: boolean }) {
+  const health = useSettingsTabHealth(open);
+  return <div data-testid="health">{JSON.stringify(health)}</div>;
+}
+
+describe("useSettingsTabHealth (address review #949: wedged MCP server timeout)", () => {
+  beforeEach(() => {
+    getConfig.mockReset();
+    listServers.mockReset();
+    checkServerHealthAsync.mockReset();
+    checkOrchestratorReadiness.mockReset();
+    has.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves a wedged (never-settling) MCP health probe instead of hanging the check() forever", async () => {
+    vi.useFakeTimers();
+    getConfig.mockResolvedValue(null);
+    listServers.mockResolvedValue([GITHUB]);
+    has.mockResolvedValue(true);
+    checkServerHealthAsync.mockImplementation(() => new Promise(() => {})); // never resolves
+
+    const { getByTestId } = render(<Harness open={true} />);
+
+    // Advance past the shared HEALTH_CHECK_TIMEOUT_MS bound (8s) so the wedged probe times out,
+    // and let the resulting setHealth() flush.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000);
+    });
+
+    const health = JSON.parse(getByTestId("health").textContent ?? "{}");
+    // No disconnected-backlog-provider critical state is raised — the timed-out probe resolves
+    // to isHealthy:false via the shared helper, not left undefined/pending forever.
+    expect(health.mcp?.severity).toBe("critical");
+  }, 15000);
+});

--- a/src/ui/src/components/settings/settings-health.test.ts
+++ b/src/ui/src/components/settings/settings-health.test.ts
@@ -1,7 +1,19 @@
 import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
 import type { MCPServerConfig } from "@shared/types/mcp";
-import { describe, expect, it } from "vitest";
-import { deriveSettingsHealth, type SettingsHealthInputs } from "./settings-health";
+import { describe, expect, it, vi } from "vitest";
+import {
+  deriveSettingsHealth,
+  fetchOrchestratorReadiness,
+  type SettingsHealthInputs,
+} from "./settings-health";
+
+vi.mock("@/services/ipc-client", () => ({
+  ipcClient: {
+    llm: {
+      checkOrchestratorReadiness: vi.fn(),
+    },
+  },
+}));
 
 const healthyLlm = {
   languageModel: { provider: "openai" as const, model: "gpt-5.2", apiKey: "sk-live-123" },
@@ -202,5 +214,52 @@ describe("deriveSettingsHealth", () => {
       inputs({ llmConfig: { languageModel: null }, hasGithubToken: false }),
     );
     expect(Object.keys(health).sort()).toEqual(["llm", "release"]);
+  });
+});
+
+describe("fetchOrchestratorReadiness", () => {
+  it("de-dupes concurrent callers into a single underlying checkOrchestratorReadiness() call", async () => {
+    const { ipcClient } = await import("@/services/ipc-client");
+    const checkOrchestratorReadiness = vi.mocked(ipcClient.llm.checkOrchestratorReadiness);
+    let resolveCheck: (
+      value: Awaited<ReturnType<typeof ipcClient.llm.checkOrchestratorReadiness>>,
+    ) => void = () => {};
+    checkOrchestratorReadiness.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCheck = resolve;
+      }),
+    );
+
+    const first = fetchOrchestratorReadiness();
+    const second = fetchOrchestratorReadiness();
+
+    resolveCheck({
+      installed: true,
+      authenticated: true,
+      ready: true,
+      state: "ready",
+      message: "",
+    });
+    await Promise.all([first, second]);
+
+    expect(checkOrchestratorReadiness).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues a fresh call on the next round once the in-flight one has settled", async () => {
+    const { ipcClient } = await import("@/services/ipc-client");
+    const checkOrchestratorReadiness = vi.mocked(ipcClient.llm.checkOrchestratorReadiness);
+    checkOrchestratorReadiness.mockReset();
+    checkOrchestratorReadiness.mockResolvedValue({
+      installed: true,
+      authenticated: true,
+      ready: true,
+      state: "ready",
+      message: "",
+    });
+
+    await fetchOrchestratorReadiness();
+    await fetchOrchestratorReadiness();
+
+    expect(checkOrchestratorReadiness).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/ui/src/components/settings/settings-health.ts
+++ b/src/ui/src/components/settings/settings-health.ts
@@ -24,6 +24,34 @@ export const SETTINGS_HEALTH_REFRESH_EVENT = "yakshaver:settings-health-refresh"
  * MCP server going unhealthy is not a critical Settings misconfiguration. */
 const BACKLOG_PROVIDER_IDS = new Set<string>(Object.values(PRESET_SERVER_IDS));
 
+/**
+ * De-duplicates concurrent `checkOrchestratorReadiness()` callers into a single
+ * in-flight round, mirroring `fetchBacklogProviderHealth` in mcp-status.ts.
+ *
+ * `checkOrchestratorReadiness` spawns a real `claude --version` child process
+ * (claude-readiness.ts). Both this hook and the sidebar `StatusDashboard` (#948)
+ * probe it on the same triggers (mount/focus/refresh-event), and the sidebar is
+ * now always mounted (rendered on every route via Layout) — so without sharing
+ * the in-flight promise here, a single window-focus event with Settings open
+ * would spawn that subprocess twice concurrently. A caller that wants an
+ * explicit, uncached re-check (e.g. a manual "recheck" button) should keep
+ * calling `ipcClient.llm.checkOrchestratorReadiness()` directly instead.
+ */
+let inFlightReadinessCheck: Promise<OrchestratorReadiness | null> | null = null;
+
+export function fetchOrchestratorReadiness(): Promise<OrchestratorReadiness | null> {
+  if (inFlightReadinessCheck) return inFlightReadinessCheck;
+
+  inFlightReadinessCheck = ipcClient.llm
+    .checkOrchestratorReadiness()
+    .catch(() => null)
+    .finally(() => {
+      inFlightReadinessCheck = null;
+    });
+
+  return inFlightReadinessCheck;
+}
+
 export interface SettingsTabHealth {
   tabId: string;
   severity: "critical";
@@ -142,10 +170,12 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
       ]);
 
       // Only probe Claude Code readiness when it's the selected backend — otherwise it's irrelevant
-      // and we skip the spawn entirely.
+      // and we skip the spawn entirely. Shared/de-duped with the sidebar StatusDashboard via
+      // fetchOrchestratorReadiness (see its docstring) so a single focus event doesn't spawn the
+      // `claude --version` subprocess twice.
       const orchestratorReadiness =
         llmConfig?.orchestrationBackend === "local-claude"
-          ? await ipcClient.llm.checkOrchestratorReadiness().catch(() => null)
+          ? await fetchOrchestratorReadiness()
           : null;
 
       // Only probe health for the enabled backlog providers we might flag.

--- a/src/ui/src/components/settings/settings-health.ts
+++ b/src/ui/src/components/settings/settings-health.ts
@@ -2,6 +2,7 @@ import { PRESET_SERVER_IDS } from "@shared/mcp/preset-servers";
 import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { MCPServerConfig } from "@shared/types/mcp";
 import { useCallback, useEffect, useState } from "react";
+import { checkServerHealthWithTimeout } from "@/components/home/mcp-status";
 import { ipcClient } from "@/services/ipc-client";
 import type { HealthStatusInfo } from "@/types";
 
@@ -184,7 +185,11 @@ export function useSettingsTabHealth(open: boolean): SettingsHealthMap {
       await Promise.all(
         backlog.map(async (server) => {
           try {
-            mcpHealthById[server.id] = await ipcClient.mcp.checkServerHealthAsync(server.id);
+            // Bounded by the shared timeout helper (address review #949 follow-up): without it, a
+            // wedged (hung, not crashed) MCP server would leave this Promise.all branch pending
+            // forever, freezing the Settings-nav health indicator on stale data — the same failure
+            // mode mcp-status.ts's fetchBacklogProviderHealth already guards against.
+            mcpHealthById[server.id] = await checkServerHealthWithTimeout(server.id);
           } catch {
             // A failed probe is inconclusive, not "disconnected" — leave undefined
             // so deriveSettingsHealth doesn't raise a false critical state.


### PR DESCRIPTION
## Summary
<img width="210" height="196" alt="image" src="https://github.com/user-attachments/assets/234f75be-976d-4e26-b466-64753d1b8e4c" />


MCP/language-model/login connection failures were silent on the main Shaves page — users only discovered a missing connection when a shave failed. This adds a **status dashboard** section in the sidebar, between "Projects" and "Settings", that shows login status, MCP server connection status, and language model connection status with green/yellow/red indicators and the exact warning copy requested in the issue.

Closes #948

Requested by @calumjs

## What changed

| File | Change |
|------|--------|
| `src/ui/src/components/layout/status-dashboard.ts` | New pure `deriveStatusDashboard()` + `useStatusDashboard()` hook — reads auth status, configured MCP servers + health, and the LLM config, and derives the three status rows. Refreshes on mount, window focus, and a new `STATUS_DASHBOARD_REFRESH_EVENT`. |
| `src/ui/src/components/layout/StatusDashboard.tsx` | New component rendering the three status rows (Login / MCP servers / Language model) with a coloured dot + warning text when a row isn't green. |
| `src/ui/src/components/layout/sidebar.tsx` | Renders `<StatusDashboard />` between the nav (`Projects`) and the bottom Settings/auth block. |
| `src/ui/src/components/settings/SettingsDialog.tsx` | Dispatches `STATUS_DASHBOARD_REFRESH_EVENT` (alongside the existing `MCP_HEALTH_REFRESH_EVENT`) when the Settings dialog closes, so reconnecting a provider or saving an LLM key updates the dashboard immediately. |
| `src/ui/src/components/auth/IdentityServerAuthManager.tsx` | Dispatches `STATUS_DASHBOARD_REFRESH_EVENT` on successful sign-in and on sign-out, so the login row updates without waiting for a focus event. |
| `src/ui/src/components/layout/status-dashboard.test.ts` | Unit tests for `deriveStatusDashboard` covering all three rows, including the exact warning strings from the acceptance criteria. |
| `src/ui/src/components/layout/StatusDashboard.test.tsx` | Component tests covering the all-red/yellow default state, an all-green state, and the refresh-event wiring. |

## Decisions

- **Decision:** Reuse the existing "backlog provider" concept (GitHub/Azure DevOps/Jira presets, from `#869`/`#878`) to decide whether "an MCP server is connected", rather than treating every configured MCP server (including custom/non-backlog servers) as counting.
  - **Why:** Consistent with the Home banner (`HomeMcpStatusBanner`, #869) and the Settings nav health indicator (`settings-health.ts`, #878) — an unrelated custom MCP server (e.g. a docs/search server) going down shouldn't be conflated with "no server connected for backlog creation".
  - **Alternatives considered:** Counting any configured+enabled MCP server as "connected" — rejected because it would report green even when no backlog provider works, defeating the purpose of the warning.
- **Decision:** A row is only shown "green"/connected on a *positive, confirmed* signal (e.g. `isHealthy === true`); an unknown/loading/failed-probe value is treated the same as "not connected" (never a false green).
  - **Why:** Matches the conservative pattern already used by `mcp-status.ts` and `settings-health.ts` — avoids a flash of false confidence while checks are in flight.
- **Decision:** Refresh on mount, window `focus`, and a new `yakshaver:status-dashboard-refresh` window event (dispatched by Settings-close and by sign-in/out), mirroring the existing `MCP_HEALTH_REFRESH_EVENT` / `SETTINGS_HEALTH_REFRESH_EVENT` conventions rather than inventing a new refresh mechanism.
  - **Why:** Consistency with `#869`/`#878`, and it satisfies the "status updates automatically" acceptance criterion without polling.
- **Decision:** Placed the dashboard as its own bordered card directly under the nav list (after "Projects"), above the bottom Settings/auth block — visually "between Projects and Settings" as the issue's "More Information" section describes (the empty area in the sidebar).

## Acceptance criteria

- [x] Add a status dashboard section in the sidebar (between "Projects" and "Settings") — `<StatusDashboard />` in `sidebar.tsx`.
- [x] Dashboard displays user login status with appropriate indicator (logged in = green, not logged in = warning) — green when authenticated, yellow with "Your shave will not be synced with the portal, etc." otherwise.
- [x] Dashboard shows MCP server connection status (green when connected; red/warning otherwise) with the exact copy: "You don't have any MCP server connected, so the shave or request might fail".
- [x] Dashboard shows language model connection status (green when connected; red/warning otherwise) with the exact copy: "You don't have any language model connected, so probably the shave will fail".
- [x] When user is not logged in, shows: "Your shave will not be synced with the portal, etc."
- [x] UI design is consistent with the existing theme and sidebar styling (same dark/translucent card style used elsewhere in the sidebar, `lucide-react` icons already used throughout).
- [x] Status updates automatically when connection states change (mount, window focus, Settings-close, sign-in/out).

## Testing

- [x] Unit tests added/updated (`status-dashboard.test.ts` — 12 cases)
- [x] Integration/component tests added/updated (`StatusDashboard.test.tsx` — 3 cases covering default/all-green/refresh-event states)
- [ ] Manual testing performed — not possible in this sandboxed build environment (no display/Electron runtime); relied on the component-test harness (jsdom + RTL, #890) as the closest available verification.
- [x] Build passes (`npm run build` — `tsc`, clean)
- [x] Tests pass (`npx vitest run` at repo root — 57 files / 595 tests; `src/ui` UI suite — 21 files / 138 tests, including the 15 new ones)
- [x] Lint / format clean (`npm run lint` — biome check, clean)

## Bug repro evidence

This issue reports an absence of a feature (no warning surfaced) rather than a logic defect, and the sandboxed build environment has no display/Electron runtime to drive a live headless-browser repro of the running app.

- **Symptom (pinned):** before this change, `sidebar.tsx` had no UI at all reflecting login/MCP/LLM connection health — a disconnected MCP server or missing LLM config produced zero signal until a shave failed.
- **Repro method:** code-level — `sidebar.tsx` (pre-change) renders only `Shaves`/`Projects` nav links and the bottom Settings/auth block; there is no status/health element in between, confirmed by reading the file directly.
- **Before (unpatched):** no status dashboard exists; `git show origin/main:src/ui/src/components/layout/sidebar.tsx` shows no status-related component.
- **After (patched):** `StatusDashboard` is rendered between the nav and the bottom block, and `StatusDashboard.test.tsx`'s first test (`shows green login, red MCP and red language-model rows with the exact warning copy when nothing is configured`) is a fail-before/pass-after style regression test — it fails immediately on the pre-change sidebar (the component didn't exist) and passes now, asserting the exact three warning behaviours the issue calls for.

## Follow-up items

- Manual verification with Playwright/screen recording against the running Electron app (once a display-capable environment is available) would strengthen confidence beyond the component-test harness.
- The dashboard currently treats "MCP connected" as "at least one enabled backlog-provider preset (GitHub/Azure DevOps/Jira) is healthy" — if the product wants custom (non-preset) MCP servers to also count, that would need a follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
