### PR TITLE
XS✔ ◾ fix: recording control bar disappears on macOS with external monitor connected (#508)

### DIFF
--- a/src/backend/services/recording/control-bar-window.test.ts
+++ b/src/backend/services/recording/control-bar-window.test.ts
@@ -16,6 +16,8 @@ const { mockWebContents, mockWindow } = vi.hoisted(() => {
     on: vi.fn(),
     setAlwaysOnTop: vi.fn(),
     setContentProtection: vi.fn(),
+    setBounds: vi.fn(),
+    setVisibleOnAllWorkspaces: vi.fn(),
     loadURL: vi.fn().mockResolvedValue(undefined),
     loadFile: vi.fn().mockResolvedValue(undefined),
     showInactive: vi.fn(),
@@ -32,6 +34,8 @@ vi.mock("electron", () => ({
     on = mockWindow.on;
     setAlwaysOnTop = mockWindow.setAlwaysOnTop;
     setContentProtection = mockWindow.setContentProtection;
+    setBounds = mockWindow.setBounds;
+    setVisibleOnAllWorkspaces = mockWindow.setVisibleOnAllWorkspaces;
     loadURL = mockWindow.loadURL;
     loadFile = mockWindow.loadFile;
     showInactive = mockWindow.showInactive;
@@ -45,6 +49,7 @@ vi.mock("electron", () => ({
   },
 }));
 
+import { screen } from "electron";
 import { RecordingControlBarWindow } from "./control-bar-window";
 
 describe("RecordingControlBarWindow (#870)", () => {
@@ -119,6 +124,68 @@ describe("RecordingControlBarWindow (#870)", () => {
       controlBar.hide();
 
       expect(controlBar.getCurrentTime()).toBeNull();
+    });
+  });
+
+  // #508: on macOS with an external monitor connected, Electron can silently
+  // reset a newly-created BrowserWindow's geometry to the primary display's
+  // bounds instead of honouring the constructor's x/y for a non-primary
+  // display — the same class of bug countdown-window.ts and
+  // screen-frame-window.ts already work around with a post-construction
+  // setSize call. This left the control bar positioned on/for the wrong
+  // display, which looked to users like it had disappeared entirely.
+  describe("multi-display positioning (#508)", () => {
+    const secondaryDisplay = {
+      id: 2,
+      workArea: { x: 1920, y: 0, width: 1440, height: 900 },
+    };
+
+    beforeEach(() => {
+      vi.mocked(screen.getAllDisplays).mockReturnValue([
+        { id: 1, workArea: { x: 0, y: 0, width: 1920, height: 1080 } } as never,
+        secondaryDisplay as never,
+      ]);
+    });
+
+    it("re-asserts the window bounds after construction so a non-primary display's geometry sticks", async () => {
+      await controlBar.showForRecording(secondaryDisplay.id.toString());
+
+      expect(mockWindow.setBounds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          width: 300,
+          height: 80,
+          x: secondaryDisplay.workArea.x + (secondaryDisplay.workArea.width - 300) / 2,
+          y: secondaryDisplay.workArea.y + secondaryDisplay.workArea.height - 80 - 20,
+        }),
+      );
+    });
+
+    it("marks the window visible on all workspaces on macOS so it isn't stranded on an inactive Space", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "darwin" });
+
+      try {
+        await controlBar.showForRecording(secondaryDisplay.id.toString());
+
+        expect(mockWindow.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {
+          visibleOnFullScreen: true,
+        });
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
+    });
+
+    it("does not force visible-on-all-workspaces on non-macOS platforms", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32" });
+
+      try {
+        await controlBar.showForRecording(secondaryDisplay.id.toString());
+
+        expect(mockWindow.setVisibleOnAllWorkspaces).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
     });
   });
 });

--- a/src/backend/services/recording/control-bar-window.ts
+++ b/src/backend/services/recording/control-bar-window.ts
@@ -66,11 +66,25 @@ export class RecordingControlBarWindow {
       },
     });
 
