### PR TITLE
XS✔ ◾ fix(ci): make PR-number extraction robust in auto-release

### DIFF
--- a/.github/workflows/automated-release-electron-app.yml
+++ b/.github/workflows/automated-release-electron-app.yml
@@ -68,18 +68,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Extract PR number from squash merge format: "title (#123)"
-          PR_NUMBER=$(git log -1 --pretty=%B | head -1 | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' || echo "")
+          # Extract PR number from squash merge format: "title (#123)".
+          # A title may contain multiple "(#N)" refs (e.g. "... (rebase #917) (#936)");
+          # the squash PR number is the LAST one, so take tail -1.
+          PR_NUMBER=$(git log -1 --pretty=%B | head -1 | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+' || echo "")
 
           # Fallback: use GitHub API to find PR by commit SHA
           if [ -z "$PR_NUMBER" ]; then
             PR_NUMBER=$(gh pr list --search "${{ github.sha }}" --state merged --json number --jq '.[0].number' 2>/dev/null || echo "")
           fi
 
+          # Guard: keep only a single, purely-numeric value so a malformed
+          # result can never write an invalid line to GITHUB_OUTPUT.
+          PR_NUMBER=$(printf '%s' "$PR_NUMBER" | grep -oE '^[0-9]+$' | head -1 || echo "")
+
           echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
           echo "Found PR number: ${PR_NUMBER}"
 
       - name: Comment on PR
+        if: steps.pr_number.outputs.pr_number != ''
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A commit title can contain multiple "(#N)" refs (e.g. "... (rebase #917) (#936)"). The previous grep collapsed all matches into a multi-line PR_NUMBER, which wrote an invalid extra line to GITHUB_OUTPUT and failed the step with "Invalid format".

- Take the LAST "(#N)" ref (the squash-merge PR number) via tail -1.
- Add a numeric-only guard so a malformed value can never break GITHUB_OUTPUT.
- Skip the "Comment on PR" step when no PR number is found.

> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Claude Code Opus 4.8

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ The failed workflow: https://github.com/SSWConsulting/SSW.YakShaver.Desktop/actions/runs/28936837827/job/85849183282 

> 2. What was changed?

✏️ Force the workflow to extract the last PR number

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ 
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
