### PR TITLE
XS✔ ◾ Remove dead My Shaves portal IPC surface that leaked raw JSON (#454)

### DIFF
--- a/src/backend/ipc/channels.ts
+++ b/src/backend/ipc/channels.ts
@@ -114,7 +114,6 @@ export const IPC_CHANNELS = {
   PROTOCOL_ERROR: "protocol:error",
 
   // Portal API
-  PORTAL_GET_MY_SHAVES: "portal:get-my-shaves",
   PORTAL_GET_MY_PROJECTS: "portal:get-my-projects",
   PORTAL_CANCEL_WORK_ITEM: "portal:cancel-work-item",
 

--- a/src/backend/ipc/portal-handlers.ts
+++ b/src/backend/ipc/portal-handlers.ts
@@ -1,80 +1,12 @@
-import https from "node:https";
 import type { GetMyProjectsResponse } from "@shared/types/portal";
 import { ipcMain } from "electron";
 import { config } from "../config/env";
 import type { IdentityServerAuthService } from "../services/auth/identity-server-auth";
 import { fetchProjectSummaries, mapProjectsResponse } from "../services/portal/portal-projects";
-import type { GetMyShavesResponse } from "../types";
 import { formatAndReportError } from "../utils/error-utils";
 import { IPC_CHANNELS } from "./channels";
 
 export function registerPortalHandlers(identityServerAuthService: IdentityServerAuthService) {
-  ipcMain.handle(IPC_CHANNELS.PORTAL_GET_MY_SHAVES, async () => {
-    try {
-      const accessToken = await identityServerAuthService.getAccessToken();
-      if (!accessToken) {
-        return { success: false, error: "Failed to obtain access token" };
-      }
-
-      // Parse the portal API URL
-      const apiUrl = config.portalApiUrl();
-      const url = new URL(apiUrl);
-      const hostname = url.hostname;
-      const port = url.port ? parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80;
-      const path = `${url.pathname.replace(/\/$/, "")}/me/shaves`; // Ensure no double slashes
-
-      // Make API call to get user's shaves using HTTPS module for SSL certificate handling
-      const data = await new Promise<GetMyShavesResponse>((resolve, reject) => {
-        const options = {
-          hostname: hostname,
-          port: port,
-          path: path,
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/json",
-          },
-        };
-
-        const req = https.request(options, (res) => {
-          let responseData = "";
-
-          res.on("data", (chunk) => {
-            responseData += chunk;
-          });
-
-          res.on("end", () => {
-            if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-              try {
-                const parsedData = JSON.parse(responseData);
-                resolve(parsedData);
-              } catch (error) {
-                reject(
-                  new Error(
-                    `Failed to parse JSON response: ${formatAndReportError(error, "portal_api")}`,
-                  ),
-                );
-              }
-            } else {
-              reject(new Error(`API call failed: ${res.statusCode} ${res.statusMessage}`));
-            }
-          });
-        });
-
-        req.on("error", (error) => {
-          reject(error);
-        });
-
-        req.end();
-      });
-
-      return { success: true, data };
-    } catch (error) {
-      console.error("Portal API error:", formatAndReportError(error, "portal_api"));
-      return { success: false, error: formatAndReportError(error, "portal_api") };
-    }
-  });
-
   // #816: list the signed-in user's projects, sourced from the portal endpoint
   // GET {portalApiUrl}/projects/summaries — the same project list the remote-prompts feature
   // already consumes in production. NOTE: that endpoint is tenant/organisation-scoped (every

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -130,7 +130,6 @@ const IPC_CHANNELS = {
   PROTOCOL_ERROR: "protocol:error",
 
   // Portal API
-  PORTAL_GET_MY_SHAVES: "portal:get-my-shaves",
   PORTAL_GET_MY_PROJECTS: "portal:get-my-projects",
   PORTAL_CANCEL_WORK_ITEM: "portal:cancel-work-item",
 
@@ -385,7 +384,6 @@ const electronAPI = {
       onIpcEvent<string>(IPC_CHANNELS.PROTOCOL_ERROR, callback),
   },
   portal: {
-    getMyShaves: () => ipcRenderer.invoke(IPC_CHANNELS.PORTAL_GET_MY_SHAVES),
     getMyProjects: () => ipcRenderer.invoke(IPC_CHANNELS.PORTAL_GET_MY_PROJECTS),
     cancelWorkItem: (workItemId: string) =>
       ipcRenderer.invoke(IPC_CHANNELS.PORTAL_CANCEL_WORK_ITEM, workItemId),

--- a/src/backend/types/index.ts
+++ b/src/backend/types/index.ts
@@ -83,24 +83,6 @@ export enum VideoSourceType {
   EXTERNAL_URL = "external_url",
 }
 
-export interface ShaveItem {
-  id: string;
-  title: string;
-  videoFile: VideoFile;
-  updatedAt: string;
-  createdAt: string;
-  shaveStatus: string;
-  workItemType: string;
-  projectName: string;
-  workItemUrl: string;
-  feedback: string | null;
-  videoEmbedUrl: string;
-}
-
-export interface GetMyShavesResponse {
-  items: ShaveItem[];
-}
-
 // Portal-projects types (#816) are shared between the backend and the UI, so per
 // AGENTS.md Rule 9 they live in `@shared/types/portal`. Re-exported here for the
 // backend's existing `../types` import sites.

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -21,7 +21,6 @@ import type {
   CustomPrompt,
   GetMyProjectsErrorCode,
   GetMyProjectsResponse,
-  GetMyShavesResponse,
   HealthStatusInfo,
   MCPStep,
   ScreenRecordingStartResult,
@@ -246,11 +245,6 @@ declare global {
         onProtocolError: (callback: (message: string) => void) => () => void;
       };
       portal: {
-        getMyShaves: () => Promise<{
-          success: boolean;
-          data?: GetMyShavesResponse;
-          error?: string;
-        }>;
         getMyProjects: () => Promise<{
           success: boolean;
           data?: GetMyProjectsResponse;

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -187,24 +187,6 @@ export interface VideoFile {
   isChromeExtension: boolean;
 }
 
-export interface ShaveItem {
-  id: string;
-  title: string;
-  videoFile: VideoFile;
-  updatedAt: string;
-  createdAt: string;
-  shaveStatus: string;
-  workItemType: string;
-  projectName: string;
-  workItemUrl: string;
-  feedback: string | null;
-  videoEmbedUrl: string;
-}
-
-export interface GetMyShavesResponse {
-  items: ShaveItem[];
-}
-
 // Portal-projects types (#816) are shared between the backend and the UI, so per
 // AGENTS.md Rule 9 they live in `@shared/types/portal`. Re-exported here for the
 // UI's existing `../types` import sites.


### PR DESCRIPTION
## Summary

After signing in and clicking "My Shave(s)" in an older Desktop build, users saw a raw JSON payload instead of a formatted UI (see attached screenshot/video on #454). Investigating on `main` today:

- The **current** "Shaves" page (`HomePage.tsx`, routed at `/`) already renders a proper table/card UI, sourced from the local database via `shave.getAll()` — this was the fix delivered by PR #830 ("change My Shaves list to use local database").
- However, the **old** `portal:get-my-shaves` IPC handler that #830 replaced was never removed. It still exists end-to-end (IPC channel, `ipcMain.handle`, preload binding, and `GetMyShavesResponse`/`ShaveItem` types) and returns the raw parsed `/me/shaves` API response as-is, with no formatting.
- That handler is **dead code** today — no component in the current UI calls `ipcClient.portal.getMyShaves()` (confirmed via repo-wide search; its sibling `getMyProjects` *is* consumed by `ProjectsPage.tsx`, for contrast). The screenshot on #454 is from an older build (pre-#815 top-nav layout) whose "My Shaves" button evidently called this raw endpoint directly.

Since the handler is unreachable from any current UI action, the literal repro no longer happens on `main`. But leaving unused code that dumps a raw API payload lying around is exactly the "unfinished feature exposed" risk the issue calls out — it could get wired back up by accident. This PR removes it entirely so that can't happen.

## Changes

- `src/backend/ipc/channels.ts` — remove `PORTAL_GET_MY_SHAVES` channel constant
- `src/backend/ipc/portal-handlers.ts` — remove the `ipcMain.handle(PORTAL_GET_MY_SHAVES, ...)` block and its now-unused `https`/`GetMyShavesResponse` imports
- `src/backend/preload.ts` — remove the channel constant and `portal.getMyShaves` bridge binding
- `src/backend/types/index.ts`, `src/ui/src/types/index.ts` — remove the now-unused `ShaveItem`/`GetMyShavesResponse` types
- `src/ui/src/services/ipc-client.ts` — remove the `portal.getMyShaves` type declaration and its import

No behavior change to the real "My Shaves" page — it never used this handler.

## Testing performed

- `npm run build` — clean (tsc, no dangling references)
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run --reporter=verbose --exclude 'src/ui/**'` — 691/691 tests passed
- `npm --prefix src/ui install && npm --prefix src/ui test` — 255/255 tests passed
- `npm run lint` — clean (one pre-existing, unrelated info-level note in `Cloud360LiveView.tsx`, not touched by this change)
- Repo-wide grep confirms zero remaining references to `PORTAL_GET_MY_SHAVES`, `getMyShaves`, `GetMyShavesResponse`, `ShaveItem`

Closes #454