### PR TITLE
XS✔ ◾ Doc: Install Python for video downloader (Mac & Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Install [Chocolatey](https://chocolatey.org/install) (skip this if you already h
 Python, in one PowerShell command (run PowerShell **as Administrator**):
 
 ```powershell
-powershell -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')); choco install python -y"
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')); choco install python -y
 ```
 
 If Chocolatey is already installed:
@@ -64,14 +64,31 @@ choco install python -y
 
 ### Verify the installation
 
+**macOS** (Homebrew installs Python as `python3`/`pip3`):
+
 ```bash
+python3 --version
+pip3 --version
+```
+
+**Windows** (Chocolatey installs Python as `python`/`pip`):
+
+```powershell
 python --version
 pip --version
 ```
 
 ### Install the video downloader (yt-dlp)
 
+**macOS**:
+
 ```bash
+python3 -m pip install -U yt-dlp
+```
+
+**Windows**:
+
+```powershell
 python -m pip install -U yt-dlp
 ```
 
@@ -83,10 +100,9 @@ yt-dlp "https://www.youtube.com/watch?v=example"
 
 ### Common PATH issues
 
-- **macOS**: if `python`/`pip` aren't found after installing via Homebrew, open a new terminal
+- **macOS**: if `python3`/`pip3` aren't found after installing via Homebrew, open a new terminal
   window (or run `source ~/.zprofile` / `source ~/.bash_profile`) so your shell picks up
-  Homebrew's PATH changes. Homebrew installs Python as `python3`/`pip3` — use those names if
-  `python`/`pip` are unavailable, or confirm your Homebrew `bin` directory (`brew --prefix`) is on
+  Homebrew's PATH changes, or confirm your Homebrew `bin` directory (`brew --prefix`) is on
   `PATH`.
 - **Windows**: if `python`/`pip` aren't recognised after installing via Chocolatey, close and
   reopen your terminal so the updated `PATH` environment variable is picked up. If it's still not

--- a/README.md
+++ b/README.md
@@ -24,6 +24,79 @@ In the root folder, run
 On Windows and macOS, `npm run setup` also installs the standalone `yt-dlp` binary used
 for YouTube downloads. This avoids relying on the operating system's Python.
 
+## Install Python for video downloader (Mac & Windows)
+
+[▶️ Watch the video (01:02)](https://www.youtube.com/watch?v=cW9aLi-8igc)
+
+`npm run setup` installs a standalone `yt-dlp` binary automatically (see [Run](#run)), so most
+users don't need to install Python at all. If you hit an issue with the bundled binary, or you're
+running the video downloader outside the app, you can install Python and `yt-dlp` yourself with
+the commands below.
+
+### macOS
+
+Install [Homebrew](https://brew.sh/) (skip this if you already have it) and then Python, in one line:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" && brew install python
+```
+
+If Homebrew is already installed:
+
+```bash
+brew install python
+```
+
+### Windows
+
+Install [Chocolatey](https://chocolatey.org/install) (skip this if you already have it) and then
+Python, in one PowerShell command (run PowerShell **as Administrator**):
+
+```powershell
+powershell -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')); choco install python -y"
+```
+
+If Chocolatey is already installed:
+
+```powershell
+choco install python -y
+```
+
+### Verify the installation
+
+```bash
+python --version
+pip --version
+```
+
+### Install the video downloader (yt-dlp)
+
+```bash
+python -m pip install -U yt-dlp
+```
+
+Once installed, you can run the video downloader from the command line, e.g.:
+
+```bash
+yt-dlp "https://www.youtube.com/watch?v=example"
+```
+
+### Common PATH issues
+
+- **macOS**: if `python`/`pip` aren't found after installing via Homebrew, open a new terminal
+  window (or run `source ~/.zprofile` / `source ~/.bash_profile`) so your shell picks up
+  Homebrew's PATH changes. Homebrew installs Python as `python3`/`pip3` — use those names if
+  `python`/`pip` are unavailable, or confirm your Homebrew `bin` directory (`brew --prefix`) is on
+  `PATH`.
+- **Windows**: if `python`/`pip` aren't recognised after installing via Chocolatey, close and
+  reopen your terminal so the updated `PATH` environment variable is picked up. If it's still not
+  found, verify the Python install directory and its `Scripts` folder were added to `PATH` (the
+  Chocolatey package does this automatically, but a prior manual Python install without the "Add
+  Python to PATH" option can shadow it — reinstall with that option checked, or add the paths
+  manually via System Properties → Environment Variables).
+- On both OSes, restarting your terminal (or your machine, if PATH still doesn't refresh) after
+  installation resolves most "command not found" issues.
+
 ## Building
 
 1. `npm run setup` – ensure all dependencies are installed


### PR DESCRIPTION
## Summary
- Adds a new README section, **Install Python for video downloader (Mac & Windows)**, right after the existing `## Run` section (which already documents the automatic `yt-dlp` binary install via `npm run setup`).
- Provides single-line CLI install commands for Python: `brew install python` (macOS, with a Homebrew bootstrap one-liner) and `choco install python -y` (Windows, with a Chocolatey bootstrap one-liner), exactly as suggested in the issue.
- Adds verification steps (`python --version`, `pip --version`) and instructions to install the video downloader dependency via `python -m pip install -U yt-dlp`.
- Adds a "Common PATH issues" subsection covering the most frequent post-install `command not found` causes on each OS (shell not picking up updated PATH, Homebrew's `python3`/`pip3` naming, a prior Python install without "Add to PATH" shadowing the Chocolatey one) and the fix (reopen the terminal / verify PATH entries).
- Links back to the issue's walkthrough video and cross-references the existing `## Run` section, since most users won't need this at all — `npm run setup` already installs a standalone `yt-dlp` binary automatically to avoid a system Python dependency for local development. This section is aimed at end users of the built app and anyone troubleshooting or running the downloader outside the app.

Closes #638

## Test plan
This is a documentation-only change (no source files touched), so the project's build/test/lint suite is not applicable.
- [x] Reviewed the new section renders correctly as Markdown (headings, code fences all paired, links valid).
- [x] Confirmed commands match exactly what the issue requested (Homebrew/Chocolatey bootstrap one-liners, `python --version`, `pip --version`, `python -m pip install -U yt-dlp`).
- [x] Cross-checked against the existing `## Run` section and `AGENTS.md` so the new section doesn't contradict the app's existing automatic `yt-dlp` binary install behaviour.
- [ ] macOS single-line command validated on macOS (commands taken verbatim from the issue's "Recommended commands" / Homebrew's own official install instructions; not independently re-run on physical macOS/Windows hardware in this environment).
- [ ] Windows single-line command validated on Windows (as above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)