### PR TITLE
XS⚠️ ◾ fix: don't let a post-EXECUTING_TASK error un-complete the workflow (#306)

### DIFF
--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -46,6 +46,7 @@ import { WorkflowStateManager } from "../services/workflow/workflow-state-manage
 import {
   applyUploadStageOutcome,
   resolveMetadataStage,
+  shouldFailStageOnUnexpectedError,
 } from "../services/workflow/youtube-stage-decisions";
 import { formatAndReportError } from "../utils/error-utils";
 import { IPC_CHANNELS } from "./channels";
@@ -699,49 +700,56 @@ export class ProcessVideoIPCHandlers {
 
         // Send to portal if authenticated and project is remote — non-fatal, does not affect workflow stage status
         // local projects don't have portal project IDs so not sent to portal regardless of auth status
-        if (
-          mcpResult &&
-          projectDetails?.projectSource === "remote" &&
-          projectDetails?.id &&
-          (await IdentityServerAuthService.getInstance().isAuthenticated())
-        ) {
+        //
+        // #306: the authenticated-ness check itself now lives INSIDE the try below (rather than
+        // as an unguarded `await` in this `if` condition). isAuthenticated() currently swallows
+        // its own errors, but evaluating it ahead of the try meant a future change there (or any
+        // other guard added to this condition) could throw with currentStage still pinned at
+        // EXECUTING_TASK, which the outer catch would then incorrectly re-fail. Keeping every
+        // await for this block inside the try removes that class of escape hatch entirely.
+        if (mcpResult && projectDetails?.projectSource === "remote" && projectDetails?.id) {
           try {
-            // Portal serialization uses the OpenAI orchestrator's structured-output helper
-            // regardless of which backend drove the loop (the local Claude backend has no
-            // convertToObjectAsync). This is a separate LLM call from the orchestration step.
-            const portalOrchestrator = await MCPOrchestrator.getInstanceAsync();
-            const objectResult = await portalOrchestrator.convertToObjectAsync(
-              mcpResult,
-              WorkItemDtoSchema,
-            );
-            const workItemDto = WorkItemDtoSchema.parse(objectResult);
-            workItemDto.projectId = projectDetails.id;
-            workItemDto.projectName = projectDetails.name;
+            const isPortalAuthenticated =
+              await IdentityServerAuthService.getInstance().isAuthenticated();
 
-            // #808: The Tenant view renders its preview from the portal payload's video fields.
-            // These were previously left to the LLM to copy out of the system prompt during
-            // structured extraction, which intermittently dropped them — the exact "missing
-            // embedUrl/videoFile" symptom #808 reports. Override them deterministically from the
-            // same authoritative upload result the local backstop uses, so a successful
-            // recording ALWAYS carries the embed URL to the portal regardless of model output.
-            // The override + its skip-on-null behaviour lives in applyPortalVideoFields so the
-            // wiring (and that it fires BEFORE the portal POST) is unit-testable.
-            applyPortalVideoFields(workItemDto, youtubeResult);
+            if (isPortalAuthenticated) {
+              // Portal serialization uses the OpenAI orchestrator's structured-output helper
+              // regardless of which backend drove the loop (the local Claude backend has no
+              // convertToObjectAsync). This is a separate LLM call from the orchestration step.
+              const portalOrchestrator = await MCPOrchestrator.getInstanceAsync();
+              const objectResult = await portalOrchestrator.convertToObjectAsync(
+                mcpResult,
+                WorkItemDtoSchema,
+              );
+              const workItemDto = WorkItemDtoSchema.parse(objectResult);
+              workItemDto.projectId = projectDetails.id;
+              workItemDto.projectName = projectDetails.name;
 
-            const portalResult = await SendWorkItemDetailsToPortal(workItemDto);
-            if (!portalResult.success) {
-              console.warn("[ProcessVideo] Portal submission failed:", portalResult.error);
-              formatAndReportError(portalResult.error, "portal_submission");
-            } else if (shaveId) {
-              const shaveService = ShaveService.getInstance();
-              // Sync the canonical portal data back to the local record so both
-              // stores stay in sync even if the workflow fails after this point.
-              shaveService.updateShave(shaveId, {
-                portalWorkItemId: portalResult.workItemId,
-                title: workItemDto.title,
-                projectName: workItemDto.projectName,
-                workItemUrl: workItemDto.workItemUrl,
-              });
+              // #808: The Tenant view renders its preview from the portal payload's video fields.
+              // These were previously left to the LLM to copy out of the system prompt during
+              // structured extraction, which intermittently dropped them — the exact "missing
+              // embedUrl/videoFile" symptom #808 reports. Override them deterministically from the
+              // same authoritative upload result the local backstop uses, so a successful
+              // recording ALWAYS carries the embed URL to the portal regardless of model output.
+              // The override + its skip-on-null behaviour lives in applyPortalVideoFields so the
+              // wiring (and that it fires BEFORE the portal POST) is unit-testable.
+              applyPortalVideoFields(workItemDto, youtubeResult);
+
+              const portalResult = await SendWorkItemDetailsToPortal(workItemDto);
+              if (!portalResult.success) {
+                console.warn("[ProcessVideo] Portal submission failed:", portalResult.error);
+                formatAndReportError(portalResult.error, "portal_submission");
+              } else if (shaveId) {
+                const shaveService = ShaveService.getInstance();
+                // Sync the canonical portal data back to the local record so both
+                // stores stay in sync even if the workflow fails after this point.
+                shaveService.updateShave(shaveId, {
+                  portalWorkItemId: portalResult.workItemId,
+                  title: workItemDto.title,
+                  projectName: workItemDto.projectName,
+                  workItemUrl: workItemDto.workItemUrl,
+                });
+              }
             }
           } catch (portalError) {
             console.warn("[ProcessVideo] Portal submission error:", portalError);
@@ -751,6 +759,14 @@ export class ProcessVideoIPCHandlers {
       }
 
       if (shouldRunStage(WorkflowProgressStage.UPDATING_METADATA)) {
+        // #306: advance currentStage here too (like every earlier stage does) so an
+        // exception that somehow escapes this block's own try/catch is attributed to
+        // UPDATING_METADATA rather than staying pinned on the already-completed
+        // EXECUTING_TASK — which the outer catch below would otherwise silently flip
+        // back to "failed", permanently blocking isWorkflowReadyForFinalOutput (it
+        // requires executing_task to stay "completed") even though the actual task
+        // (issue creation) already succeeded.
+        currentStage = WorkflowProgressStage.UPDATING_METADATA;
         const videoId = resolveMetadataStage(youtubeResult, workflowManager);
         if (videoId) {
           try {
@@ -802,10 +818,12 @@ export class ProcessVideoIPCHandlers {
       return { success: true, youtubeResult, mcpResult, workflowId };
     } catch (error) {
       const errorMessage = formatAndReportError(error, "video_processing");
-      // Mark the current stage as failed (if not already failed by fault injection)
+      // #306: only mark currentStage as failed if it was genuinely interrupted
+      // mid-flight — see shouldFailStageOnUnexpectedError for why a stage that already
+      // reached "completed"/"skipped" must not be retroactively re-failed here.
       if (currentStage) {
         const stepState = workflowManager.getStepState(currentStage);
-        if (stepState.status !== "failed") {
+        if (shouldFailStageOnUnexpectedError(stepState.status)) {
           workflowManager.failStage(currentStage, errorMessage);
         }
       }

--- a/src/backend/services/workflow/youtube-stage-decisions.test.ts
+++ b/src/backend/services/workflow/youtube-stage-decisions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { ProgressStage } from "../../../shared/types/workflow";
+import { ProgressStage, type WorkflowStatus } from "../../../shared/types/workflow";
 import type { VideoUploadResult } from "../auth/types";
 import {
   applyUploadStageOutcome,
@@ -7,6 +7,7 @@ import {
   resolveMetadataStage,
   resolveUploadFailureMessage,
   type StageSink,
+  shouldFailStageOnUnexpectedError,
   uploadSucceeded,
 } from "./youtube-stage-decisions";
 
@@ -171,5 +172,39 @@ describe("resolveMetadataStage (#798 — routes the Updating Metadata stage)", (
 
     expect(videoId).toBeNull();
     expect(sink.skipStage).toHaveBeenCalledWith(ProgressStage.UPDATING_METADATA);
+  });
+});
+
+describe("shouldFailStageOnUnexpectedError (#306 — outer catch must not un-complete a finished stage)", () => {
+  it("re-fails a stage that was genuinely interrupted mid-flight (in_progress)", () => {
+    expect(shouldFailStageOnUnexpectedError("in_progress")).toBe(true);
+  });
+
+  it("fails a stage that never even started (not_started) — the error happened before it began", () => {
+    expect(shouldFailStageOnUnexpectedError("not_started")).toBe(true);
+  });
+
+  it("does NOT re-fail a stage that already completed — a later, unrelated error must not silently un-complete a real success (#306)", () => {
+    expect(shouldFailStageOnUnexpectedError("completed")).toBe(false);
+  });
+
+  it("does NOT re-fail a stage that was already skipped", () => {
+    expect(shouldFailStageOnUnexpectedError("skipped")).toBe(false);
+  });
+
+  it("does NOT re-fail a stage that already failed (fault injection / earlier failure already recorded)", () => {
+    expect(shouldFailStageOnUnexpectedError("failed")).toBe(false);
+  });
+
+  it("covers every WorkflowStatus value so a future status can't silently change behaviour unnoticed", () => {
+    const allStatuses: WorkflowStatus[] = [
+      "not_started",
+      "in_progress",
+      "completed",
+      "failed",
+      "skipped",
+    ];
+    const results = allStatuses.map((status) => shouldFailStageOnUnexpectedError(status));
+    expect(results).toEqual([true, true, false, false, false]);
   });
 });

--- a/src/backend/services/workflow/youtube-stage-decisions.test.ts
+++ b/src/backend/services/workflow/youtube-stage-decisions.test.ts
@@ -197,14 +197,20 @@ describe("shouldFailStageOnUnexpectedError (#306 — outer catch must not un-com
   });
 
   it("covers every WorkflowStatus value so a future status can't silently change behaviour unnoticed", () => {
-    const allStatuses: WorkflowStatus[] = [
-      "not_started",
-      "in_progress",
-      "completed",
-      "failed",
-      "skipped",
-    ];
-    const results = allStatuses.map((status) => shouldFailStageOnUnexpectedError(status));
-    expect(results).toEqual([true, true, false, false, false]);
+    const decisions = {
+      not_started: shouldFailStageOnUnexpectedError("not_started"),
+      in_progress: shouldFailStageOnUnexpectedError("in_progress"),
+      completed: shouldFailStageOnUnexpectedError("completed"),
+      failed: shouldFailStageOnUnexpectedError("failed"),
+      skipped: shouldFailStageOnUnexpectedError("skipped"),
+    } satisfies Record<WorkflowStatus, boolean>;
+
+    expect(decisions).toEqual({
+      not_started: true,
+      in_progress: true,
+      completed: false,
+      failed: false,
+      skipped: false,
+    });
   });
 });

--- a/src/backend/services/workflow/youtube-stage-decisions.ts
+++ b/src/backend/services/workflow/youtube-stage-decisions.ts
@@ -1,6 +1,7 @@
 import {
   ProgressStage as WorkflowProgressStage,
   type WorkflowState,
+  type WorkflowStatus,
 } from "../../../shared/types/workflow";
 import type { VideoUploadResult } from "../auth/types";
 
@@ -87,4 +88,24 @@ export function resolveMetadataStage(result: VideoUploadResult, sink: StageSink)
     return null;
   }
   return videoId;
+}
+
+/**
+ * #306: whether the outer `processVideoSource` catch-all should mark `currentStage` as
+ * failed for an exception that escaped every stage's own local try/catch.
+ *
+ * `currentStage` tracks "the stage this function was last working on", but a stage can
+ * have already reached a genuinely terminal, non-error status ("completed" or "skipped")
+ * by the time an unrelated LATER exception (e.g. a network blip in a best-effort,
+ * non-fatal step that runs after the stage finished) bubbles up to the outer catch. Only
+ * a stage still "in_progress" (actively being worked on) or "not_started" (never even
+ * reached its own startStage/updateStagePayload call) represents the stage that was
+ * genuinely interrupted by the error — re-failing it is correct. Re-failing a stage that
+ * already reported "completed" or "skipped" would silently erase a real success (e.g. a
+ * work item that was genuinely created) and — since the UI's isWorkflowReadyForFinalOutput
+ * requires `executing_task` to stay "completed" — permanently hide the Final Result panel
+ * for a run that actually succeeded.
+ */
+export function shouldFailStageOnUnexpectedError(currentStatus: WorkflowStatus): boolean {
+  return currentStatus === "in_progress" || currentStatus === "not_started";
 }


### PR DESCRIPTION
## Summary

After creating a YakShaver issue from a video, the app could show **"failed after 3 attempts - cannot connect to API"** and never show the Final Result panel — even though the issue was created and the YouTube metadata had genuinely been updated. A maintainer noted the "Updating Metadata" step never got its ✅ checkmark despite the metadata actually being applied.

Closes #306

## Root cause

In `src/backend/ipc/process-video-handlers.ts`, `processVideoSource` tracks a local `currentStage` variable that is advanced at the start of every stage (`CONVERTING_AUDIO`, `TRANSCRIBING`, … `EXECUTING_TASK`) so the outer `catch` can attribute an escaping error to the right stage. **It was never advanced to `UPDATING_METADATA`.**

So once `EXECUTING_TASK` completed (the issue was created), `currentStage` stayed pinned at `EXECUTING_TASK` for the rest of the run — through the best-effort portal submission and the YouTube metadata update. If *any* exception escaped to the outer `catch` during that window (e.g. a `googleapis`/`gaxios` network call that gives up after its default 3 retries — exactly "failed after 3 attempts" — during the metadata update, or an equivalent transient failure in the non-fatal portal submission), the outer catch did:

```ts
if (currentStage) {
  const stepState = workflowManager.getStepState(currentStage);
  if (stepState.status !== "failed") {
    workflowManager.failStage(currentStage, errorMessage);
  }
}
```

Since `currentStage` was still `"executing_task"` and that stage's status was `"completed"` (not `"failed"`), this **silently flipped a genuinely-completed `EXECUTING_TASK` back to `"failed"`** — even though the backlog item had already been created. The renderer's `isWorkflowReadyForFinalOutput` (`src/ui/src/utils/index.ts`) requires `executing_task.status === "completed"` before it will ever show the Final Result panel, so this single mis-attribution both:
- explains why the metadata step's checkmark was missing (the run errored out before/around that stage even though the YouTube API call itself may have already gone through), and
- explains why the Final Result panel never appeared (the completed `EXECUTING_TASK` stage had been silently un-completed).

This is the same class of "silent success masked as failure" bug this codebase has fixed before for the upload/metadata stages (#672, #861, #808) — this time for the outer catch's stage attribution itself.

## Fix

1. **Advance `currentStage` to `UPDATING_METADATA`** right before that stage's block runs, mirroring every other stage. Any stray exception in that region is now correctly attributed to `UPDATING_METADATA` (which the UI already tolerates as a terminal "failed" state) instead of the unrelated, already-completed `EXECUTING_TASK`.
2. **Removed an unguarded `await`** from the portal-submission `if` condition (`IdentityServerAuthService...isAuthenticated()` was evaluated ahead of that block's own `try`). It's now the first line inside the `try`, closing a structural gap where a future change to that method (or condition) could throw with `currentStage` still stuck at `EXECUTING_TASK`.
3. **Hardened the outer catch** with a new pure helper, `shouldFailStageOnUnexpectedError` (`src/backend/services/workflow/youtube-stage-decisions.ts`): only re-fail a stage that was genuinely `"in_progress"` or `"not_started"` when the error hit. A stage that already reached `"completed"` or `"skipped"` is never retroactively re-failed by an unrelated, later error. This closes the *class* of bug (not just today's known call sites) so a future stage that forgets to advance `currentStage` can't reproduce this again.

## Bug repro evidence

I reproduced the panel-gating logic directly with a throwaway React Testing Library test against `FinalResultPanel`, confirming the pure UI state machine correctly shows the panel once `updating_metadata` reaches *any* terminal status (including `"failed"`). That ruled out the UI layer and pointed the investigation squarely at the backend's stage bookkeeping.

I then traced the exact code path: `metadataBuilder.build()` and `youtube.updateVideoMetadata()` calls are correctly wrapped by their own local try/catch and do fail the metadata stage cleanly on their own — but `currentStage` never reaching `UPDATING_METADATA` meant the *outer* catch was the actual defect: it could re-fail `EXECUTING_TASK` behind the scenes whenever anything else in that later window threw, independent of which specific dependency (portal submission, YouTube API, or an LLM call) was the trigger. Confirmed via `googleapis-common`'s `apirequest.js` (`options.retry = true` by default) + `gaxios`'s default `retry: 3` / `noResponseRetries: 2` config that a YouTube API call genuinely does give up after 3 attempts on a network blip, matching the reported error text.

Since a full end-to-end repro requires simulating an Electron main-process video-processing run with mocked Google/LLM/portal APIs, I instead added regression coverage at the same seam the codebase already uses for this kind of stage-routing logic (`youtube-stage-decisions.ts`, home of `applyUploadStageOutcome`/`resolveMetadataStage` from #672/#798): `shouldFailStageOnUnexpectedError` is unit-tested against every `WorkflowStatus` value, proving a stage that already completed/skipped is never re-failed while one still in-flight correctly still is.

## Testing performed

- `npm run build` — clean
- `npx vitest run --reporter=verbose --exclude 'src/ui/**'` — 690 passed (67 files), including new `shouldFailStageOnUnexpectedError` coverage
- `npm --prefix src/ui test` — 228 passed (32 files)
- `npm run lint` — clean

## Files changed

- `src/backend/ipc/process-video-handlers.ts` — advance `currentStage`, move the auth check inside its try, use the new helper in the outer catch
- `src/backend/services/workflow/youtube-stage-decisions.ts` — new `shouldFailStageOnUnexpectedError` helper
- `src/backend/services/workflow/youtube-stage-decisions.test.ts` — regression tests for the new helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)