### PR TITLE
XS⚠️ ◾ UX: reduce Settings cards to lightweight dividers, standardize warning color (#872)

### DIFF
--- a/src/ui/src/App.css
+++ b/src/ui/src/App.css
@@ -69,6 +69,10 @@
   --ssw-red-foreground: oklch(0.984 0.004 36.02);
   /* SSW hot-red — reserved for irreversible / destructive actions */
   --danger: #ff453a;
+  /* #872 AC1 — one shared "needs attention" token so warning banners/badges across
+   * Settings stop hand-mixing ad hoc amber/yellow shades. */
+  --warning: #f2b134;
+  --warning-foreground: oklch(0.134 0.029 49.263);
 }
 
 @theme {
@@ -110,6 +114,8 @@
   --color-ssw-red: var(--ssw-red);
   --color-ssw-red-foreground: var(--ssw-red-foreground);
   --color-danger: var(--danger);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
 }
 
 .dark {
@@ -148,6 +154,10 @@
   --ssw-red-foreground: oklch(0.929 0.008 39.026);
   /* SSW hot-red — reserved for irreversible / destructive actions */
   --danger: #ff453a;
+  /* #872 AC1 — one shared "needs attention" token so warning banners/badges across
+   * Settings stop hand-mixing ad hoc amber/yellow shades. */
+  --warning: #f2b134;
+  --warning-foreground: oklch(0.134 0.029 49.263);
 }
 
 @layer base {

--- a/src/ui/src/components/settings/SettingsNavHealthIndicator.tsx
+++ b/src/ui/src/components/settings/SettingsNavHealthIndicator.tsx
@@ -7,10 +7,16 @@ interface SettingsNavHealthIndicatorProps {
 
 /**
  * #878 — the single shared indicator shown on a Settings side-nav tab that has a
- * critical configuration problem. An amber warning triangle (carrying the issue
- * as its accessible name) plus a hover/focus tooltip explaining the specific
- * issue. Using one component everywhere keeps the treatment consistent across
- * every page (AC4).
+ * critical configuration problem. A warning triangle (carrying the issue as its
+ * accessible name) plus a hover/focus tooltip explaining the specific issue.
+ * Using one component everywhere keeps the treatment consistent across every
+ * page (AC4/AC13/AC14).
+ *
+ * #872 (AC1) — uses the shared `--warning` token rather than a hand-mixed amber
+ * shade, so this reads consistently with every other "needs attention" surface
+ * in Settings (`SettingsWarningBanner` etc.), and keeps `danger` reserved
+ * exclusively for destructive actions (AC7/AC8) — this indicator flags a
+ * configuration problem, not something the user is about to destroy.
  *
  * The parent nav button must be `group relative` for the hover tooltip to anchor.
  */
@@ -18,14 +24,14 @@ export function SettingsNavHealthIndicator({ health }: SettingsNavHealthIndicato
   return (
     <span className="relative inline-flex shrink-0 items-center">
       <AlertTriangle
-        className="h-4 w-4 text-amber-400"
+        className="h-4 w-4 text-warning"
         role="img"
         aria-label={`Configuration issue: ${health.message}`}
       />
-      {/* Flat, semi-transparent amber tooltip (no shadow) per design review (#878). */}
+      {/* Flat, semi-transparent tooltip (no shadow) per design review (#878). */}
       <span
         role="tooltip"
-        className="pointer-events-none invisible absolute right-0 top-6 z-50 w-max max-w-[220px] whitespace-normal rounded-md border border-amber-500/40 bg-amber-950/90 px-2.5 py-1.5 text-left text-xs font-normal text-amber-100 group-hover:visible group-focus-within:visible"
+        className="pointer-events-none invisible absolute right-0 top-6 z-50 w-max max-w-[220px] whitespace-normal rounded-md border border-warning/40 bg-warning/15 px-2.5 py-1.5 text-left text-xs font-normal text-warning group-hover:visible group-focus-within:visible"
       >
         {health.message}
       </span>

--- a/src/ui/src/components/settings/SettingsSection.test.tsx
+++ b/src/ui/src/components/settings/SettingsSection.test.tsx
@@ -34,4 +34,18 @@ describe("SettingsSection", () => {
     // The content wrapper is the child's parent; it should carry the custom class.
     expect(child.parentElement?.className).toContain("justify-between");
   });
+
+  it("renders as a lightweight divider, not an elevated Card (#872 AC2)", () => {
+    render(
+      <SettingsSection title="Key Mapping">
+        <span>content</span>
+      </SettingsSection>,
+    );
+    const section = screen.getByText("content").closest("section");
+    expect(section).not.toBeNull();
+    // No card surface (background/shadow/rounded) — just a bottom-border divider.
+    expect(section?.className).toContain("border-b");
+    expect(section?.className).not.toContain("shadow");
+    expect(section?.className).not.toContain("bg-card");
+  });
 });

--- a/src/ui/src/components/settings/SettingsSection.tsx
+++ b/src/ui/src/components/settings/SettingsSection.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 interface SettingsSectionProps {
@@ -10,17 +9,24 @@ interface SettingsSectionProps {
   description?: ReactNode;
   /** Extra classes for the content area — panels vary (grid, flex row, etc.). */
   contentClassName?: string;
-  /** Extra classes for the Card wrapper. */
+  /** Extra classes for the section wrapper. */
   className?: string;
-  children: ReactNode;
+  /** Optional so a transient loading/empty state can render just the header. */
+  children?: ReactNode;
 }
 
 /**
  * #880 (AC16) — the shared "settings section" surface. Every settings panel was
  * repeating the same `Card` + `CardHeader(title/description)` + `CardContent`
  * shell (e.g. Key Mapping, Tool Approval, model settings). Extracting it removes
- * that duplication and gives one place to evolve the treatment — including a
- * later cards→dividers visual pass (#880 AC2) without editing every panel.
+ * that duplication and gives one place to evolve the treatment.
+ *
+ * #872 (AC2) — no `Card` here anymore: a raised, bordered, shadowed panel isn't
+ * warranted for content that carries no elevation meaning (it's not a modal, a
+ * popover, or "floating" over anything). A bottom border reads as a section
+ * divider instead, which is lighter-weight while still separating sections
+ * visually — the same treatment `KeyMappingSetting`/`StartupSetting` etc. get
+ * automatically since they already compose through this component.
  */
 export function SettingsSection({
   title,
@@ -30,12 +36,14 @@ export function SettingsSection({
   children,
 }: SettingsSectionProps) {
   return (
-    <Card className={cn("w-full gap-4 border-white/10 py-4", className)}>
-      <CardHeader className="px-4">
-        <CardTitle className="flex items-center gap-2">{title}</CardTitle>
-        {description ? <CardDescription>{description}</CardDescription> : null}
-      </CardHeader>
-      <CardContent className={cn("px-4", contentClassName)}>{children}</CardContent>
-    </Card>
+    <section
+      className={cn("w-full border-b border-white/10 pb-5 last:border-b-0 last:pb-0", className)}
+    >
+      <div className="flex flex-col gap-1">
+        <h3 className="flex items-center gap-2 text-sm leading-none font-semibold">{title}</h3>
+        {description ? <p className="text-muted-foreground text-sm">{description}</p> : null}
+      </div>
+      {children ? <div className={cn("mt-4", contentClassName)}>{children}</div> : null}
+    </section>
   );
 }

--- a/src/ui/src/components/settings/SettingsSection.tsx
+++ b/src/ui/src/components/settings/SettingsSection.tsx
@@ -37,7 +37,7 @@ export function SettingsSection({
 }: SettingsSectionProps) {
   return (
     <section
-      className={cn("w-full border-b border-white/10 pb-5 last:border-b-0 last:pb-0", className)}
+      className={cn("w-full border-b border-white/10 pb-3 last:border-b-0 last:pb-0", className)}
     >
       <div className="flex flex-col gap-1">
         <h3 className="flex items-center gap-2 text-sm leading-none font-semibold">{title}</h3>

--- a/src/ui/src/components/settings/SettingsWarningBanner.tsx
+++ b/src/ui/src/components/settings/SettingsWarningBanner.tsx
@@ -17,11 +17,18 @@ interface SettingsWarningBannerProps {
  * shades and borders. This is the one place to render that state, on the
  * shared `--warning` token, so every non-destructive "fix this" message reads
  * the same way across the dialog instead of a wall of inconsistent ambers.
+ *
+ * #954 review follow-up — this banner is often present on initial render (e.g.
+ * "no MCP servers configured"), not just triggered after a state change, so an
+ * `<output>` element (implicit `role="status"`) with `aria-live="polite"` is used
+ * instead of `role="alert"`: `alert`'s assertive interrupt is meant for a one-shot,
+ * attention-demanding message, not a warning that can already be present at mount.
+ * Mirrors the same convention `StatusDashboard` follows (see its #949 note).
  */
 export function SettingsWarningBanner({ children, action, className }: SettingsWarningBannerProps) {
   return (
-    <div
-      role="alert"
+    <output
+      aria-live="polite"
       className={cn(
         "flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs leading-relaxed text-warning",
         className,
@@ -32,6 +39,6 @@ export function SettingsWarningBanner({ children, action, className }: SettingsW
         <span className="break-words">{children}</span>
         {action ? <div>{action}</div> : null}
       </div>
-    </div>
+    </output>
   );
 }

--- a/src/ui/src/components/settings/SettingsWarningBanner.tsx
+++ b/src/ui/src/components/settings/SettingsWarningBanner.tsx
@@ -1,0 +1,37 @@
+import { AlertTriangle } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface SettingsWarningBannerProps {
+  children: ReactNode;
+  /** Extra actions rendered under the message, e.g. a "Re-check" button. */
+  action?: ReactNode;
+  className?: string;
+}
+
+/**
+ * #872 (AC1) — the shared "this needs attention" banner for Settings pages.
+ *
+ * Several panels (Orchestrator readiness, GitHub token, custom prompts) each
+ * hand-rolled their own amber/yellow warning box with slightly different
+ * shades and borders. This is the one place to render that state, on the
+ * shared `--warning` token, so every non-destructive "fix this" message reads
+ * the same way across the dialog instead of a wall of inconsistent ambers.
+ */
+export function SettingsWarningBanner({ children, action, className }: SettingsWarningBannerProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs leading-relaxed text-warning",
+        className,
+      )}
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <div className="flex min-w-0 flex-col gap-2">
+        <span className="break-words">{children}</span>
+        {action ? <div>{action}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/account/ResetAccountSetting.tsx
+++ b/src/ui/src/components/settings/account/ResetAccountSetting.tsx
@@ -14,7 +14,7 @@ import {
   AlertDialogTitle,
 } from "../../ui/alert-dialog";
 import { Button, buttonVariants } from "../../ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../ui/card";
+import { SettingsSection } from "../SettingsSection";
 
 export function ResetAccountSetting() {
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
@@ -63,23 +63,20 @@ export function ResetAccountSetting() {
 
   return (
     <>
-      <Card className="w-full gap-4 border-white/10 py-4">
-        <CardHeader className="px-4">
-          <CardTitle className="flex items-center gap-2 text-danger">
+      <SettingsSection
+        title={
+          <span className="flex items-center gap-2 text-danger">
             <AlertTriangle className="h-5 w-5" />
             Reset Account
-          </CardTitle>
-          <CardDescription>
-            Log out of all services and clear all configurations. This action cannot be undone.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="px-4">
-          {/* #880 AC17: no longer full-width — a single confirmation-gated action doesn't warrant it on desktop. */}
-          <Button onClick={() => setIsResetDialogOpen(true)} variant="destructiveOutline">
-            Reset Account to Default
-          </Button>
-        </CardContent>
-      </Card>
+          </span>
+        }
+        description="Log out of all services and clear all configurations. This action cannot be undone."
+      >
+        {/* #880 AC17: no longer full-width — a single confirmation-gated action doesn't warrant it on desktop. */}
+        <Button onClick={() => setIsResetDialogOpen(true)} variant="destructiveOutline">
+          Reset Account to Default
+        </Button>
+      </SettingsSection>
 
       <AlertDialog open={isResetDialogOpen} onOpenChange={setIsResetDialogOpen}>
         <AlertDialogContent>

--- a/src/ui/src/components/settings/account/TelemetryUsageDataSetting.tsx
+++ b/src/ui/src/components/settings/account/TelemetryUsageDataSetting.tsx
@@ -2,10 +2,10 @@ import { Activity, BarChart3, Bug } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useTelemetryConsent } from "@/hooks/useTelemetryConsent";
+import { SettingsSection } from "../SettingsSection";
 import { TelemetryConsentDialog } from "../telemetry/TelemetryConsentDialog";
 
 export function TelemetryUsageDataSetting() {
@@ -64,101 +64,89 @@ export function TelemetryUsageDataSetting() {
     setShowConsentDialog(false);
   };
 
+  const title = (
+    <span className="flex items-center gap-2">
+      <BarChart3 className="h-5 w-5" />
+      Telemetry & Usage Data
+    </span>
+  );
+
   if (isLoading) {
-    return (
-      <Card className="w-full gap-4 border-white/10 py-4">
-        <CardHeader className="px-4">
-          <CardTitle className="flex items-center gap-2">
-            <BarChart3 className="h-5 w-5" />
-            Telemetry & Usage Data
-          </CardTitle>
-          <CardDescription>Loading settings...</CardDescription>
-        </CardHeader>
-      </Card>
-    );
+    return <SettingsSection title={title} description="Loading settings..." />;
   }
 
   return (
     <>
-      <Card className="w-full gap-4 border-white/10 py-4">
-        <CardHeader className="px-4">
-          <CardTitle className="flex items-center gap-2">
-            <BarChart3 className="h-5 w-5" />
-            Telemetry & Usage Data
-          </CardTitle>
-          <CardDescription>
-            We'd like to collect anonymous usage data to help improve YakShaver. Your privacy is
-            important to us - no personal information or video content is ever collected.
-          </CardDescription>
-        </CardHeader>
-
-        <CardContent className="space-y-6 px-4">
-          {!hasMadeDecision || !isEnabled ? (
-            <div className="bg-muted/50 p-4 rounded-lg">
-              <p className="text-sm mb-3">
-                Help us improve YakShaver by sharing anonymous usage data. We never collect personal
-                information or video content.
-              </p>
-              <Button onClick={() => setShowConsentDialog(true)}>Enable Telemetry</Button>
-            </div>
-          ) : (
+      <SettingsSection
+        title={title}
+        description="We'd like to collect anonymous usage data to help improve YakShaver. Your privacy is important to us - no personal information or video content is ever collected."
+        contentClassName="space-y-6"
+      >
+        {!hasMadeDecision || !isEnabled ? (
+          <div className="bg-muted/50 p-4 rounded-lg">
+            <p className="text-sm mb-3">
+              Help us improve YakShaver by sharing anonymous usage data. We never collect personal
+              information or video content.
+            </p>
+            <Button onClick={() => setShowConsentDialog(true)}>Enable Telemetry</Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
             <div className="space-y-4">
-              <div className="space-y-4">
-                <div className="flex items-start justify-between">
-                  <div className="flex items-start gap-3">
-                    <Bug className="h-4 w-4 mt-1 text-muted-foreground" />
-                    <div>
-                      <Label className="text-sm font-medium">Error reports</Label>
-                      <p className="text-xs text-muted-foreground">
-                        Stack traces and error messages to help us fix bugs
-                      </p>
-                    </div>
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-3">
+                  <Bug className="h-4 w-4 mt-1 text-muted-foreground" />
+                  <div>
+                    <Label className="text-sm font-medium">Error reports</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Stack traces and error messages to help us fix bugs
+                    </p>
                   </div>
-                  <Switch
-                    checked={settings?.allowErrorReporting ?? true}
-                    onCheckedChange={handleToggleErrorReporting}
-                    disabled={!isEnabled}
-                  />
                 </div>
+                <Switch
+                  checked={settings?.allowErrorReporting ?? true}
+                  onCheckedChange={handleToggleErrorReporting}
+                  disabled={!isEnabled}
+                />
+              </div>
 
-                <div className="flex items-start justify-between">
-                  <div className="flex items-start gap-3">
-                    <Activity className="h-4 w-4 mt-1 text-muted-foreground" />
-                    <div>
-                      <Label className="text-sm font-medium">Workflow performance</Label>
-                      <p className="text-xs text-muted-foreground">
-                        How long processing stages take (transcription, analysis, etc.)
-                      </p>
-                    </div>
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-3">
+                  <Activity className="h-4 w-4 mt-1 text-muted-foreground" />
+                  <div>
+                    <Label className="text-sm font-medium">Workflow performance</Label>
+                    <p className="text-xs text-muted-foreground">
+                      How long processing stages take (transcription, analysis, etc.)
+                    </p>
                   </div>
-                  <Switch
-                    checked={settings?.allowWorkflowTracking ?? true}
-                    onCheckedChange={handleToggleWorkflowTracking}
-                    disabled={!isEnabled}
-                  />
                 </div>
+                <Switch
+                  checked={settings?.allowWorkflowTracking ?? true}
+                  onCheckedChange={handleToggleWorkflowTracking}
+                  disabled={!isEnabled}
+                />
+              </div>
 
-                <div className="flex items-start justify-between">
-                  <div className="flex items-start gap-3">
-                    <BarChart3 className="h-4 w-4 mt-1 text-muted-foreground" />
-                    <div>
-                      <Label className="text-sm font-medium">Usage metrics</Label>
-                      <p className="text-xs text-muted-foreground">
-                        Feature usage counts and app version information
-                      </p>
-                    </div>
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-3">
+                  <BarChart3 className="h-4 w-4 mt-1 text-muted-foreground" />
+                  <div>
+                    <Label className="text-sm font-medium">Usage metrics</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Feature usage counts and app version information
+                    </p>
                   </div>
-                  <Switch
-                    checked={settings?.allowUsageMetrics ?? true}
-                    onCheckedChange={handleToggleUsageMetrics}
-                    disabled={!isEnabled}
-                  />
                 </div>
+                <Switch
+                  checked={settings?.allowUsageMetrics ?? true}
+                  onCheckedChange={handleToggleUsageMetrics}
+                  disabled={!isEnabled}
+                />
               </div>
             </div>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </SettingsSection>
 
       <TelemetryConsentDialog
         open={showConsentDialog}

--- a/src/ui/src/components/settings/advanced/AdvancedSettingsPanel.tsx
+++ b/src/ui/src/components/settings/advanced/AdvancedSettingsPanel.tsx
@@ -1,9 +1,9 @@
 import { FlaskConical } from "lucide-react";
 import { useId } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { useAdvancedSettings } from "@/contexts/AdvancedSettingsContext";
 import { SettingsPageHeader } from "../SettingsPageHeader";
+import { SettingsSection } from "../SettingsSection";
 
 export function AdvancedSettingsPanel() {
   const { isYoutubeUrlWorkflowEnabled, setYoutubeUrlWorkflowEnabled } = useAdvancedSettings();
@@ -17,22 +17,17 @@ export function AdvancedSettingsPanel() {
         description="Toggle experimental workflows and power-user options. These settings affect how controls appear in the main workspace."
       />
 
-      <Card>
-        <CardHeader className="space-y-1">
-          <CardTitle>YouTube URL Workflow</CardTitle>
-          <CardDescription>
-            Adds an upload button next to the recording controls that opens a dialog where you can
-            paste an existing YouTube link for processing without recording a new video.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex items-center justify-between gap-4">
-          <Switch
-            id={inputId}
-            checked={isYoutubeUrlWorkflowEnabled}
-            onCheckedChange={setYoutubeUrlWorkflowEnabled}
-          />
-        </CardContent>
-      </Card>
+      <SettingsSection
+        title="YouTube URL Workflow"
+        description="Adds an upload button next to the recording controls that opens a dialog where you can paste an existing YouTube link for processing without recording a new video."
+        contentClassName="flex items-center justify-between gap-4"
+      >
+        <Switch
+          id={inputId}
+          checked={isYoutubeUrlWorkflowEnabled}
+          onCheckedChange={setYoutubeUrlWorkflowEnabled}
+        />
+      </SettingsSection>
     </div>
   );
 }

--- a/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
+++ b/src/ui/src/components/settings/custom-prompt/PromptForm.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../ui/form";
 import { Input } from "../../ui/input";
 import type { MCPServerConfig } from "../mcp/McpServerForm";
+import { SettingsWarningBanner } from "../SettingsWarningBanner";
 import { HighlightedTextarea, hasPlaceholder } from "./HighlightedTextarea";
 import {
   PROMPT_DESCRIPTION_MAX,
@@ -305,7 +306,7 @@ export function PromptForm({
                   />
                 </FormControl>
                 {hasPlaceholders && !isTemplate && (
-                  <p className="text-xs text-amber-500/80 flex items-center gap-1 mt-1">
+                  <p className="text-xs text-warning flex items-center gap-1 mt-1">
                     <AlertTriangle className="w-3 h-3 shrink-0" />
                     Replace the highlighted fields before using this prompt
                   </p>
@@ -391,9 +392,7 @@ export function PromptForm({
                               <span className="ml-2 text-xs text-white/50">(Built-in)</span>
                             )}
                             {isServerDisabled && (
-                              <span className="ml-2 text-xs text-yellow-500/70">
-                                (Not connected)
-                              </span>
+                              <span className="ml-2 text-xs text-warning/80">(Not connected)</span>
                             )}
                           </label>
                         </div>
@@ -432,7 +431,7 @@ export function PromptForm({
                     )}
                   </div>
                   {hasDisconnectedSelection && (
-                    <p className="text-xs text-yellow-500/80 mt-1">
+                    <p className="text-xs text-warning/80 mt-1">
                       Some selected servers are disconnected. Connect them in MCP settings tab to
                       make their tools available.
                     </p>
@@ -445,10 +444,10 @@ export function PromptForm({
         )}
 
         {serversLoaded && serversWithIds.length === 0 && (
-          <div className="text-sm text-yellow-500/80 p-3 rounded-md border border-yellow-500/30 bg-yellow-500/10">
+          <SettingsWarningBanner>
             No external MCP servers configured. You can add additional MCP servers in the MCP
             settings tab.
-          </div>
+          </SettingsWarningBanner>
         )}
 
         <div className="flex justify-between gap-2 shrink-0">

--- a/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
+++ b/src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx
@@ -1,10 +1,9 @@
 import type { LLMConfigV2, OrchestrationBackend, OrchestratorReadiness } from "@shared/types/llm";
 import { DEFAULT_ORCHESTRATION_BACKEND } from "@shared/types/llm";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
   SelectContent,
@@ -14,6 +13,8 @@ import {
 } from "@/components/ui/select";
 import { ipcClient } from "@/services/ipc-client";
 import { formatErrorMessage } from "@/utils";
+import { SettingsSection } from "../SettingsSection";
+import { SettingsWarningBanner } from "../SettingsWarningBanner";
 
 interface OrchestratorBackendSettingProps {
   isActive: boolean;
@@ -151,69 +152,58 @@ export function OrchestratorBackendSetting({ isActive }: OrchestratorBackendSett
   );
 
   return (
-    <Card className="w-full gap-4 border-white/10 py-4">
-      <CardHeader className="px-4">
-        <CardTitle>Orchestrator</CardTitle>
-        <CardDescription>
+    <SettingsSection
+      title="Orchestrator"
+      description={
+        <>
           Choose which backend drives backlog creation. Claude Code requires the{" "}
           <code className="rounded bg-white/10 px-1 py-0.5 text-xs">claude</code> CLI installed, and
           uses your Claude Code sign-in instead of an Anthropic API key.
-        </CardDescription>
-      </CardHeader>
+        </>
+      }
+      contentClassName="flex flex-col gap-2"
+    >
+      <Select
+        value={currentBackend}
+        onValueChange={(value) => {
+          if (isOrchestrationBackend(value)) void handleSelect(value);
+        }}
+        disabled={isLoading || pendingBackend !== null}
+      >
+        <SelectTrigger className="w-full md:w-72" aria-label="Orchestrator backend">
+          <SelectValue placeholder="Select an orchestrator" />
+        </SelectTrigger>
+        <SelectContent>
+          {BACKEND_OPTIONS.map((option) => (
+            <SelectItem key={option.id} value={option.id}>
+              {option.title}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        {BACKEND_OPTIONS.find((o) => o.id === currentBackend)?.description}
+      </p>
 
-      <CardContent className="flex flex-col gap-2 px-4">
-        <Select
-          value={currentBackend}
-          onValueChange={(value) => {
-            if (isOrchestrationBackend(value)) void handleSelect(value);
-          }}
-          disabled={isLoading || pendingBackend !== null}
+      {/* Claude Code readiness: warn + instruct when the backend is selected but the local CLI
+          isn't installed or isn't signed in, so the user fixes it BEFORE a run fails. */}
+      {currentBackend === "local-claude" && readiness && !readiness.ready && (
+        <SettingsWarningBanner
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void checkReadiness()}
+              disabled={isCheckingReadiness}
+            >
+              {isCheckingReadiness && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
+              Re-check
+            </Button>
+          }
         >
-          <SelectTrigger className="w-full md:w-72" aria-label="Orchestrator backend">
-            <SelectValue placeholder="Select an orchestrator" />
-          </SelectTrigger>
-          <SelectContent>
-            {BACKEND_OPTIONS.map((option) => (
-              <SelectItem key={option.id} value={option.id}>
-                {option.title}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          {BACKEND_OPTIONS.find((o) => o.id === currentBackend)?.description}
-        </p>
-
-        {/* Claude Code readiness: warn + instruct when the backend is selected but the local CLI
-            isn't installed or isn't signed in, so the user fixes it BEFORE a run fails. */}
-        {currentBackend === "local-claude" && readiness && !readiness.ready && (
-          <div
-            role="alert"
-            className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-950/40 px-3 py-2 text-xs leading-relaxed text-amber-100"
-          >
-            <AlertTriangle
-              className="mt-0.5 h-4 w-4 shrink-0 text-amber-400"
-              role="img"
-              aria-label="Claude Code not ready"
-            />
-            <div className="flex min-w-0 flex-col gap-2">
-              <span className="break-words">{readiness.message}</span>
-              <div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 border-amber-500/40 bg-transparent text-amber-100 hover:bg-amber-500/10"
-                  onClick={() => void checkReadiness()}
-                  disabled={isCheckingReadiness}
-                >
-                  {isCheckingReadiness && <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />}
-                  Re-check
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          {readiness.message}
+        </SettingsWarningBanner>
+      )}
+    </SettingsSection>
   );
 }

--- a/src/ui/src/components/settings/release-channels/GitHubTokenSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/GitHubTokenSetting.tsx
@@ -2,7 +2,6 @@ import { Eye, EyeOff } from "lucide-react";
 import { useCallback, useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { DeleteConfirmDialog } from "@/components/dialogs/DeleteConfirmDialog";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ipcClient } from "@/services/ipc-client";
 import type { HealthStatusInfo } from "@/types";
 import { formatErrorMessage } from "@/utils";
@@ -10,6 +9,7 @@ import { HealthStatus } from "../../health-status/health-status";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
+import { SettingsSection } from "../SettingsSection";
 
 interface GitHubTokenSettingProps {
   isActive: boolean;
@@ -145,82 +145,78 @@ export function GitHubTokenSetting({ isActive }: GitHubTokenSettingProps) {
 
   return (
     <>
-      <Card className="w-full gap-4 border-white/10 py-4">
-        <CardHeader className="px-4">
-          <CardTitle>GitHub Token</CardTitle>
-          <CardDescription>
-            Add a personal access token so YakShaver can list and download PR releases.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4 px-4">
-          {isLoading ? (
-            <div className="text-muted-foreground text-center py-8">Loading...</div>
-          ) : (
-            <>
-              {hasToken && (
-                <div className="flex items-center gap-3">
-                  <p className="text-white/80 text-sm">Token Status:</p>
-                  <span className="text-green-400 text-sm font-mono">Saved</span>
-                  <HealthStatus
-                    isChecking={healthStatus?.isChecking ?? false}
-                    isHealthy={healthStatus?.isHealthy ?? false}
-                    successMessage={healthStatus?.successMessage}
-                    successDetails={verifyDetails ?? undefined}
-                    error={healthStatus?.error}
-                    isDisabled={!hasToken}
-                  />
-                </div>
-              )}
-              {!hasToken && (
-                <p className="text-white/80 text-sm">
-                  Status: <span className="text-ssw-red">No Token Saved</span>
-                </p>
-              )}
-              <div className="flex flex-col gap-2">
-                <Label htmlFor={inputId}>GitHub Personal Access Token</Label>
-                <div className="relative">
-                  <Input
-                    id={inputId}
-                    type={showToken ? "text" : "password"}
-                    value={token}
-                    onChange={(e) => setToken(e.target.value)}
-                    placeholder={hasToken ? "Token is saved (hidden)" : "ghp_xxxxxxxxxxxxxxxxxxxx"}
-                    disabled={isSaving}
-                  />
-                  {token && (
-                    <button
-                      type="button"
-                      onClick={toggleShowToken}
-                      className="absolute right-3 top-1/2 -translate-y-1/2"
-                      aria-label={showToken ? "Hide token" : "Show token"}
-                    >
-                      {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                    </button>
-                  )}
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  The token is encrypted and stored locally on your device
-                </p>
+      <SettingsSection
+        title="GitHub Token"
+        description="Add a personal access token so YakShaver can list and download PR releases."
+        contentClassName="flex flex-col gap-4"
+      >
+        {isLoading ? (
+          <div className="text-muted-foreground text-center py-8">Loading...</div>
+        ) : (
+          <>
+            {hasToken && (
+              <div className="flex items-center gap-3">
+                <p className="text-white/80 text-sm">Token Status:</p>
+                <span className="text-green-400 text-sm font-mono">Saved</span>
+                <HealthStatus
+                  isChecking={healthStatus?.isChecking ?? false}
+                  isHealthy={healthStatus?.isHealthy ?? false}
+                  successMessage={healthStatus?.successMessage}
+                  successDetails={verifyDetails ?? undefined}
+                  error={healthStatus?.error}
+                  isDisabled={!hasToken}
+                />
               </div>
-
-              <div className="flex gap-3 justify-end pt-2">
-                {hasToken && (
-                  <Button
-                    variant="destructiveOutline"
-                    onClick={() => setClearConfirmOpen(true)}
-                    disabled={isSaving}
+            )}
+            {!hasToken && (
+              <p className="text-white/80 text-sm">
+                Status: <span className="text-ssw-red">No Token Saved</span>
+              </p>
+            )}
+            <div className="flex flex-col gap-2">
+              <Label htmlFor={inputId}>GitHub Personal Access Token</Label>
+              <div className="relative">
+                <Input
+                  id={inputId}
+                  type={showToken ? "text" : "password"}
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  placeholder={hasToken ? "Token is saved (hidden)" : "ghp_xxxxxxxxxxxxxxxxxxxx"}
+                  disabled={isSaving}
+                />
+                {token && (
+                  <button
+                    type="button"
+                    onClick={toggleShowToken}
+                    className="absolute right-3 top-1/2 -translate-y-1/2"
+                    aria-label={showToken ? "Hide token" : "Show token"}
                   >
-                    Clear Token
-                  </Button>
+                    {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
                 )}
-                <Button onClick={handleSave} disabled={isSaving || !token.trim()}>
-                  {isSaving ? "Saving..." : "Save Token"}
-                </Button>
               </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+              <p className="text-xs text-muted-foreground">
+                The token is encrypted and stored locally on your device
+              </p>
+            </div>
+
+            <div className="flex gap-3 justify-end pt-2">
+              {hasToken && (
+                <Button
+                  variant="destructiveOutline"
+                  onClick={() => setClearConfirmOpen(true)}
+                  disabled={isSaving}
+                >
+                  Clear Token
+                </Button>
+              )}
+              <Button onClick={handleSave} disabled={isSaving || !token.trim()}>
+                {isSaving ? "Saving..." : "Save Token"}
+              </Button>
+            </div>
+          </>
+        )}
+      </SettingsSection>
       <DeleteConfirmDialog
         open={clearConfirmOpen}
         onOpenChange={setClearConfirmOpen}

--- a/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
@@ -303,8 +303,13 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
       )}
 
       {showInvalidTokenBanner && (
-        <div className="rounded-md border border-danger/40 bg-danger/10 p-3 text-danger">
-          <h3 className="mb-1 font-medium">GitHub Token Invalid</h3>
+        <div
+          role="alert"
+          className="rounded-md border border-danger/40 bg-danger/10 p-3 text-danger"
+        >
+          {/* Bold lead-in rather than a nested heading — SettingsSection's own title is
+           * already an <h3>; a second <h3> here would duplicate that heading level. */}
+          <p className="mb-1 text-sm font-medium">GitHub Token Invalid</p>
           <p className="text-sm">
             {tokenHealthError
               ? `GitHub token verification failed: ${tokenHealthError}. PR releases can't be listed, selected, or downloaded until this is resolved.`

--- a/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
+++ b/src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -12,6 +11,8 @@ import {
 } from "@/components/ui/select";
 import { ipcClient } from "@/services/ipc-client";
 import { formatErrorMessage, getVersionBumpType, type VersionBumpType } from "@/utils";
+import { SettingsSection } from "../SettingsSection";
+import { SettingsWarningBanner } from "../SettingsWarningBanner";
 import { GITHUB_TOKEN_UPDATED_EVENT } from "./GitHubTokenSetting";
 import type { ProcessedRelease, ReleaseChannel } from "./types";
 
@@ -289,124 +290,114 @@ export function ReleaseChannelSetting({ isActive }: ReleaseChannelSettingProps) 
   const prSelectionDisabled = isCheckingToken || !isTokenHealthy;
 
   return (
-    <Card className="w-full gap-4 border-white/10 py-4">
-      <CardHeader className="px-4">
-        <CardTitle>Release Channel</CardTitle>
-        <CardDescription>
-          Choose the stable release or a PR release to test updates.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4 px-4">
-        {showNoTokenBanner && (
-          <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
-            <h3 className="mb-1 font-medium text-yellow-200">GitHub Token Required</h3>
-            <p className="text-sm text-yellow-100">
-              A GitHub token is required to view and download PR releases. Add one below.
-            </p>
-          </div>
-        )}
+    <SettingsSection
+      title="Release Channel"
+      description="Choose the stable release or a PR release to test updates."
+      contentClassName="space-y-4"
+    >
+      {showNoTokenBanner && (
+        <SettingsWarningBanner>
+          <span className="font-medium">GitHub Token Required.</span> A GitHub token is required to
+          view and download PR releases. Add one below.
+        </SettingsWarningBanner>
+      )}
 
-        {showInvalidTokenBanner && (
-          <div className="rounded-md border border-ssw-red/30 bg-ssw-red/10 p-3">
-            <h3 className="mb-1 font-medium text-red-200">GitHub Token Invalid</h3>
-            <p className="text-sm text-red-100">
-              {tokenHealthError
-                ? `GitHub token verification failed: ${tokenHealthError}. PR releases can't be listed, selected, or downloaded until this is resolved.`
-                : "Your GitHub token is invalid or expired, so PR releases can't be listed, selected, or downloaded. Update it below."}
-            </p>
-          </div>
-        )}
+      {showInvalidTokenBanner && (
+        <div className="rounded-md border border-danger/40 bg-danger/10 p-3 text-danger">
+          <h3 className="mb-1 font-medium">GitHub Token Invalid</h3>
+          <p className="text-sm">
+            {tokenHealthError
+              ? `GitHub token verification failed: ${tokenHealthError}. PR releases can't be listed, selected, or downloaded until this is resolved.`
+              : "Your GitHub token is invalid or expired, so PR releases can't be listed, selected, or downloaded. Update it below."}
+          </p>
+        </div>
+      )}
 
-        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor={selectId}>Select Release Channel To Test</Label>
-            <Select value={selectValue} onValueChange={handleSelectionChange}>
-              <SelectTrigger id={selectId}>
-                <SelectValue placeholder="Choose a release">
-                  {selectValue === SELECT_LATEST
-                    ? "Latest Stable (default)"
-                    : selectValue
-                      ? `PR #${selectValue}`
-                      : "Choose a release"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent className="max-h-80">
-                <SelectItem value={SELECT_LATEST} textValue="Latest Stable (default)">
-                  Latest Stable (default)
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor={selectId}>Select Release Channel To Test</Label>
+          <Select value={selectValue} onValueChange={handleSelectionChange}>
+            <SelectTrigger id={selectId}>
+              <SelectValue placeholder="Choose a release">
+                {selectValue === SELECT_LATEST
+                  ? "Latest Stable (default)"
+                  : selectValue
+                    ? `PR #${selectValue}`
+                    : "Choose a release"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent className="max-h-80">
+              <SelectItem value={SELECT_LATEST} textValue="Latest Stable (default)">
+                Latest Stable (default)
+              </SelectItem>
+              {isLoadingReleases && (
+                <SelectItem value="__loading" disabled>
+                  Loading releases...
                 </SelectItem>
-                {isLoadingReleases && (
-                  <SelectItem value="__loading" disabled>
-                    Loading releases...
+              )}
+              {!isLoadingReleases && dropdownOptions.length === 0 && (
+                <SelectItem value="__empty" disabled>
+                  No PR releases available
+                </SelectItem>
+              )}
+              {!isLoadingReleases &&
+                dropdownOptions.map((option) => (
+                  <SelectItem
+                    key={option.value}
+                    value={option.value}
+                    className="text-white"
+                    textValue={option.label}
+                    disabled={prSelectionDisabled}
+                  >
+                    <div className="flex flex-col">
+                      <span>{option.label}</span>
+                      <span className="text-xs">{option.version}</span>
+                      <span className="text-xs">
+                        {new Date(option.publishedAt).toLocaleString()}
+                      </span>
+                    </div>
                   </SelectItem>
-                )}
-                {!isLoadingReleases && dropdownOptions.length === 0 && (
-                  <SelectItem value="__empty" disabled>
-                    No PR releases available
-                  </SelectItem>
-                )}
-                {!isLoadingReleases &&
-                  dropdownOptions.map((option) => (
-                    <SelectItem
-                      key={option.value}
-                      value={option.value}
-                      className="text-white"
-                      textValue={option.label}
-                      disabled={prSelectionDisabled}
-                    >
-                      <div className="flex flex-col">
-                        <span>{option.label}</span>
-                        <span className="text-xs">{option.version}</span>
-                        <span className="text-xs">
-                          {new Date(option.publishedAt).toLocaleString()}
-                        </span>
-                      </div>
-                    </SelectItem>
-                  ))}
-              </SelectContent>
-            </Select>
+                ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button
+          onClick={handleCheckUpdates}
+          disabled={
+            isLoading || !selectValue || (channel.type === "pr" ? !isTokenHealthy : !hasGitHubToken)
+          }
+        >
+          Check for Updates
+        </Button>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {currentVersion && (
+          <div className="rounded-md border border-border bg-card p-3">
+            <p className="text-sm text-muted-foreground">Current Version</p>
+            <p className="text-lg">{currentVersion}</p>
           </div>
+        )}
 
-          <Button
-            onClick={handleCheckUpdates}
-            disabled={
-              isLoading ||
-              !selectValue ||
-              (channel.type === "pr" ? !isTokenHealthy : !hasGitHubToken)
-            }
-          >
-            Check for Updates
-          </Button>
-        </div>
+        {availableVersion && (
+          <div className="rounded-md border border-border bg-card p-3">
+            <p className="text-sm text-muted-foreground">New Version Available</p>
+            <p className="text-lg">
+              {availableVersion}{" "}
+              {bumpType !== "unknown" && (
+                <span className="text-sm text-muted-foreground">({BUMP_TYPE_LABEL[bumpType]})</span>
+              )}
+            </p>
+          </div>
+        )}
 
-        <div className="grid gap-3 md:grid-cols-2">
-          {currentVersion && (
-            <div className="rounded-md border border-border bg-card p-3">
-              <p className="text-sm text-muted-foreground">Current Version</p>
-              <p className="text-lg">{currentVersion}</p>
-            </div>
-          )}
-
-          {availableVersion && (
-            <div className="rounded-md border border-border bg-card p-3">
-              <p className="text-sm text-muted-foreground">New Version Available</p>
-              <p className="text-lg">
-                {availableVersion}{" "}
-                {bumpType !== "unknown" && (
-                  <span className="text-sm text-muted-foreground">
-                    ({BUMP_TYPE_LABEL[bumpType]})
-                  </span>
-                )}
-              </p>
-            </div>
-          )}
-
-          {updateStatus && (
-            <div className="rounded-md border border-border bg-card p-3">
-              <p className="text-sm">{updateStatus}</p>
-            </div>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+        {updateStatus && (
+          <div className="rounded-md border border-border bg-card p-3">
+            <p className="text-sm">{updateStatus}</p>
+          </div>
+        )}
+      </div>
+    </SettingsSection>
   );
 }


### PR DESCRIPTION
## Summary

Part of the #872 Settings-dialog UX PBI. Converts `SettingsSection` from an elevated `Card` shell to a lightweight bottom-border divider (no elevation semantics warranted for standard content), migrates the settings panels that still hand-rolled their own `Card`/`CardTitle` shell onto `SettingsSection`, and introduces one shared `--warning` design token + `SettingsWarningBanner` component so the several ad hoc amber/yellow warning surfaces render consistently.

Relates to #872

## What changed

| File | Change |
|------|--------|
| `src/ui/src/components/settings/SettingsSection.tsx` | `Card` → `<section>` with a bottom-border divider; `children` made optional for loading/empty states |
| `src/ui/src/components/settings/SettingsWarningBanner.tsx` | New — shared "needs attention" banner on the `--warning` token |
| `src/ui/src/App.css` | Adds `--warning` / `--warning-foreground` tokens (light + dark) |
| `src/ui/src/components/settings/SettingsNavHealthIndicator.tsx` | Amber → shared `--warning` token (kept distinct from `--danger`, which stays reserved for destructive actions) |
| `src/ui/src/components/settings/llm/OrchestratorBackendSetting.tsx` | Hand-rolled `Card` → `SettingsSection`; readiness warning → `SettingsWarningBanner`; removed a one-off `h-7` button that broke the standard height scale |
| `src/ui/src/components/settings/account/ResetAccountSetting.tsx` | Hand-rolled `Card` → `SettingsSection` |
| `src/ui/src/components/settings/account/TelemetryUsageDataSetting.tsx` | Hand-rolled `Card` → `SettingsSection` (incl. loading state) |
| `src/ui/src/components/settings/advanced/AdvancedSettingsPanel.tsx` | Hand-rolled `Card` → `SettingsSection` |
| `src/ui/src/components/settings/release-channels/GitHubTokenSetting.tsx` | Hand-rolled `Card` → `SettingsSection` |
| `src/ui/src/components/settings/release-channels/ReleaseChannelSetting.tsx` | Hand-rolled `Card` → `SettingsSection`; no-token banner → `SettingsWarningBanner` |
| `src/ui/src/components/settings/custom-prompt/PromptForm.tsx` | Ad hoc amber/yellow warning text → shared `warning` token; standalone "no MCP servers" banner → `SettingsWarningBanner` |
| `src/ui/src/components/settings/SettingsSection.test.tsx` | New test locking in the divider-not-card behaviour |

## Decisions

- **Decision:** `SettingsSection`'s public API (`title`/`description`/`contentClassName`/`className`/`children`) is unchanged — only its internal markup changed from `Card` to `<section>`.
  - **Why:** Every panel already composing through it (Key Mapping, Model Settings, Tool Approval, Startup, Setup Wizard) gets the AC2 divider treatment for free, with zero call-site changes.
- **Decision:** Added a new `--warning` token rather than reusing `--danger` or a raw Tailwind `amber-*` class.
  - **Why:** AC7/AC8 require the destructive color stay reserved for destructive actions. A "this needs attention" indicator (nav health, orchestrator readiness, missing token) is a different semantic than "you're about to do something irreversible" and needed its own token to avoid conflating the two.
  - **Alternatives considered:** Kept raw `amber-500`/`yellow-500` utility classes as-is — rejected because AC1 explicitly calls out inconsistent ad hoc amber usage as the problem.
- **Decision:** Left `TemplateCard.tsx` (custom-prompt template grid) on `Card`.
  - **Why:** It's a genuinely elevated, selectable list-item card in a grid, not a settings-page section shell — a different UI pattern outside this PR's scope.
- **Decision:** Scoped this PR to AC1/AC2/AC6/AC16 rather than attempting all 17 acceptance criteria from #872 in one PR.
  - **Why:** Research showed AC3 (global header removed), AC7/AC8 (destructive color), AC9 (confirmation modals), AC11 (conditional buttons), AC12–14 (nav health indicators + tooltips), and AC17 (no full-width buttons) were already substantially implemented by prior PRs (#878, #879, #880, #919, #949). The remaining open, non-trivial items — extending nav-health coverage to more tabs, and explicitly communicating differing save behaviors (AC10) — are larger, separately-scoped design decisions better suited to their own focused PR/issue rather than inflating this diff.

## Acceptance criteria (from #872)

- [x] AC1 — neutral palette / no ad hoc amber: shared `--warning` token + `SettingsWarningBanner` replace hand-mixed amber/yellow across Orchestrator readiness, Release Channel, and Custom Prompt warnings
- [x] AC2 — cards reduced to dividers: `SettingsSection` no longer renders a `Card`; six more panels migrated off hand-rolled `Card`
- [x] AC6 — consistent button height: removed the `h-7` custom-height "Re-check" button in Orchestrator settings
- [x] AC16 — key-mapping/model-settings patterns reused elsewhere: `SettingsSection` is now the shell for every panel in this PR
- [ ] AC3, AC7, AC8, AC9, AC11, AC15, AC17 — already satisfied by prior PRs (#878/#879/#880/#919/#949); verified, not re-implemented here
- [ ] AC4, AC5 — largely satisfied already; not further audited in this pass
- [ ] AC10, AC12, AC13, AC14 — out of scope for this PR; left for a follow-up (see below)

## Testing

- [x] Unit tests added/updated (`SettingsSection.test.tsx`)
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] Build passes (`npm run build`, root + `src/ui`)
- [x] Tests pass (`658` root/backend + `196` UI = `854` tests, all green)
- [x] Lint / format clean (`npm run lint`, `npm run format` — no diff)

No pre-existing failures encountered on the base branch.

## Screenshots

Not captured in this run (headless environment, no display). The visual result is a straightforward divider-instead-of-card change plus a consistent warning-banner color across the touched panels — reviewable directly from the diff.

## Follow-up items

- Extend `settings-health.ts` nav-indicator coverage (AC12/AC13) beyond the current 3 of 8 tabs (`llm`, `mcp`, `release`) to `general`, `videoHost`, `prompts`, `advanced`, `account`.
- Explicitly communicate differing save behaviors across settings (AC10) — currently a mix of explicit Save buttons, auto-save-on-change, and save-bundled-with-another-action with no visual cue distinguishing them.
- Consider a real `Tooltip` primitive (none exists in the repo yet) if the hand-rolled CSS tooltip in `SettingsNavHealthIndicator` needs to generalize further.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)