### PR TITLE
XS✔ ◾ Enable ssw-rnd plugin for the whole team

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "ssw-rnd-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "sswconsulting/ssw.rnd"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ssw-rnd@ssw-rnd-marketplace": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ tmpclaude*
 # Keep shared, version-controlled Claude Code skills
 !.claude/
 .claude/*
+!.claude/settings.json
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/yakshaver-config/


### PR DESCRIPTION
### 📝 Summary
Commits `.claude/settings.json`, enabling the `ssw-rnd` Claude Code plugin (marketplace `sswconsulting/ssw.rnd`) for everyone working in this repo — provides the `rnd-core-activity`, `rnd-experiment`, `rnd-capture`, and `rnd-submission` skills automatically, instead of each person having to run `/plugin marketplace add` + `/plugin install` themselves.

`.claude/` is otherwise gitignored here except `.claude/skills/yakshaver-config/` — added a single targeted `!.claude/settings.json` exception rather than loosening the broader pattern.

### 🤷‍♂️ Why
We used these skills this sprint to register an R&D Core Activity in this repo (#921) — see the docs scaffold in #958. Without this file committed, only the person who happened to configure it locally gets the skills; anyone else opening this repo in Claude Code doesn't.

### 🧪 Test plan
- Pull this branch, open Claude Code in the repo, run `/reload-plugins` (or start a fresh session) and confirm `ssw-rnd:rnd-core-activity` etc. appear in the available skills.
- Confirm `.claude/skills/yakshaver-config/` and other existing `.claude/` exclusions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)