### PR TITLE
XS✔ ◾ Remove redundant "Feature -"/"Bug -" prefixes from generated PBI titles

### DIFF
--- a/src/backend/constants/prompts.test.ts
+++ b/src/backend/constants/prompts.test.ts
@@ -38,6 +38,41 @@ describe("SHARED_ISSUE_CREATION_RULES — issue title rules (#719)", () => {
   });
 });
 
+// Regression guard for #544: "PBIs created via the desktop app currently include both an emoji
+// (✨ for features, 🐛 for bugs) and an explicit text prefix like 'Feature -' or 'Bug -'". The
+// emoji already conveys the semantic type, so the redundant text label must be dropped while the
+// emoji itself is kept. These assertions lock in that the generation rules tell the model to keep
+// the emoji but drop the "Feature -"/"Bug -" text label, for both the feature and bug flows.
+describe("SHARED_ISSUE_CREATION_RULES — drop redundant title text prefix, keep emoji only (#544)", () => {
+  it("instructs the model to keep the emoji but drop the redundant text label", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/drop.*redundant fixed text label/i);
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/keep the emoji, remove the text label/i);
+  });
+
+  it("explicitly forbids the old 'Feature -' / 'Bug -' prefixed titles", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toContain('NEVER "🐛 Bug -" or "✨ Feature -" as a prefix');
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(
+      /still carries the redundant "Feature -"\/"Bug -" text label/i,
+    );
+  });
+
+  it("gives a worked bug example with the emoji kept and the 'Bug -' label dropped", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toContain(
+      "a correct title is `🐛 Login button does not respond to clicks`, NOT `🐛 Bug - Login button does not respond to clicks`",
+    );
+  });
+
+  it("gives a worked feature example with the emoji kept and the 'Feature -' label dropped", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toContain(
+      "NOT `✨ Feature - Dark mode - Add a dark theme toggle to settings`",
+    );
+  });
+
+  it("still requires the emoji itself to be preserved (only the text label is dropped)", () => {
+    expect(SHARED_ISSUE_CREATION_RULES).toMatch(/Do not omit the emoji or substitute it/i);
+  });
+});
+
 // Bug #862: a previously created PBI that has since been DELETED in Azure DevOps was still
 // treated as a live duplicate. The agent then tried to update the deleted item (rejected by the
 // platform) and fell back to creating an incomplete item with only a title + a "duplicate"

