### PR TITLE
XS✔ ◾ fix: stop update-ready reminder from re-popping and stacking within a session

### DIFF
--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 // Keep Electron, the real autoUpdater, and encrypted storage out of this unit test — we're
-// exercising the token-health gating logic in ReleaseChannelIPCHandlers (#919), not Electron
-// itself.
+// exercising both the token-health gating logic (#919) and the update-ready reminder dialog's
+// anti-stacking guard behavior (#456) in ReleaseChannelIPCHandlers, driven via mocked
+// Electron/autoUpdater listeners rather than the real Electron runtime.
 const showMessageBoxMock = vi.fn().mockResolvedValue({ response: 1 });
 vi.mock("electron", () => ({
   app: {
@@ -425,12 +426,13 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
   });
 
   it("releases the guard after the dialog settles so a later legitimate event is handled normally", async () => {
-    // Directly pins the .finally() reset behavior (review on #456): once the first dialog settles
-    // and releases isUpdateDialogOpen, a subsequent update-downloaded event must show its own
-    // dialog rather than being treated as a stack-on-top of a still-open one. Uses the dialog
-    // timeout fallback (rather than a "Restart Now"/"Later" response) so the guard's own release
-    // is what's under test, not short-circuited by updateDialogDismissedInSession or
-    // isRestartingToInstall — neither of which the timeout path touches.
+    // Directly pins the watchdog-timeout reset behavior (review on #456): once the first dialog's
+    // bounded watchdog fires and releases isUpdateDialogOpen, a subsequent update-downloaded event
+    // must show its own dialog rather than being treated as a stack-on-top of a still-open one.
+    // Uses the dialog timeout fallback (rather than a "Restart Now"/"Later" response) so the
+    // guard's own release is what's under test, not short-circuited by
+    // updateDialogDismissedInSession or isRestartingToInstall — neither of which the timeout path
+    // touches.
     vi.useFakeTimers();
     try {
       showMessageBoxMock.mockImplementation(() => new Promise(() => {})); // never settles
@@ -440,13 +442,71 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
       emitAutoUpdaterEvent("update-downloaded");
       expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
 
-      // Let the dialog's bounded timeout fallback fire, releasing isUpdateDialogOpen.
+      // Let the dialog's bounded watchdog fire, releasing isUpdateDialogOpen.
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
 
       // A later legitimate event must now be handled normally — a second dialog is shown, proving
       // isUpdateDialogOpen was released rather than left stuck true.
       emitAutoUpdaterEvent("update-downloaded");
       expect(showMessageBoxMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still honors the original dialog's real answer after the watchdog timeout releases the guard, without disturbing a newer dialog (#456 blocking fix)", async () => {
+    // Pins the blocking fix directly (review on #456): the old Promise.race implementation
+    // attached .then/.finally to the RACE, not to the real dialogPromise, so once the 5-minute
+    // timeout "won" (a) the guard reset while the original, uncancellable native dialog was still
+    // on screen — reopening the stacking bug once a third event landed — and (b) the user's
+    // eventual real click on that original dialog fired no callback at all (silently dropped).
+    //
+    // Scenario: dialog 1 hangs past its watchdog (guard releases) -> dialog 2 opens for a new
+    // event -> dialog 1's ORIGINAL promise finally resolves with "Later". Assert dialog 1's late
+    // response is still honored (updateDialogDismissedInSession flips) AND that honoring it does
+    // not incorrectly reset the guard out from under dialog 2, which is still open and unanswered.
+    // (Resolving dialog 1 with "Later" rather than "Restart Now" keeps this test isolated from the
+    // separate isRestartingToInstall short-circuit, which would otherwise also suppress a 4th
+    // event and make the guard-not-clobbered assertion below inconclusive.)
+    vi.useFakeTimers();
+    try {
+      let resolveFirstDialog: ((result: { response: number }) => void) | undefined;
+      showMessageBoxMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstDialog = resolve;
+          }),
+      );
+
+      new ReleaseChannelIPCHandlers();
+
+      // Dialog 1 opens and hangs.
+      emitAutoUpdaterEvent("update-downloaded");
+      expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+
+      // Its watchdog fires, releasing the guard for future events — but dialog 1 itself is still
+      // open on screen (native dialogs can't be cancelled) and its promise is still pending.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
+
+      // A third event now lands and opens dialog 2 (never settles either, for this test).
+      showMessageBoxMock.mockImplementationOnce(() => new Promise(() => {}));
+      emitAutoUpdaterEvent("update-downloaded");
+      expect(showMessageBoxMock).toHaveBeenCalledTimes(2);
+
+      // Dialog 1's ORIGINAL promise finally resolves — the user clicked "Later" on the
+      // stale-but-still-real dialog well after the timeout warning fired. Flush dialog 1's
+      // .then/.finally microtasks under fake timers before asserting.
+      resolveFirstDialog?.({ response: 1 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The late response must still be honored — dialog 1's own "Later" branch ran even though
+      // its watchdog already fired — and it must NOT have clobbered the guard state for dialog 2,
+      // which is still legitimately open and unanswered. A fourth event landing right now must
+      // still be suppressed as a stack-on-top of dialog 2, proving dialog 1's late .finally() did
+      // not incorrectly flip isUpdateDialogOpen back to false out from under dialog 2.
+      showMessageBoxMock.mockClear();
+      emitAutoUpdaterEvent("update-downloaded");
+      expect(showMessageBoxMock).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vite
 // Keep Electron, the real autoUpdater, and encrypted storage out of this unit test — we're
 // exercising the token-health gating logic in ReleaseChannelIPCHandlers (#919), not Electron
 // itself.
+const showMessageBoxMock = vi.fn().mockResolvedValue({ response: 1 });
 vi.mock("electron", () => ({
   app: {
     getName: () => "YakShaver",
@@ -10,12 +11,25 @@ vi.mock("electron", () => ({
     isPackaged: true,
   },
   BrowserWindow: { getAllWindows: () => [] },
-  dialog: { showMessageBox: vi.fn().mockResolvedValue({ response: 1 }) },
+  dialog: { showMessageBox: (...args: unknown[]) => showMessageBoxMock(...args) },
   ipcMain: { handle: vi.fn() },
 }));
 
 const checkForUpdatesMock = vi.fn();
 const setFeedURLMock = vi.fn();
+// Capture registered autoUpdater listeners (keyed by event name) so tests can fire events like
+// "update-downloaded" directly, the same way the real electron-updater instance would (#456).
+const autoUpdaterListeners = new Map<string, Array<(...args: unknown[]) => void>>();
+const autoUpdaterOnMock = vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+  const listeners = autoUpdaterListeners.get(event) ?? [];
+  listeners.push(listener);
+  autoUpdaterListeners.set(event, listeners);
+});
+function emitAutoUpdaterEvent(event: string, ...args: unknown[]) {
+  for (const listener of autoUpdaterListeners.get(event) ?? []) {
+    listener(...args);
+  }
+}
 vi.mock("electron-updater", () => ({
   autoUpdater: {
     autoDownload: false,
@@ -24,7 +38,7 @@ vi.mock("electron-updater", () => ({
     allowPrerelease: false,
     allowDowngrade: false,
     requestHeaders: {},
-    on: vi.fn(),
+    on: (...args: [string, (...a: unknown[]) => void]) => autoUpdaterOnMock(...args),
     setFeedURL: (...args: unknown[]) => setFeedURLMock(...args),
     checkForUpdates: (...args: unknown[]) => checkForUpdatesMock(...args),
   },
@@ -371,5 +385,55 @@ describe("ReleaseChannelIPCHandlers — PR releases require a healthy GitHub tok
     // verifyGitHubToken is never even consulted for the stable channel.
     expect(verifyGitHubTokenMock).not.toHaveBeenCalled();
     expect(result).toEqual({ available: false, currentVersion: "1.2.3" });
+  });
+});
+
+describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    autoUpdaterListeners.clear();
+    showMessageBoxMock.mockReset();
+  });
+
+  it("does not stack a second reminder dialog while the first is still awaiting a response", async () => {
+    // The reported bug's second half: "If the reminder dialog is open already, a subsequent
+    // update check should not open another reminder dialog on top of it." Simulate the first
+    // dialog's promise never resolving (user hasn't answered yet) and fire a second
+    // "update-downloaded" event (e.g. the periodic background check landing mid-dialog) — only one
+    // dialog must ever be shown.
+    let resolveFirstDialog: ((result: { response: number }) => void) | undefined;
+    showMessageBoxMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstDialog = resolve;
+        }),
+    );
+
+    new ReleaseChannelIPCHandlers();
+
+    emitAutoUpdaterEvent("update-downloaded");
+    emitAutoUpdaterEvent("update-downloaded");
+
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+
+    // Resolve the first dialog so the test doesn't leave a dangling promise.
+    resolveFirstDialog?.({ response: 1 });
+  });
+
+  it("does not show a reminder again this session after the user clicks Later — the originally reported bug", async () => {
+    // The reported bug's first half: clicking "Remind me later" must stop further reminders for
+    // the rest of the current session, even when the periodic ~10-minute check fires again.
+    showMessageBoxMock.mockResolvedValue({ response: 1 }); // 1 = "Later"
+
+    new ReleaseChannelIPCHandlers();
+
+    emitAutoUpdaterEvent("update-downloaded");
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    // Simulate the periodic check finding the same update again later in the session.
+    emitAutoUpdaterEvent("update-downloaded");
+    emitAutoUpdaterEvent("update-downloaded");
+
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -454,21 +454,23 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
     }
   });
 
-  it("still honors the original dialog's real answer after the watchdog timeout releases the guard, without disturbing a newer dialog (#456 blocking fix)", async () => {
-    // Pins the blocking fix directly (review on #456): the old Promise.race implementation
-    // attached .then/.finally to the RACE, not to the real dialogPromise, so once the 5-minute
-    // timeout "won" (a) the guard reset while the original, uncancellable native dialog was still
-    // on screen — reopening the stacking bug once a third event landed — and (b) the user's
-    // eventual real click on that original dialog fired no callback at all (silently dropped).
+  it("ignores the original dialog's late answer once superseded by a newer dialog, and does not disturb the newer dialog (#456 blocking fix, review round 3)", async () => {
+    // Pins the blocking fix directly (review on #456, round 3): the .then() handler must check
+    // requestId before acting on a resolved dialog's result, exactly like .finally() already does.
+    // Without that check, dialog 1's late click could silently flip updateDialogDismissedInSession
+    // (or worse, trigger quitAndInstall on "Restart Now") out from under dialog 2, which is a
+    // different, currently-open dialog the user hasn't answered yet — reintroducing a variant of
+    // the original stacking bug at the "whose answer wins" layer instead of the "which dialog
+    // opens" layer.
     //
-    // Scenario: dialog 1 hangs past its watchdog (guard releases) -> dialog 2 opens for a new
-    // event -> dialog 1's ORIGINAL promise finally resolves with "Later". Assert dialog 1's late
-    // response is still honored (updateDialogDismissedInSession flips) AND that honoring it does
-    // not incorrectly reset the guard out from under dialog 2, which is still open and unanswered.
-    // (Resolving dialog 1 with "Later" rather than "Restart Now" keeps this test isolated from the
-    // separate isRestartingToInstall short-circuit, which would otherwise also suppress a 4th
-    // event and make the guard-not-clobbered assertion below inconclusive.)
+    // Scenario: dialog 1 hangs past its watchdog (guard releases, requestId is now stale for
+    // dialog 1) -> dialog 2 opens for a new event (claims the current requestId) -> dialog 1's
+    // ORIGINAL promise finally resolves with "Later". Assert dialog 1's late response is IGNORED
+    // (updateDialogDismissedInSession stays false) and dialog 2's guard state is undisturbed — a
+    // subsequent event is still suppressed as a stack-on-top of the still-open, still-unanswered
+    // dialog 2.
     vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       let resolveFirstDialog: ((result: { response: number }) => void) | undefined;
       showMessageBoxMock.mockImplementationOnce(
@@ -478,7 +480,9 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
           }),
       );
 
-      new ReleaseChannelIPCHandlers();
+      const handlers = new ReleaseChannelIPCHandlers() as unknown as {
+        updateDialogDismissedInSession: boolean;
+      };
 
       // Dialog 1 opens and hangs.
       emitAutoUpdaterEvent("update-downloaded");
@@ -488,26 +492,37 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
       // open on screen (native dialogs can't be cancelled) and its promise is still pending.
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
 
-      // A third event now lands and opens dialog 2 (never settles either, for this test).
+      // A third event now lands and opens dialog 2 (never settles either, for this test). Dialog 2
+      // now owns the current requestId.
       showMessageBoxMock.mockImplementationOnce(() => new Promise(() => {}));
       emitAutoUpdaterEvent("update-downloaded");
       expect(showMessageBoxMock).toHaveBeenCalledTimes(2);
 
       // Dialog 1's ORIGINAL promise finally resolves — the user clicked "Later" on the
-      // stale-but-still-real dialog well after the timeout warning fired. Flush dialog 1's
-      // .then/.finally microtasks under fake timers before asserting.
+      // stale-but-still-real dialog well after the timeout warning fired and after dialog 2 opened.
+      // Flush dialog 1's .then/.finally microtasks under fake timers before asserting.
       resolveFirstDialog?.({ response: 1 });
       await vi.advanceTimersByTimeAsync(0);
 
-      // The late response must still be honored — dialog 1's own "Later" branch ran even though
-      // its watchdog already fired — and it must NOT have clobbered the guard state for dialog 2,
-      // which is still legitimately open and unanswered. A fourth event landing right now must
-      // still be suppressed as a stack-on-top of dialog 2, proving dialog 1's late .finally() did
-      // not incorrectly flip isUpdateDialogOpen back to false out from under dialog 2.
+      // Dialog 1's late response must be IGNORED, not honored: it no longer owns the current
+      // requestId (dialog 2 does), so it must not flip session-wide state out from under dialog 2.
+      // Asserting this directly (rather than only inferring it from suppression below, which
+      // isUpdateDialogOpen alone could also explain) is what actually pins the requestId guard on
+      // .then() — this is the assertion the pre-fix code would fail, since it honored the late
+      // response unconditionally.
+      expect(handlers.updateDialogDismissedInSession).toBe(false);
+      expect(showMessageBoxMock).toHaveBeenCalledTimes(2); // no third dialog was opened
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("superseded by a newer dialog"));
+
+      // Dialog 2's guard state must also be undisturbed by dialog 1's late (ignored) resolution: a
+      // fourth event landing right now must still be suppressed as a stack-on-top of dialog 2,
+      // proving dialog 1's late .then()/.finally() did not incorrectly flip isUpdateDialogOpen out
+      // from under dialog 2, which is still legitimately open and unanswered.
       showMessageBoxMock.mockClear();
       emitAutoUpdaterEvent("update-downloaded");
       expect(showMessageBoxMock).not.toHaveBeenCalled();
     } finally {
+      warnSpy.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -425,14 +425,7 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
     await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
   });
 
-  it("releases the guard after the dialog settles so a later legitimate event is handled normally", async () => {
-    // Directly pins the watchdog-timeout reset behavior (review on #456): once the first dialog's
-    // bounded watchdog fires and releases isUpdateDialogOpen, a subsequent update-downloaded event
-    // must show its own dialog rather than being treated as a stack-on-top of a still-open one.
-    // Uses the dialog timeout fallback (rather than a "Restart Now"/"Later" response) so the
-    // guard's own release is what's under test, not short-circuited by
-    // updateDialogDismissedInSession or isRestartingToInstall — neither of which the timeout path
-    // touches.
+  it("keeps suppressing duplicate reminders while a long-running dialog remains open", async () => {
     vi.useFakeTimers();
     try {
       showMessageBoxMock.mockImplementation(() => new Promise(() => {})); // never settles
@@ -442,88 +435,33 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
       emitAutoUpdaterEvent("update-downloaded");
       expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
 
-      // Let the dialog's bounded watchdog fire, releasing isUpdateDialogOpen.
-      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
+      // Advance beyond both the removed five-minute watchdog and the ten-minute update interval.
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
 
-      // A later legitimate event must now be handled normally — a second dialog is shown, proving
-      // isUpdateDialogOpen was released rather than left stuck true.
+      // The original native dialog is still visible, so another event must remain suppressed.
       emitAutoUpdaterEvent("update-downloaded");
-      expect(showMessageBoxMock).toHaveBeenCalledTimes(2);
+      expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("ignores the original dialog's late answer once superseded by a newer dialog, and does not disturb the newer dialog (#456 blocking fix, review round 3)", async () => {
-    // Pins the blocking fix directly (review on #456, round 3): the .then() handler must check
-    // requestId before acting on a resolved dialog's result, exactly like .finally() already does.
-    // Without that check, dialog 1's late click could silently flip updateDialogDismissedInSession
-    // (or worse, trigger quitAndInstall on "Restart Now") out from under dialog 2, which is a
-    // different, currently-open dialog the user hasn't answered yet — reintroducing a variant of
-    // the original stacking bug at the "whose answer wins" layer instead of the "which dialog
-    // opens" layer.
-    //
-    // Scenario: dialog 1 hangs past its watchdog (guard releases, requestId is now stale for
-    // dialog 1) -> dialog 2 opens for a new event (claims the current requestId) -> dialog 1's
-    // ORIGINAL promise finally resolves with "Later". Assert dialog 1's late response is IGNORED
-    // (updateDialogDismissedInSession stays false) and dialog 2's guard state is undisturbed — a
-    // subsequent event is still suppressed as a stack-on-top of the still-open, still-unanswered
-    // dialog 2.
-    vi.useFakeTimers();
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("releases the guard after a dialog error so a later event can retry", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    showMessageBoxMock
+      .mockRejectedValueOnce(new Error("dialog failed"))
+      .mockImplementationOnce(() => new Promise(() => {}));
+
     try {
-      let resolveFirstDialog: ((result: { response: number }) => void) | undefined;
-      showMessageBoxMock.mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveFirstDialog = resolve;
-          }),
-      );
+      new ReleaseChannelIPCHandlers();
 
-      const handlers = new ReleaseChannelIPCHandlers() as unknown as {
-        updateDialogDismissedInSession: boolean;
-      };
-
-      // Dialog 1 opens and hangs.
       emitAutoUpdaterEvent("update-downloaded");
-      expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
 
-      // Its watchdog fires, releasing the guard for future events — but dialog 1 itself is still
-      // open on screen (native dialogs can't be cancelled) and its promise is still pending.
-      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
-
-      // A third event now lands and opens dialog 2 (never settles either, for this test). Dialog 2
-      // now owns the current requestId.
-      showMessageBoxMock.mockImplementationOnce(() => new Promise(() => {}));
       emitAutoUpdaterEvent("update-downloaded");
       expect(showMessageBoxMock).toHaveBeenCalledTimes(2);
-
-      // Dialog 1's ORIGINAL promise finally resolves — the user clicked "Later" on the
-      // stale-but-still-real dialog well after the timeout warning fired and after dialog 2 opened.
-      // Flush dialog 1's .then/.finally microtasks under fake timers before asserting.
-      resolveFirstDialog?.({ response: 1 });
-      await vi.advanceTimersByTimeAsync(0);
-
-      // Dialog 1's late response must be IGNORED, not honored: it no longer owns the current
-      // requestId (dialog 2 does), so it must not flip session-wide state out from under dialog 2.
-      // Asserting this directly (rather than only inferring it from suppression below, which
-      // isUpdateDialogOpen alone could also explain) is what actually pins the requestId guard on
-      // .then() — this is the assertion the pre-fix code would fail, since it honored the late
-      // response unconditionally.
-      expect(handlers.updateDialogDismissedInSession).toBe(false);
-      expect(showMessageBoxMock).toHaveBeenCalledTimes(2); // no third dialog was opened
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("superseded by a newer dialog"));
-
-      // Dialog 2's guard state must also be undisturbed by dialog 1's late (ignored) resolution: a
-      // fourth event landing right now must still be suppressed as a stack-on-top of dialog 2,
-      // proving dialog 1's late .then()/.finally() did not incorrectly flip isUpdateDialogOpen out
-      // from under dialog 2, which is still legitimately open and unanswered.
-      showMessageBoxMock.mockClear();
-      emitAutoUpdaterEvent("update-downloaded");
-      expect(showMessageBoxMock).not.toHaveBeenCalled();
     } finally {
-      warnSpy.mockRestore();
-      vi.useRealTimers();
+      errorSpy.mockRestore();
     }
   });
 

--- a/src/backend/ipc/release-channel-handlers.test.ts
+++ b/src/backend/ipc/release-channel-handlers.test.ts
@@ -17,6 +17,7 @@ vi.mock("electron", () => ({
 
 const checkForUpdatesMock = vi.fn();
 const setFeedURLMock = vi.fn();
+const quitAndInstallMock = vi.fn();
 // Capture registered autoUpdater listeners (keyed by event name) so tests can fire events like
 // "update-downloaded" directly, the same way the real electron-updater instance would (#456).
 const autoUpdaterListeners = new Map<string, Array<(...args: unknown[]) => void>>();
@@ -41,6 +42,7 @@ vi.mock("electron-updater", () => ({
     on: (...args: [string, (...a: unknown[]) => void]) => autoUpdaterOnMock(...args),
     setFeedURL: (...args: unknown[]) => setFeedURLMock(...args),
     checkForUpdates: (...args: unknown[]) => checkForUpdatesMock(...args),
+    quitAndInstall: (...args: unknown[]) => quitAndInstallMock(...args),
   },
 }));
 
@@ -416,8 +418,38 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
 
     expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
 
-    // Resolve the first dialog so the test doesn't leave a dangling promise.
+    // Resolve the first dialog and wait for the handler's .then/.finally chain to flush before
+    // the test ends, matching the sibling test's vi.waitFor pattern rather than firing-and-forgetting.
     resolveFirstDialog?.({ response: 1 });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("releases the guard after the dialog settles so a later legitimate event is handled normally", async () => {
+    // Directly pins the .finally() reset behavior (review on #456): once the first dialog settles
+    // and releases isUpdateDialogOpen, a subsequent update-downloaded event must show its own
+    // dialog rather than being treated as a stack-on-top of a still-open one. Uses the dialog
+    // timeout fallback (rather than a "Restart Now"/"Later" response) so the guard's own release
+    // is what's under test, not short-circuited by updateDialogDismissedInSession or
+    // isRestartingToInstall — neither of which the timeout path touches.
+    vi.useFakeTimers();
+    try {
+      showMessageBoxMock.mockImplementation(() => new Promise(() => {})); // never settles
+
+      new ReleaseChannelIPCHandlers();
+
+      emitAutoUpdaterEvent("update-downloaded");
+      expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+
+      // Let the dialog's bounded timeout fallback fire, releasing isUpdateDialogOpen.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000);
+
+      // A later legitimate event must now be handled normally — a second dialog is shown, proving
+      // isUpdateDialogOpen was released rather than left stuck true.
+      emitAutoUpdaterEvent("update-downloaded");
+      expect(showMessageBoxMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not show a reminder again this session after the user clicks Later — the originally reported bug", async () => {
@@ -435,5 +467,28 @@ describe("ReleaseChannelIPCHandlers — update-ready reminder dialog (#456)", ()
     emitAutoUpdaterEvent("update-downloaded");
 
     expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show another reminder after the user clicks Restart Now, even before quitAndInstall fires", async () => {
+    // Regression coverage (review on #456): isUpdateDialogOpen resets in .finally() synchronously,
+    // but the real quit (autoUpdater.quitAndInstall) is deferred via setImmediate. A second
+    // "update-downloaded" event landing in that gap must not stack a dialog moments before the app
+    // quits — pinned here via the isRestartingToInstall short-circuit.
+    showMessageBoxMock.mockResolvedValue({ response: 0 }); // 0 = "Restart Now"
+
+    new ReleaseChannelIPCHandlers();
+
+    emitAutoUpdaterEvent("update-downloaded");
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    // A second event landing after the dialog resolved (isUpdateDialogOpen already released) but
+    // before the deferred quitAndInstall() fires must still be suppressed.
+    emitAutoUpdaterEvent("update-downloaded");
+
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1);
+
+    // Let the deferred quitAndInstall() flush before the test ends, so it doesn't fire during a
+    // later test.
+    await vi.waitFor(() => expect(quitAndInstallMock).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -79,6 +79,17 @@ export class ReleaseChannelIPCHandlers {
   // autoUpdater "update-downloaded" event (e.g. a periodic re-check landing while the first
   // dialog is still awaiting a response) from stacking a duplicate dialog on top of it.
   private isUpdateDialogOpen = false;
+  // Once the user picks "Restart Now" the app is on its way out (review on #456) - short-circuit
+  // any further "update-downloaded" events immediately rather than relying solely on the
+  // isUpdateDialogOpen guard, which resets in .finally() before the deferred quitAndInstall() call
+  // actually fires and would otherwise leave a narrow window where a second event could stack a
+  // dialog moments before quit.
+  private isRestartingToInstall = false;
+  // Bound how long we wait on dialog.showMessageBox() before giving up on it (review on #456) - if
+  // the promise never settles (e.g. the parent window is destroyed while the dialog is up, or a
+  // native dialog-subsystem hang), isUpdateDialogOpen must not get stuck true forever, which would
+  // silently suppress every future update-ready reminder for the rest of the session.
+  private static readonly UPDATE_DIALOG_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
   constructor() {
     ipcMain.handle(IPC_CHANNELS.RELEASE_CHANNEL_GET, () => this.getChannel());
@@ -121,6 +132,13 @@ export class ReleaseChannelIPCHandlers {
         return;
       }
 
+      // Skip if the app is already on its way out from a prior "Restart Now" (review on #456) -
+      // checked before isUpdateDialogOpen since that guard resets in .finally() slightly before
+      // the deferred quitAndInstall() call actually fires.
+      if (this.isRestartingToInstall) {
+        return;
+      }
+
       // Skip if a reminder dialog is already open (#456) - a subsequent "update-downloaded" event
       // (e.g. the periodic background check firing again) must not stack another dialog on top of
       // one the user hasn't responded to yet.
@@ -129,17 +147,39 @@ export class ReleaseChannelIPCHandlers {
       }
       this.isUpdateDialogOpen = true;
 
-      dialog
-        .showMessageBox({
-          type: "info",
-          title: "Update Ready",
-          message: "A new version has been downloaded. Restart now to install?",
-          buttons: ["Restart Now", "Later"],
-          defaultId: 0,
-          cancelId: 1,
-        })
+      // Race the dialog against a bounded timeout (review on #456) - dialog.showMessageBox() can
+      // in principle never settle (e.g. the parent window is destroyed while it's up, or a native
+      // dialog-subsystem hang), which would otherwise leave isUpdateDialogOpen stuck true forever
+      // and silently suppress every future reminder for the rest of the session.
+      const timeout = new Promise<{ response: number; timedOut: true }>((resolve) => {
+        setTimeout(
+          () => resolve({ response: -1, timedOut: true }),
+          ReleaseChannelIPCHandlers.UPDATE_DIALOG_TIMEOUT_MS,
+        );
+      });
+
+      const dialogPromise = dialog.showMessageBox({
+        type: "info",
+        title: "Update Ready",
+        message: "A new version has been downloaded. Restart now to install?",
+        buttons: ["Restart Now", "Later"],
+        defaultId: 0,
+        cancelId: 1,
+      });
+
+      Promise.race([dialogPromise, timeout])
         .then((result) => {
+          if ("timedOut" in result) {
+            // The dialog never got a response in time - leave updateDialogDismissedInSession
+            // untouched so a future update-downloaded event can still offer the reminder again.
+            console.warn("Update-ready dialog timed out waiting for a response.");
+            return;
+          }
+
           if (result.response === 0) {
+            // The app is quitting to install - short-circuit any further events immediately,
+            // ahead of the isUpdateDialogOpen reset in .finally() below.
+            this.isRestartingToInstall = true;
             // Set isQuitting to true so that the before-quit handler allows the app to quit
             setIsQuitting(true);
             // Force immediate quit and install

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -92,16 +92,6 @@ export class ReleaseChannelIPCHandlers {
   // (soon-to-exit) session is the safer failure mode versus risking a reminder popping up while the
   // app believes it is already on its way out.
   private isRestartingToInstall = false;
-  // Bound how long we wait on dialog.showMessageBox() before giving up on it (review on #456) - if
-  // the promise never settles (e.g. the parent window is destroyed while the dialog is up, or a
-  // native dialog-subsystem hang), isUpdateDialogOpen must not get stuck true forever, which would
-  // silently suppress every future update-ready reminder for the rest of the session.
-  private static readonly UPDATE_DIALOG_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-  // Monotonically increasing id for each dialog.showMessageBox() call this session (review on #456,
-  // blocking finding). Captured per-invocation so a late resolution from an *abandoned* dialog (one
-  // whose watchdog already fired and released the guard for a newer dialog) can be told apart from
-  // the *current* dialog's resolution - see the handler below for how it's used.
-  private updateDialogRequestId = 0;
 
   constructor() {
     ipcMain.handle(IPC_CHANNELS.RELEASE_CHANNEL_GET, () => this.getChannel());
@@ -159,44 +149,16 @@ export class ReleaseChannelIPCHandlers {
       }
       this.isUpdateDialogOpen = true;
 
-      // Identify this specific dialog invocation (review on #456, blocking finding) so the
-      // watchdog below can tell "my own dialog settled" apart from "a different, newer dialog is
-      // now open" when deciding whether it's still safe to touch isUpdateDialogOpen.
-      const requestId = ++this.updateDialogRequestId;
-
-      const dialogPromise = dialog.showMessageBox({
-        type: "info",
-        title: "Update Ready",
-        message: "A new version has been downloaded. Restart now to install?",
-        buttons: ["Restart Now", "Later"],
-        defaultId: 0,
-        cancelId: 1,
-      });
-
-      // The handler below is attached directly to dialogPromise - NOT to a Promise.race with a
-      // timeout (review on #456, blocking finding). dialog.showMessageBox() is a real, uncancellable
-      // native OS-modal dialog: racing it against a timeout and wiring .then/.finally to the race
-      // meant that once the timeout "won", the guard reset while the real dialog was still on
-      // screen (re-opening the original stacking bug ~5 minutes later) AND the user's eventual real
-      // click fired no callback at all (silently dropped, per Promise.race semantics - only the
-      // winning branch's continuation ever runs). Attaching here instead means a late, real
-      // response is always honored, however late it arrives.
-      dialogPromise
+      dialog
+        .showMessageBox({
+          type: "info",
+          title: "Update Ready",
+          message: "A new version has been downloaded. Restart now to install?",
+          buttons: ["Restart Now", "Later"],
+          defaultId: 0,
+          cancelId: 1,
+        })
         .then((result) => {
-          // Guard against an *abandoned* dialog's late response (review on #456, blocking finding):
-          // once this dialog's watchdog has fired and a newer dialog has claimed requestId, this
-          // dialog's own click must not act on session-wide state (dismissing the session, or
-          // quitting to install) out from under the newer, currently-open dialog. Only the dialog
-          // that still owns the current requestId is allowed to act on its result; a stale one is
-          // logged and otherwise ignored.
-          if (this.updateDialogRequestId !== requestId) {
-            console.warn(
-              "Update-ready dialog resolved after being superseded by a newer dialog; ignoring " +
-                "its response so it doesn't affect the newer dialog's outcome.",
-            );
-            return;
-          }
-
           if (result.response === 0) {
             // The app is quitting to install - short-circuit any further events immediately,
             // ahead of the isUpdateDialogOpen reset in .finally() below.
@@ -218,40 +180,11 @@ export class ReleaseChannelIPCHandlers {
           console.error("Error showing update dialog:", err);
         })
         .finally(() => {
-          // Only release the guard if a newer dialog hasn't already claimed it (see the watchdog
-          // below) - otherwise a very-late resolution of an abandoned dialog could incorrectly
-          // clear the guard out from under a dialog that's currently open.
-          if (this.updateDialogRequestId === requestId) {
-            this.isUpdateDialogOpen = false;
-          }
-          // Cancel the watchdog now that this dialog has settled on its own (review on #456,
-          // minor finding) - avoids leaving a live 5-minute timer registered for every dialog
-          // shown when it isn't needed anymore (the common case: the user responds quickly).
-          clearTimeout(watchdogTimer);
-        });
-
-      // Bounded watchdog, separate from the dialog's own resolution (review on #456) - if
-      // dialog.showMessageBox() never settles (e.g. the parent window is destroyed while it's up,
-      // or a native dialog-subsystem hang), isUpdateDialogOpen must not stay stuck true forever,
-      // which would silently suppress every future update-ready reminder for the rest of the
-      // session. This does NOT touch dialogPromise or its .then/.finally chain above - it only
-      // (a) logs a warning and (b) frees the guard so a *future* update-downloaded event can show
-      // its own dialog. The original dialogPromise keeps listening in the background; if the user
-      // eventually does click it, the .then handler above still runs, but (per the requestId check
-      // added above) only acts on the result if this dialog still owns the current requestId -
-      // otherwise it's an abandoned dialog's late click and is ignored rather than honored.
-      const watchdogTimer = setTimeout(() => {
-        if (this.updateDialogRequestId === requestId && this.isUpdateDialogOpen) {
-          console.warn(
-            "Update-ready dialog has not received a response after " +
-              `${ReleaseChannelIPCHandlers.UPDATE_DIALOG_TIMEOUT_MS / 1000}s; releasing the ` +
-              "dialog-open guard so future update-ready reminders are not permanently suppressed. " +
-              "The original dialog is still on screen; if the user eventually responds to it, that " +
-              "response will now be ignored rather than honored, to avoid clobbering a newer dialog.",
-          );
+          // Keep the guard for the full lifetime of the native dialog. This dialog has no reliable
+          // cross-platform cancellation configured, so releasing the guard on a timeout would
+          // allow another dialog to stack on top while the original is still visible.
           this.isUpdateDialogOpen = false;
-        }
-      }, ReleaseChannelIPCHandlers.UPDATE_DIALOG_TIMEOUT_MS);
+        });
     });
   }
 

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -84,12 +84,24 @@ export class ReleaseChannelIPCHandlers {
   // isUpdateDialogOpen guard, which resets in .finally() before the deferred quitAndInstall() call
   // actually fires and would otherwise leave a narrow window where a second event could stack a
   // dialog moments before quit.
+  //
+  // Never reset back to false (review on #456): quitAndInstall() is fired via a fire-and-forget
+  // setImmediate() with no completion signal, so there is no reliable point at which we could learn
+  // the quit was blocked/failed and it's safe to resume showing reminders. Once the user has
+  // committed to restarting, permanently suppressing further reminders for the rest of this
+  // (soon-to-exit) session is the safer failure mode versus risking a reminder popping up while the
+  // app believes it is already on its way out.
   private isRestartingToInstall = false;
   // Bound how long we wait on dialog.showMessageBox() before giving up on it (review on #456) - if
   // the promise never settles (e.g. the parent window is destroyed while the dialog is up, or a
   // native dialog-subsystem hang), isUpdateDialogOpen must not get stuck true forever, which would
   // silently suppress every future update-ready reminder for the rest of the session.
   private static readonly UPDATE_DIALOG_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+  // Monotonically increasing id for each dialog.showMessageBox() call this session (review on #456,
+  // blocking finding). Captured per-invocation so a late resolution from an *abandoned* dialog (one
+  // whose watchdog already fired and released the guard for a newer dialog) can be told apart from
+  // the *current* dialog's resolution - see the handler below for how it's used.
+  private updateDialogRequestId = 0;
 
   constructor() {
     ipcMain.handle(IPC_CHANNELS.RELEASE_CHANNEL_GET, () => this.getChannel());
@@ -147,16 +159,10 @@ export class ReleaseChannelIPCHandlers {
       }
       this.isUpdateDialogOpen = true;
 
-      // Race the dialog against a bounded timeout (review on #456) - dialog.showMessageBox() can
-      // in principle never settle (e.g. the parent window is destroyed while it's up, or a native
-      // dialog-subsystem hang), which would otherwise leave isUpdateDialogOpen stuck true forever
-      // and silently suppress every future reminder for the rest of the session.
-      const timeout = new Promise<{ response: number; timedOut: true }>((resolve) => {
-        setTimeout(
-          () => resolve({ response: -1, timedOut: true }),
-          ReleaseChannelIPCHandlers.UPDATE_DIALOG_TIMEOUT_MS,
-        );
-      });
+      // Identify this specific dialog invocation (review on #456, blocking finding) so the
+      // watchdog below can tell "my own dialog settled" apart from "a different, newer dialog is
+      // now open" when deciding whether it's still safe to touch isUpdateDialogOpen.
+      const requestId = ++this.updateDialogRequestId;
 
       const dialogPromise = dialog.showMessageBox({
         type: "info",
@@ -167,15 +173,16 @@ export class ReleaseChannelIPCHandlers {
         cancelId: 1,
       });
 
-      Promise.race([dialogPromise, timeout])
+      // The handler below is attached directly to dialogPromise - NOT to a Promise.race with a
+      // timeout (review on #456, blocking finding). dialog.showMessageBox() is a real, uncancellable
+      // native OS-modal dialog: racing it against a timeout and wiring .then/.finally to the race
+      // meant that once the timeout "won", the guard reset while the real dialog was still on
+      // screen (re-opening the original stacking bug ~5 minutes later) AND the user's eventual real
+      // click fired no callback at all (silently dropped, per Promise.race semantics - only the
+      // winning branch's continuation ever runs). Attaching here instead means a late, real
+      // response is always honored, however late it arrives.
+      dialogPromise
         .then((result) => {
-          if ("timedOut" in result) {
-            // The dialog never got a response in time - leave updateDialogDismissedInSession
-            // untouched so a future update-downloaded event can still offer the reminder again.
-            console.warn("Update-ready dialog timed out waiting for a response.");
-            return;
-          }
-
           if (result.response === 0) {
             // The app is quitting to install - short-circuit any further events immediately,
             // ahead of the isUpdateDialogOpen reset in .finally() below.
@@ -197,8 +204,34 @@ export class ReleaseChannelIPCHandlers {
           console.error("Error showing update dialog:", err);
         })
         .finally(() => {
-          this.isUpdateDialogOpen = false;
+          // Only release the guard if a newer dialog hasn't already claimed it (see the watchdog
+          // below) - otherwise a very-late resolution of an abandoned dialog could incorrectly
+          // clear the guard out from under a dialog that's currently open.
+          if (this.updateDialogRequestId === requestId) {
+            this.isUpdateDialogOpen = false;
+          }
         });
+
+      // Bounded watchdog, separate from the dialog's own resolution (review on #456) - if
+      // dialog.showMessageBox() never settles (e.g. the parent window is destroyed while it's up,
+      // or a native dialog-subsystem hang), isUpdateDialogOpen must not stay stuck true forever,
+      // which would silently suppress every future update-ready reminder for the rest of the
+      // session. This does NOT touch dialogPromise or its .then/.finally chain above - it only
+      // (a) logs a warning and (b) frees the guard so a *future* update-downloaded event can show
+      // its own dialog. The original dialogPromise keeps listening in the background; if the user
+      // eventually does click it, the .then handler above still runs and is still honored - it just
+      // won't re-release an already-released (or newer) guard, per the requestId check.
+      setTimeout(() => {
+        if (this.updateDialogRequestId === requestId && this.isUpdateDialogOpen) {
+          console.warn(
+            "Update-ready dialog has not received a response after " +
+              `${ReleaseChannelIPCHandlers.UPDATE_DIALOG_TIMEOUT_MS / 1000}s; releasing the ` +
+              "dialog-open guard so future update-ready reminders are not permanently suppressed. " +
+              "The original dialog is still on screen and its eventual response will still be honored.",
+          );
+          this.isUpdateDialogOpen = false;
+        }
+      }, ReleaseChannelIPCHandlers.UPDATE_DIALOG_TIMEOUT_MS);
     });
   }
 

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -75,6 +75,10 @@ export class ReleaseChannelIPCHandlers {
   private updateCheckInterval: NodeJS.Timeout | null = null;
   private readonly UPDATE_CHECK_INTERVAL = 10 * 60 * 1000; // Check every 10 minutes
   private updateDialogDismissedInSession = false; // Track if user dismissed update dialog this session
+  // Track whether the "Update Ready" dialog is currently open (#456) - guards against a second
+  // autoUpdater "update-downloaded" event (e.g. a periodic re-check landing while the first
+  // dialog is still awaiting a response) from stacking a duplicate dialog on top of it.
+  private isUpdateDialogOpen = false;
 
   constructor() {
     ipcMain.handle(IPC_CHANNELS.RELEASE_CHANNEL_GET, () => this.getChannel());
@@ -111,10 +115,19 @@ export class ReleaseChannelIPCHandlers {
     });
 
     autoUpdater.on("update-downloaded", () => {
-      // Skip showing dialog if user already dismissed it this session
+      // Skip showing dialog if user already dismissed it this session (#456) - once "Later" is
+      // clicked, no further reminder should appear for the rest of the current session.
       if (this.updateDialogDismissedInSession) {
         return;
       }
+
+      // Skip if a reminder dialog is already open (#456) - a subsequent "update-downloaded" event
+      // (e.g. the periodic background check firing again) must not stack another dialog on top of
+      // one the user hasn't responded to yet.
+      if (this.isUpdateDialogOpen) {
+        return;
+      }
+      this.isUpdateDialogOpen = true;
 
       dialog
         .showMessageBox({
@@ -135,12 +148,16 @@ export class ReleaseChannelIPCHandlers {
               autoUpdater.quitAndInstall(false, true);
             });
           } else {
-            // User chose "Later" - remember this for the current session
+            // User chose "Later" - remember this for the current session so no further reminder
+            // is shown, whether from another "update-downloaded" event or the periodic check.
             this.updateDialogDismissedInSession = true;
           }
         })
         .catch((err) => {
           console.error("Error showing update dialog:", err);
+        })
+        .finally(() => {
+          this.isUpdateDialogOpen = false;
         });
     });
   }

--- a/src/backend/ipc/release-channel-handlers.ts
+++ b/src/backend/ipc/release-channel-handlers.ts
@@ -183,6 +183,20 @@ export class ReleaseChannelIPCHandlers {
       // response is always honored, however late it arrives.
       dialogPromise
         .then((result) => {
+          // Guard against an *abandoned* dialog's late response (review on #456, blocking finding):
+          // once this dialog's watchdog has fired and a newer dialog has claimed requestId, this
+          // dialog's own click must not act on session-wide state (dismissing the session, or
+          // quitting to install) out from under the newer, currently-open dialog. Only the dialog
+          // that still owns the current requestId is allowed to act on its result; a stale one is
+          // logged and otherwise ignored.
+          if (this.updateDialogRequestId !== requestId) {
+            console.warn(
+              "Update-ready dialog resolved after being superseded by a newer dialog; ignoring " +
+                "its response so it doesn't affect the newer dialog's outcome.",
+            );
+            return;
+          }
+
           if (result.response === 0) {
             // The app is quitting to install - short-circuit any further events immediately,
             // ahead of the isUpdateDialogOpen reset in .finally() below.
@@ -210,6 +224,10 @@ export class ReleaseChannelIPCHandlers {
           if (this.updateDialogRequestId === requestId) {
             this.isUpdateDialogOpen = false;
           }
+          // Cancel the watchdog now that this dialog has settled on its own (review on #456,
+          // minor finding) - avoids leaving a live 5-minute timer registered for every dialog
+          // shown when it isn't needed anymore (the common case: the user responds quickly).
+          clearTimeout(watchdogTimer);
         });
 
       // Bounded watchdog, separate from the dialog's own resolution (review on #456) - if
@@ -219,15 +237,17 @@ export class ReleaseChannelIPCHandlers {
       // session. This does NOT touch dialogPromise or its .then/.finally chain above - it only
       // (a) logs a warning and (b) frees the guard so a *future* update-downloaded event can show
       // its own dialog. The original dialogPromise keeps listening in the background; if the user
-      // eventually does click it, the .then handler above still runs and is still honored - it just
-      // won't re-release an already-released (or newer) guard, per the requestId check.
-      setTimeout(() => {
+      // eventually does click it, the .then handler above still runs, but (per the requestId check
+      // added above) only acts on the result if this dialog still owns the current requestId -
+      // otherwise it's an abandoned dialog's late click and is ignored rather than honored.
+      const watchdogTimer = setTimeout(() => {
         if (this.updateDialogRequestId === requestId && this.isUpdateDialogOpen) {
           console.warn(
             "Update-ready dialog has not received a response after " +
               `${ReleaseChannelIPCHandlers.UPDATE_DIALOG_TIMEOUT_MS / 1000}s; releasing the ` +
               "dialog-open guard so future update-ready reminders are not permanently suppressed. " +
-              "The original dialog is still on screen and its eventual response will still be honored.",
+              "The original dialog is still on screen; if the user eventually responds to it, that " +
+              "response will now be ignored rather than honored, to avoid clobbering a newer dialog.",
           );
           this.isUpdateDialogOpen = false;
         }


### PR DESCRIPTION
## Summary

After clicking "Remind me later" on the update-ready dialog, the periodic ~10-minute background update check could fire another `update-downloaded` event while the first dialog was still open, stacking a second reminder dialog on top of it. This PR closes that re-entrancy gap so at most one reminder dialog is ever shown at a time, and the existing per-session "Later" dismissal continues to suppress all further reminders for the rest of the session.

Closes #456

## What changed

| File | Change |
|------|--------|
| `src/backend/ipc/release-channel-handlers.ts` | Added an `isUpdateDialogOpen` guard around the `update-downloaded` handler so a subsequent event can't open a second "Update Ready" dialog while one is already awaiting a response. Cleared via `.finally()` once the dialog settles. |
| `src/backend/ipc/release-channel-handlers.test.ts` | Added regression tests: (1) a second `update-downloaded` event while the first dialog is still pending must not open another dialog; (2) after "Later" is chosen, further `update-downloaded` events this session must not show a dialog again. Also extended the `electron`/`electron-updater` test mocks to capture registered `autoUpdater.on(...)` listeners and a controllable `dialog.showMessageBox` mock so these events can be driven directly in tests. |

## Decisions

- **Decision:** Guard re-entrancy at the dialog-open boundary (`isUpdateDialogOpen`) rather than gating the periodic timer's `checkForUpdates()` call itself.
  - **Why:** `checkForUpdates()` is shared with the user-initiated "Check for Updates" button and the PR-channel flow that can find a genuinely newer version; blocking the periodic call entirely once dismissed would also suppress checks for an unrelated, newer update later in the session. The issue only asks that the *reminder* not repeat/stack — not that background checking stop — so the fix targets exactly the dialog-presentation layer.
  - **Alternatives considered:** Gating the periodic `setInterval` callback on `updateDialogDismissedInSession` — rejected because it changes checking behavior beyond what was reported and could mask a legitimately newer release.

Note: the primary "dialog re-appears after clicking Later" symptom described in the issue was already fixed by PR #762 (`updateDialogDismissedInSession`), which landed after this issue was filed. What remained unaddressed was the issue's second, explicit ask: "If the reminder dialog is open already, a subsequent update check should not open another reminder dialog on top of it" — that's the gap this PR closes.

## Acceptance criteria

- [x] After "Remind me later", no further reminder appears for the rest of the session — covered by the pre-existing `updateDialogDismissedInSession` flag (from #762) plus a new regression test confirming it still holds across repeated `update-downloaded` events.
- [x] If a reminder dialog is already open, a subsequent update check does not stack another dialog on top — new `isUpdateDialogOpen` guard, with a regression test that fails without the fix.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed (native Electron dialog; verified via unit tests driving the real `autoUpdater` event/listener wiring)
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm rebuild better-sqlite3 --build-from-source && npx vitest run --exclude 'src/ui/**'` — 693/693; `npm --prefix src/ui test` — 255/255)
- [x] Lint / format clean (`npm run lint` — 0 errors; one pre-existing, unrelated info-level style note in `src/ui/src/components/cloud360/Cloud360LiveView.tsx`, not touched by this change)

## Bug repro evidence

- **Symptom (pinned):** A second "Update Ready" dialog (`dialog.showMessageBox`) opens on top of a still-open one when a second `autoUpdater` `update-downloaded` event fires (e.g. the periodic ~10-minute background check landing while the user hasn't yet answered the first dialog).
- **Repro method:** Regression test driving the real `ReleaseChannelIPCHandlers` `update-downloaded` listener wiring via a mocked `autoUpdater.on`/`dialog.showMessageBox`, firing the event twice while the first dialog's promise is deliberately left unresolved.
- **Before (unpatched):** With the `isUpdateDialogOpen` guard removed, the test throws (`TypeError: Cannot read properties of undefined (reading 'then')`) because `showMessageBox` is invoked a second time — i.e. a second dialog attempt is made while the first is still open.
- **After (patched):** `showMessageBox` is called exactly once across both events; test passes.

## Follow-up items

- A Mac-specific comment on the issue (auto-update isn't certified for Mac yet, tracked in #351) suggests disabling this dialog on Mac entirely — out of scope here since it's a separate, already-tracked concern.