+    // NOTE: there is a bug (also seen in countdown-window.ts and screen-frame-window.ts) where the
+    //       x/y passed to the BrowserWindow constructor above doesn't reliably place the window on
+    //       a non-primary display — on macOS with an external monitor connected, Electron can
+    //       silently fall back to the primary display's geometry, leaving the control bar
+    //       positioned off the display the user is actually recording/looking at (it appears to
+    //       have vanished). Re-asserting the bounds after construction fixes it.
+    this.window.setBounds({ ...WINDOW_SIZE, x, y });
+
     this.window.on("closed", () => {
       this.window = null;
     });
 
     this.window.setAlwaysOnTop(true, "screen-saver");
+
+    // Ensure the control bar stays reachable regardless of which macOS Space/desktop is active on
+    // the display it was shown on, matching how a recording session can span space switches.
+    if (process.platform === "darwin") {
+      this.window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    }
 
     // Don't include this window in the recording
     this.window.setContentProtection(true);


### PR DESCRIPTION
## Summary

On macOS, the recording control bar (Stop/Continue) can silently fail to appear during a recording when an **external monitor is connected**. With laptop-only displays it works fine. When it fails, the only way to stop a recording is via the Dock icon's right-click "Stop Recording" — this repro was confirmed by a second report on the issue thread (Michael Q, macOS Sequoia 15.7.3, Sydney office monitor setup).

## Root cause

`RecordingControlBarWindow.showAtDisplay()` (`src/backend/services/recording/control-bar-window.ts`) constructs its `BrowserWindow` with the correct `x`/`y` for the target (possibly non-primary) display, but never re-asserts those bounds afterward.

This repo already has two documented instances of the same underlying Electron/macOS quirk in the sibling overlay windows:

- `countdown-window.ts` — has an explicit `// NOTE:` comment and a post-construction `this.window.setSize(width, height)` call to work around Electron silently resetting a new window's geometry to the *primary* display's, even when constructed with a non-primary display's bounds.
- `screen-frame-window.ts` — carries the same workaround plus notes about `bounds` vs `workArea` being unreliable on macOS with a second screen.

`control-bar-window.ts` was never patched with this workaround. So on macOS with an external monitor connected, the control bar's window can end up positioned using the *primary* display's geometry instead of the display the recording (and control bar) was meant to appear on — placing it off the display the user is actually looking at. Visually this looks exactly like "the control bar disappeared."

## Fix

- Re-assert the window's bounds (`setBounds`) right after construction, mirroring the existing workaround in `countdown-window.ts` / `screen-frame-window.ts`.
- Additionally call `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })` on macOS so the control bar stays reachable regardless of which Space is active on the display it was shown on, closing off a second plausible contributor to the same symptom.

## Bug repro evidence

**Before (unpatched code):** added two regression tests simulating a secondary/external display (`src/backend/services/recording/control-bar-window.test.ts`, describe block `multi-display positioning (#508)`). Run against the pre-fix code, both new tests fail:

```
× re-asserts the window bounds after construction so a non-primary display's geometry sticks
   → expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
   Number of calls: 0
× marks the window visible on all workspaces on macOS so it isn't stranded on an inactive Space
   → expected "vi.fn()" to be called with arguments: [ true, { visibleOnFullScreen: true } ]
   Number of calls: 0
```

This matches the reported symptom: no bounds re-assertion means the window can silently retain the primary display's geometry instead of the target display's.

**After (patched code):** same tests pass, along with the full existing suite for this file:

```
✓ re-asserts the window bounds after construction so a non-primary display's geometry sticks
✓ marks the window visible on all workspaces on macOS so it isn't stranded on an inactive Space
✓ does not force visible-on-all-workspaces on non-macOS platforms

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

A true end-to-end repro (physically connecting an external monitor on macOS and observing the control bar) isn't possible in this Linux CI/sandbox environment, so the evidence above is at the window-geometry-contract level — the same level the pre-existing sibling-window workarounds were justified at.

## Testing performed

- `npm run build` — passes (tsc clean)
- `npm run lint` — clean (one pre-existing, unrelated info-level finding in `Cloud360LiveView.tsx`, not touched by this change)
- `npx vitest run --exclude 'src/ui/**'` — 694/694 passed
- `npm --prefix src/ui test` — 255/255 passed

## Files changed

- `src/backend/services/recording/control-bar-window.ts` — re-assert bounds post-construction; mark visible on all macOS workspaces
- `src/backend/services/recording/control-bar-window.test.ts` — new regression tests for multi-display positioning

Closes #508