--- a/src/backend/constants/prompts.ts
+++ b/src/backend/constants/prompts.ts
@@ -43,11 +43,12 @@ export const SHARED_ISSUE_CREATION_RULES = `3) **Follow Issue Templates**: If th
 - **Mentions**: Tag all members listed in the project details. Use their GitHub username for GitHub; otherwise, use their full name.
 
 5) **Issue Title Rules**:
-- The title MUST strictly follow the template's frontmatter pattern, INCLUDING ANY EMOJIS.
-- Do not omit fixed words (e.g., "🐛 Bug -") or substitute emojis.
-- **CRITICAL — Fill in the placeholders**: The template title contains placeholders such as \`{{ FEATURE NAME }}\`, \`{{ FEATURE DESCRIPTION }}\`, or \`{{ TITLE }}\`. You MUST replace EVERY placeholder with a concise, specific summary derived from the video transcription. Keep the template's fixed words and emojis, but the rest of the title MUST describe what the video is actually about.
-- A title that is ONLY an emoji, ONLY the fixed words, or that still contains any leftover \`{{ ... }}\` placeholder is INVALID. The final title MUST contain real, descriptive words from the video — NEVER just "✨" or "🐛 Bug -" on their own.
-- Example: for a feature template \`✨ {{ FEATURE NAME }} - {{ FEATURE DESCRIPTION }}\` about adding dark mode, a correct title is \`✨ Dark mode - Add a dark theme toggle to settings\`, NOT \`✨\`.
+- The title MUST use the template's frontmatter emoji (e.g., "✨" for a feature, "🐛" for a bug), but DROP any redundant fixed text label that follows it in the template (e.g., "Feature -", "Bug -"). Keep the emoji, remove the text label.
+- Do not omit the emoji or substitute it for a different one.
+- **CRITICAL — Fill in the placeholders**: The template title contains placeholders such as \`{{ FEATURE NAME }}\`, \`{{ FEATURE DESCRIPTION }}\`, or \`{{ TITLE }}\`. You MUST replace EVERY placeholder with a concise, specific summary derived from the video transcription. Keep the template's emoji, but drop any fixed text label (e.g., "Feature -", "Bug -") and any separator that only existed to join the label to the placeholders — the rest of the title MUST describe what the video is actually about.
+- A title that is ONLY an emoji, that still carries the redundant "Feature -"/"Bug -" text label, or that still contains any leftover \`{{ ... }}\` placeholder is INVALID. The final title MUST contain real, descriptive words from the video — NEVER just "✨" or "🐛" on their own, and NEVER "🐛 Bug -" or "✨ Feature -" as a prefix.
+- Example: for a feature template \`✨ {{ FEATURE NAME }} - {{ FEATURE DESCRIPTION }}\` about adding dark mode, a correct title is \`✨ Dark mode - Add a dark theme toggle to settings\`, NOT \`✨\` and NOT \`✨ Feature - Dark mode - Add a dark theme toggle to settings\`.
+- Example: for a bug template \`🐛 Bug - {{ BUG DESCRIPTION }}\` about a broken login button, a correct title is \`🐛 Login button does not respond to clicks\`, NOT \`🐛 Bug - Login button does not respond to clicks\`.
 - The descriptive summary belongs in the TITLE field. Do NOT leave the title as a bare emoji/prefix and push the actual title text into the issue body instead.
 - **No template**: when the repository has no issue template, the title is still a real, descriptive summary of the video — a plain, concise sentence (no emoji prefix required), never empty, generic, or just a placeholder.
 


### PR DESCRIPTION
## Summary

PBI titles generated by the desktop app's automated issue-creation flow included both the emoji (✨/🐛) *and* a redundant text label ("Feature -"/"Bug -") copied verbatim from the GitHub issue template's frontmatter. The emoji already conveys the semantic type, so the text label was pure clutter. This updates the shared issue-creation prompt so generated titles keep the emoji but drop the redundant text label, for both the feature and bug flows.

Closes #544

## What changed

| File | Change |
|------|--------|
| `src/backend/constants/prompts.ts` | Rewrote rule 5 ("Issue Title Rules") in `SHARED_ISSUE_CREATION_RULES` — the agent now keeps the template's emoji but strips the fixed text label ("Feature -"/"Bug -") and its trailing separator when generating a title, with worked examples for both flows. |
| `src/backend/constants/prompts.test.ts` | Added regression tests (#544) locking in that titles keep the emoji only, plus worked-example assertions for the feature and bug cases. Existing #719 tests still pass unchanged. |

## Decisions

- **Decision:** Fix this at the single shared prompt source (`SHARED_ISSUE_CREATION_RULES`) rather than editing the `.github/ISSUE_TEMPLATE/*.md` files.
  - **Why:** Both `defaultProjectPrompt` (remote/portal flow) and `defaultCustomPrompt` (local flow) already compose from this one constant, so a single change reaches both feature and bug creation flows consistently. Editing the GitHub issue templates themselves would violate the acceptance criterion that existing templates/labels/sections remain unchanged, and would also affect manually-filed issues, not just YakShaver-generated ones.
  - **Alternatives considered:** Editing `.github/ISSUE_TEMPLATE/0-feature.md` / `1-bug.md` directly — rejected because the issue explicitly requires templates/labels/sections to stay unchanged, and the templates are also used for manual issue creation where the fixed label may still be wanted.
- **Decision:** Kept the emoji strictly (no substitution), only dropped the fixed text label — not any other frontmatter content.
  - **Why:** Matches the acceptance criteria exactly: titles must still start with the correct emoji, only the redundant words are removed.

## Acceptance criteria

- [x] Feature PBI titles start with ✨ and do not include "Feature -" — enforced by the updated rule 5 + regression test.
- [x] Bug PBI titles start with 🐛 and do not include "Bug -" — enforced by the updated rule 5 + regression test.
- [x] The prompt/template generating GitHub issue titles is updated — `SHARED_ISSUE_CREATION_RULES` in `src/backend/constants/prompts.ts`.
- [x] Existing issue templates/required labels/sections remain unchanged — `.github/ISSUE_TEMPLATE/*.md` files untouched; body section/heading rules (rule 6) untouched.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] Build passes
- [x] Tests pass
- [x] Lint / format clean

Ran the project's configured commands from `.armada/config.json`:
- `npm run build` — passes (tsc, no errors).
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run --reporter=verbose --exclude 'src/ui/**'` — 68 test files / 696 tests passed, including the new and existing prompt regression tests.
- `npm --prefix src/ui install && npm --prefix src/ui test` — 35 test files / 255 tests passed.
- `npm run lint` — clean (biome check, 0 errors/warnings; one unrelated pre-existing info-level suggestion in `Cloud360LiveView.tsx`, not part of this change).

This is a prompt/instruction change (no runtime UI surface), so coverage is via the string-assertion regression tests in `prompts.test.ts` that lock in the new title-generation rule — the same test strategy already used for the #719 and #862 prompt regressions in this file.

## Follow-up items

- The issue's task list suggests confirming with the product owner whether "Bug -" should be configurable/kept as an option for bugs. This PR defaults to emoji-only for both flows per the issue's stated default ("default to emoji-only as requested"); a toggle was not implemented since the acceptance criteria call for emoji-only behavior without mentioning a settings toggle. If the product owner wants the text label back for bugs, that would be a small follow-up change to the same rule.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
