### PR TITLE
S✔ ◾ Fix: Executing Task loop hangs indefinitely — add configurable timeout + retry (#698)

### DIFF
--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -180,6 +180,7 @@ export class ProcessVideoIPCHandlers {
               onStep: mcpAdapter.onStep,
             },
             executingTaskTimeoutMs,
+            () => mcpAdapter.discard(),
           );
 
           const mcpResult = loopResult.text;
@@ -685,6 +686,7 @@ export class ProcessVideoIPCHandlers {
             onStep: mcpAdapter.onStep,
           },
           executingTaskTimeoutMs,
+          () => mcpAdapter.discard(),
         );
 
         mcpResult = loopResult.text;

--- a/src/backend/ipc/process-video-handlers.ts
+++ b/src/backend/ipc/process-video-handlers.ts
@@ -23,10 +23,12 @@ import { SendWorkItemDetailsToPortal, WorkItemDtoSchema } from "../services/port
 import type { ProjectDto } from "../services/prompt/prompt-manager";
 import { ShaveService } from "../services/shave/shave-service";
 import { LlmStorage } from "../services/storage/llm-storage";
+import { UserSettingsStorage } from "../services/storage/user-settings-storage";
 import { optimizeTranscript } from "../services/transcript/optimize-transcript-service";
 import { UserInteractionService } from "../services/user-interaction/user-interaction-service";
 import { VideoMetadataBuilder } from "../services/video/video-metadata-builder";
 import { YouTubeDownloadService } from "../services/video/youtube-service";
+import { runManualLoopWithTimeout } from "../services/workflow/executing-task-timeout";
 import { McpWorkflowAdapter } from "../services/workflow/mcp-workflow-adapter";
 import { formatNoWorkItemError } from "../services/workflow/no-work-item-error";
 import { PromptSelectionService } from "../services/workflow/prompt-selection-service";
@@ -163,7 +165,10 @@ export class ProcessVideoIPCHandlers {
             orchestrator: backend,
           });
 
-          const loopResult = await orchestrator.manualLoopAsync(
+          const { executingTaskTimeoutMs } =
+            await UserSettingsStorage.getInstance().getSettingsAsync();
+          const loopResult = await runManualLoopWithTimeout(
+            orchestrator,
             intermediateOutput,
             videoUploadResult,
             {
@@ -174,6 +179,7 @@ export class ProcessVideoIPCHandlers {
               shaveId,
               onStep: mcpAdapter.onStep,
             },
+            executingTaskTimeoutMs,
           );
 
           const mcpResult = loopResult.text;
@@ -206,7 +212,12 @@ export class ProcessVideoIPCHandlers {
     // Different from RERUN_TASK which is a user-initiated re-execution after success.
     ipcMain.handle(
       IPC_CHANNELS.WORKFLOW_RETRY_FROM_STAGE,
-      async (_event: IpcMainInvokeEvent, stage: keyof WorkflowState, shaveId?: string) => {
+      async (
+        _event: IpcMainInvokeEvent,
+        stage: keyof WorkflowState,
+        shaveId?: string,
+        customPrompt?: string,
+      ) => {
         if (!WORKFLOW_STAGE_ORDER.includes(stage)) {
           return { success: false, error: `Invalid stage: ${stage}` };
         }
@@ -222,7 +233,11 @@ export class ProcessVideoIPCHandlers {
 
         if (shaveId) this.activeRetries.add(shaveId);
         try {
-          return await this.retryService.retryFromStage(stage, shaveId);
+          return await this.retryService.retryFromStage(
+            stage,
+            shaveId,
+            customPrompt?.trim() || undefined,
+          );
         } catch (error) {
           const errorMessage = formatAndReportError(error, "retry_from_stage");
           return { success: false, error: errorMessage };
@@ -405,7 +420,7 @@ export class ProcessVideoIPCHandlers {
   }
 
   private async processVideoSource(
-    { filePath, youtubeResult, shaveId, shaveAutoApprove }: VideoProcessingContext,
+    { filePath, youtubeResult, shaveId, shaveAutoApprove, customPrompt }: VideoProcessingContext,
     workflowManager: WorkflowStateManager,
     startFromStage?: keyof WorkflowState,
   ): Promise<RetryResult> {
@@ -655,17 +670,21 @@ export class ProcessVideoIPCHandlers {
           orchestrator: backend,
         });
 
-        const loopResult = await orchestrator.manualLoopAsync(
+        const { executingTaskTimeoutMs } =
+          await UserSettingsStorage.getInstance().getSettingsAsync();
+        const loopResult = await runManualLoopWithTimeout(
+          orchestrator,
           effectiveExecutionTranscript,
           youtubeResult,
           {
             projectMetaData,
-            desktopAgentProjectPrompt,
+            desktopAgentProjectPrompt: customPrompt ?? desktopAgentProjectPrompt,
             videoFilePath: filePath,
             serverFilter,
             shaveId,
             onStep: mcpAdapter.onStep,
           },
+          executingTaskTimeoutMs,
         );
 
         mcpResult = loopResult.text;

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -263,8 +263,8 @@ const electronAPI = {
   workflow: {
     onProgressNeo: (callback: (progress: unknown) => void) =>
       onIpcEvent(IPC_CHANNELS.WORKFLOW_PROGRESS_NEO, callback),
-    retryFromStage: (stage: keyof WorkflowState, shaveId?: string) =>
-      ipcRenderer.invoke(IPC_CHANNELS.WORKFLOW_RETRY_FROM_STAGE, stage, shaveId),
+    retryFromStage: (stage: keyof WorkflowState, shaveId?: string, customPrompt?: string) =>
+      ipcRenderer.invoke(IPC_CHANNELS.WORKFLOW_RETRY_FROM_STAGE, stage, shaveId, customPrompt),
     getRetryStatus: (shaveId: string) =>
       ipcRenderer.invoke(IPC_CHANNELS.WORKFLOW_GET_RETRY_STATUS, shaveId),
     cancelRetry: (shaveId: string) =>

--- a/src/backend/services/mcp/backlog-orchestrator.ts
+++ b/src/backend/services/mcp/backlog-orchestrator.ts
@@ -8,6 +8,7 @@ export type MCPTerminationReason =
   | "content-filter"
   | "cancelled"
   | "max-iterations"
+  | "timeout"
   | "unknown";
 
 export interface BacklogArtifact {

--- a/src/backend/services/workflow/executing-task-timeout.test.ts
+++ b/src/backend/services/workflow/executing-task-timeout.test.ts
@@ -94,4 +94,56 @@ describe("runManualLoopWithTimeout — #698 wall-clock guard on the Executing Ta
       runManualLoopWithTimeout(orchestrator, "transcript", undefined, {}, 5_000),
     ).rejects.toThrow("LLM client not initialized");
   });
+
+  it("calls onTimeout when — and only when — the timeout actually fires (#698 stale-write guard)", async () => {
+    const onTimeout = vi.fn();
+    const orchestrator: IBacklogOrchestrator = {
+      manualLoopAsync: vi.fn().mockReturnValue(new Promise(() => {})),
+    };
+
+    const resultPromise = runManualLoopWithTimeout(
+      orchestrator,
+      "transcript",
+      undefined,
+      {},
+      2_000,
+      onTimeout,
+    );
+
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await resultPromise;
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onTimeout when the loop finishes before the timeout", async () => {
+    const onTimeout = vi.fn();
+    const orchestrator: IBacklogOrchestrator = {
+      manualLoopAsync: vi.fn().mockResolvedValue({
+        text: "done",
+        backlogActionSucceeded: true,
+        artifacts: [],
+        terminationReason: "stop",
+      }),
+    };
+
+    await runManualLoopWithTimeout(orchestrator, "transcript", undefined, {}, 60_000, onTimeout);
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("does not call onTimeout when the loop rejects with a non-timeout error", async () => {
+    const onTimeout = vi.fn();
+    const orchestrator: IBacklogOrchestrator = {
+      manualLoopAsync: vi.fn().mockRejectedValue(new Error("boom")),
+    };
+
+    await expect(
+      runManualLoopWithTimeout(orchestrator, "transcript", undefined, {}, 5_000, onTimeout),
+    ).rejects.toThrow("boom");
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
 });

--- a/src/backend/services/workflow/executing-task-timeout.test.ts
+++ b/src/backend/services/workflow/executing-task-timeout.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IBacklogOrchestrator } from "../mcp/backlog-orchestrator";
+import { runManualLoopWithTimeout } from "./executing-task-timeout";
+
+describe("runManualLoopWithTimeout — #698 wall-clock guard on the Executing Task loop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves normally when the loop finishes before the timeout", async () => {
+    const orchestrator: IBacklogOrchestrator = {
+      manualLoopAsync: vi.fn().mockResolvedValue({
+        text: "done",
+        backlogActionSucceeded: true,
+        artifacts: [{ type: "issue", idOrUrl: "https://example.com/1" }],
+        terminationReason: "stop",
+      }),
+    };
+
+    const result = await runManualLoopWithTimeout(
+      orchestrator,
+      "transcript",
+      undefined,
+      {},
+      60_000,
+    );
+
+    expect(result.backlogActionSucceeded).toBe(true);
+    expect(result.terminationReason).toBe("stop");
+  });
+
+  it("fails closed with terminationReason 'timeout' when the loop never settles", async () => {
+    // A loop that never resolves/rejects — simulates the real bug (#698): a stuck LLM/tool
+    // round-trip that hangs forever with no error.
+    const hangingLoop = new Promise(() => {});
+    const orchestrator: IBacklogOrchestrator = {
+      manualLoopAsync: vi.fn().mockReturnValue(hangingLoop),
+    };
+
+    const resultPromise = runManualLoopWithTimeout(
+      orchestrator,
+      "transcript",
+      undefined,
+      {},
+      5_000,
+    );
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const result = await resultPromise;
+    expect(result).toEqual({
+      text: "",
+      backlogActionSucceeded: false,
+      artifacts: [],
+      terminationReason: "timeout",
+    });
+  });
+
+  it("passes an AbortSignal to the orchestrator and aborts it on timeout", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const orchestrator: IBacklogOrchestrator = {
+      manualLoopAsync: vi.fn().mockImplementation((_transcript, _upload, options) => {
+        capturedSignal = options?.signal;
+        return new Promise(() => {});
+      }),
+    };
+
+    const resultPromise = runManualLoopWithTimeout(
+      orchestrator,
+      "transcript",
+      undefined,
+      {},
+      1_000,
+    );
+
+    expect(capturedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await resultPromise;
+
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it("re-throws non-timeout errors from the loop unchanged", async () => {
+    const orchestrator: IBacklogOrchestrator = {
+      manualLoopAsync: vi.fn().mockRejectedValue(new Error("LLM client not initialized")),
+    };
+
+    await expect(
+      runManualLoopWithTimeout(orchestrator, "transcript", undefined, {}, 5_000),
+    ).rejects.toThrow("LLM client not initialized");
+  });
+});

--- a/src/backend/services/workflow/executing-task-timeout.ts
+++ b/src/backend/services/workflow/executing-task-timeout.ts
@@ -1,0 +1,64 @@
+import { withTimeout } from "../../utils/async-utils";
+import type { VideoUploadResult } from "../auth/types";
+import type {
+  IBacklogOrchestrator,
+  ManualLoopOptions,
+  MCPLoopResult,
+} from "../mcp/backlog-orchestrator";
+
+/**
+ * Runs the Executing Task loop with a wall-clock timeout (#698). Neither orchestrator backend
+ * guarantees it returns in bounded time on its own: the in-process OpenAI/Azure loop
+ * (`MCPOrchestrator`) has only a 20-iteration safety cap and does not read `options.signal` at
+ * all, so a single stuck LLM/tool round-trip (e.g. repeatedly retrying a tool or resource that
+ * doesn't exist) can hang indefinitely with no error and no way to retry. Racing the call against
+ * a timer here guarantees the EXECUTING_TASK stage always settles — the timeout fails the stage
+ * with a clear `terminationReason: "timeout"` instead of leaving the UI spinning for 30+ minutes.
+ *
+ * On timeout we also fire `signal`, which `LocalClaudeOrchestrator` already honours (killing the
+ * spawned child); `MCPOrchestrator` ignores it, so its underlying HTTP call may keep running
+ * detached in the background — the same accepted tradeoff `LocalClaudeOrchestrator`'s own
+ * internal timeout makes, since abandoning a hung call is strictly better than never surfacing an
+ * error at all.
+ *
+ * Extracted as a standalone function (rather than a private method) so the timeout/race behaviour
+ * is unit-testable without standing up `ProcessVideoIPCHandlers` and its Electron dependencies.
+ */
+export async function runManualLoopWithTimeout(
+  orchestrator: IBacklogOrchestrator,
+  videoTranscription: string,
+  videoUploadResult: VideoUploadResult | undefined,
+  options: ManualLoopOptions | undefined,
+  timeoutMs: number,
+): Promise<MCPLoopResult> {
+  const controller = new AbortController();
+
+  try {
+    return await withTimeout(
+      orchestrator.manualLoopAsync(videoTranscription, videoUploadResult, {
+        ...options,
+        signal: controller.signal,
+      }),
+      timeoutMs,
+      "Executing Task",
+    );
+  } catch (error) {
+    if (!(error instanceof Error) || !/^Timeout waiting for/.test(error.message)) {
+      throw error;
+    }
+    // Signal cancellation to whichever backend is honouring it (LocalClaudeOrchestrator kills its
+    // spawned child; MCPOrchestrator currently ignores the signal — see the doc comment above for
+    // why that's accepted).
+    controller.abort();
+    const timeoutSeconds = Math.round(timeoutMs / 1000);
+    console.warn(
+      `[ProcessVideo] Executing Task timed out after ${timeoutSeconds}s — failing the stage.`,
+    );
+    return {
+      text: "",
+      backlogActionSucceeded: false,
+      artifacts: [],
+      terminationReason: "timeout",
+    } satisfies MCPLoopResult;
+  }
+}

--- a/src/backend/services/workflow/executing-task-timeout.ts
+++ b/src/backend/services/workflow/executing-task-timeout.ts
@@ -19,7 +19,9 @@ import type {
  * spawned child); `MCPOrchestrator` ignores it, so its underlying HTTP call may keep running
  * detached in the background — the same accepted tradeoff `LocalClaudeOrchestrator`'s own
  * internal timeout makes, since abandoning a hung call is strictly better than never surfacing an
- * error at all.
+ * error at all. Callers should also pass `onTimeout` to detach whatever was observing the call
+ * (see the parameter doc below) so a late completion from the detached call can't corrupt state a
+ * subsequent retry is by then relying on.
  *
  * Extracted as a standalone function (rather than a private method) so the timeout/race behaviour
  * is unit-testable without standing up `ProcessVideoIPCHandlers` and its Electron dependencies.
@@ -30,6 +32,14 @@ export async function runManualLoopWithTimeout(
   videoUploadResult: VideoUploadResult | undefined,
   options: ManualLoopOptions | undefined,
   timeoutMs: number,
+  /**
+   * Called synchronously right when the timeout fires, before this function returns. Lets the
+   * caller detach/mute whatever was observing the abandoned `manualLoopAsync` call (e.g.
+   * `McpWorkflowAdapter.discard()`) so a late completion from a backend that ignores `signal`
+   * (`MCPOrchestrator`) can't write into a `WorkflowStateManager` that a subsequent retry for the
+   * same shave is by then using — see the class-level comment on `McpWorkflowAdapter`.
+   */
+  onTimeout?: () => void,
 ): Promise<MCPLoopResult> {
   const controller = new AbortController();
 
@@ -50,6 +60,7 @@ export async function runManualLoopWithTimeout(
     // spawned child; MCPOrchestrator currently ignores the signal — see the doc comment above for
     // why that's accepted).
     controller.abort();
+    onTimeout?.();
     const timeoutSeconds = Math.round(timeoutMs / 1000);
     console.warn(
       `[ProcessVideo] Executing Task timed out after ${timeoutSeconds}s — failing the stage.`,

--- a/src/backend/services/workflow/mcp-workflow-adapter.test.ts
+++ b/src/backend/services/workflow/mcp-workflow-adapter.test.ts
@@ -102,4 +102,73 @@ describe("McpWorkflowAdapter", () => {
   it("targets the EXECUTING_TASK stage", () => {
     expect(WorkflowProgressStage.EXECUTING_TASK).toBe("executing_task");
   });
+
+  /**
+   * #698: `runManualLoopWithTimeout` abandons the underlying `manualLoopAsync` call on timeout
+   * without necessarily stopping it (MCPOrchestrator ignores the cancellation signal). Because
+   * `WorkflowStateManager` instances are cached and reused per shaveId across retries, a late
+   * `onStep`/`complete`/`fail` from that abandoned call would otherwise land on whatever the next
+   * attempt has since written. `discard()` is the guard against that.
+   */
+  describe("discard() (#698)", () => {
+    it("ignores onStep after discard", () => {
+      const { manager, readPayload } = makeStubManager();
+      const adapter = new McpWorkflowAdapter(manager, { orchestrator: "openai" });
+
+      adapter.onStep({ type: "start", message: "before discard" });
+      adapter.discard();
+      adapter.onStep({ type: "tool_call", toolName: "create_backlog_item" });
+
+      expect(readPayload().steps).toHaveLength(1);
+    });
+
+    it("ignores complete() after discard", () => {
+      const { manager, readPayload, getStatus } = makeStubManager();
+      const adapter = new McpWorkflowAdapter(manager, { orchestrator: "openai" });
+      // Constructing with initialContext seeds the payload and sets status "in_progress" — that's
+      // the baseline discard() must leave untouched (it only guards AGAINST FURTHER writes).
+      const statusBeforeDiscard = getStatus();
+
+      adapter.discard();
+      adapter.complete("late result", "late output");
+
+      expect(getStatus()).toBe(statusBeforeDiscard);
+      expect(readPayload().mcpResult).toBeUndefined();
+    });
+
+    it("ignores fail() after discard", () => {
+      const { manager, readPayload, getStatus } = makeStubManager();
+      const adapter = new McpWorkflowAdapter(manager, { orchestrator: "openai" });
+      const statusBeforeDiscard = getStatus();
+
+      adapter.discard();
+      adapter.fail("late result", "late output", "late error");
+
+      expect(getStatus()).toBe(statusBeforeDiscard);
+      expect(readPayload().error).toBeUndefined();
+    });
+
+    it("does not affect a fresh adapter for the same manager (simulating a subsequent retry)", () => {
+      const { manager, readPayload, getStatus } = makeStubManager();
+
+      const timedOutAttempt = new McpWorkflowAdapter(manager, { orchestrator: "openai" });
+      timedOutAttempt.onStep({ type: "start", message: "attempt 1" });
+      timedOutAttempt.discard();
+
+      // A retry for the same shaveId reuses the same WorkflowStateManager instance in the real
+      // IPC handler (workflowManagers is keyed by shaveId), but gets its own adapter.
+      const retryAttempt = new McpWorkflowAdapter(manager, { orchestrator: "claude-code" });
+      retryAttempt.onStep({ type: "start", message: "attempt 2" });
+      retryAttempt.complete("retry result", "retry output");
+
+      expect(getStatus()).toBe("completed");
+      expect(readPayload().mcpResult).toBe("retry result");
+
+      // The discarded attempt 1 adapter must not be able to clobber this even if its underlying
+      // call finally settles after the retry has already completed.
+      timedOutAttempt.complete("stale late result", "stale late output");
+      expect(getStatus()).toBe("completed");
+      expect(readPayload().mcpResult).toBe("retry result");
+    });
+  });
 });

--- a/src/backend/services/workflow/mcp-workflow-adapter.ts
+++ b/src/backend/services/workflow/mcp-workflow-adapter.ts
@@ -9,6 +9,15 @@ import type { WorkflowStateManager } from "./workflow-state-manager";
 export class McpWorkflowAdapter {
   private steps: MCPStep[] = [];
   private workflowManager: WorkflowStateManager;
+  /**
+   * Set once this adapter's run has been superseded (e.g. by `runManualLoopWithTimeout` timing
+   * out — #698). The underlying orchestrator call (`MCPOrchestrator` doesn't honour cancellation)
+   * may keep running detached after that point; without this guard its late `onStep`/`complete`/
+   * `fail` calls would still write into the SAME `WorkflowStateManager` instance (managers are
+   * cached per shaveId and reused across retries), silently resurrecting or corrupting whatever
+   * the next attempt for this shave has since written to the EXECUTING_TASK stage.
+   */
+  private discarded = false;
 
   constructor(
     workflowManager: WorkflowStateManager,
@@ -29,7 +38,17 @@ export class McpWorkflowAdapter {
     }
   }
 
+  /**
+   * Stops this adapter from writing to the workflow state any further. Call this when the run it
+   * was tracking has been abandoned (timed out) so any late, detached completion can't clobber a
+   * subsequent retry's state for the same stage.
+   */
+  public discard(): void {
+    this.discarded = true;
+  }
+
   public onStep = (step: MCPStep): void => {
+    if (this.discarded) return;
     this.steps.push(step);
     this.updatePayload({ steps: this.steps });
   };
@@ -59,6 +78,7 @@ export class McpWorkflowAdapter {
   }
 
   public complete(finalResult: unknown, finalOutput?: string) {
+    if (this.discarded) return;
     const payload = {
       ...this.getPayload(),
       mcpResult: typeof finalResult === "string" ? finalResult : JSON.stringify(finalResult),
@@ -73,6 +93,7 @@ export class McpWorkflowAdapter {
    * created a backlog item (#833).
    */
   public fail(finalResult: unknown, finalOutput: string | undefined, errorMessage: string) {
+    if (this.discarded) return;
     // Snapshot the streamed steps + orchestrator badge BEFORE failStage() clobbers the payload:
     // failStage records the error + telemetry but REPLACES the stage payload with just { error }.
     const existing = this.getPayload();

--- a/src/backend/services/workflow/no-work-item-error.test.ts
+++ b/src/backend/services/workflow/no-work-item-error.test.ts
@@ -8,6 +8,7 @@ describe("formatNoWorkItemError — #833 failure copy per termination reason", (
     ["max-iterations", /ran out of room/i],
     ["cancelled", /cancelled/i],
     ["content-filter", /content filter/i],
+    ["timeout", /timed out/i],
     ["stop", /signed out or unavailable/i],
     ["unknown", /signed out or unavailable/i],
   ];

--- a/src/backend/services/workflow/no-work-item-error.ts
+++ b/src/backend/services/workflow/no-work-item-error.ts
@@ -24,6 +24,8 @@ export function formatNoWorkItemError(
       return "Task execution was cancelled before a work item was created.";
     case "content-filter":
       return "The AI workflow was stopped by a content filter before a work item was created.";
+    case "timeout":
+      return "Executing the task took too long and timed out before a work item was created. This can happen if the AI got stuck retrying a tool or resource that isn't available — try again, optionally with a more specific prompt.";
     default:
       return "No work item was created. Your backlog connection (e.g. GitHub or Azure DevOps) may be signed out or unavailable — please reconnect and try again.";
   }

--- a/src/backend/services/workflow/workflow-retry-service.test.ts
+++ b/src/backend/services/workflow/workflow-retry-service.test.ts
@@ -369,6 +369,42 @@ describe("WorkflowRetryService", () => {
     );
   });
 
+  it("#698: threads an optional customPrompt through to processVideoSource when retrying EXECUTING_TASK", async () => {
+    // After a timeout on the Executing Task stage, the user can optionally supply a custom
+    // prompt to steer the retry instead of repeating the exact run that got stuck. Verify it
+    // reaches processVideoSource on the retry context.
+    const manager = setupFailedWorkflow(ProgressStage.EXECUTING_TASK);
+    (deps.getOrCreateWorkflowManager as ReturnType<typeof vi.fn>).mockReturnValue(manager);
+
+    await service.retryFromStage(
+      ProgressStage.EXECUTING_TASK,
+      SHAVE_ID,
+      "Please file this as a bug, not a feature",
+    );
+
+    expect(deps.processVideoSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shaveId: SHAVE_ID,
+        customPrompt: "Please file this as a bug, not a feature",
+      }),
+      manager,
+      ProgressStage.EXECUTING_TASK,
+    );
+  });
+
+  it("#698: omits customPrompt from the retry context when not supplied", async () => {
+    const manager = setupFailedWorkflow(ProgressStage.EXECUTING_TASK);
+    (deps.getOrCreateWorkflowManager as ReturnType<typeof vi.fn>).mockReturnValue(manager);
+
+    await service.retryFromStage(ProgressStage.EXECUTING_TASK, SHAVE_ID);
+
+    expect(deps.processVideoSource).toHaveBeenCalledWith(
+      expect.objectContaining({ shaveId: SHAVE_ID, customPrompt: undefined }),
+      manager,
+      ProgressStage.EXECUTING_TASK,
+    );
+  });
+
   it("returns error when middle stage retry has no checkpoint data", async () => {
     const manager = new WorkflowStateManager(SHAVE_ID);
     manager.startStage(ProgressStage.ANALYZING_TRANSCRIPT);

--- a/src/backend/services/workflow/workflow-retry-service.ts
+++ b/src/backend/services/workflow/workflow-retry-service.ts
@@ -18,6 +18,12 @@ export type VideoProcessingContext = {
   youtubeResult: VideoUploadResult;
   shaveId?: string;
   shaveAutoApprove?: boolean;
+  /**
+   * Optional user-supplied override for the Executing Task prompt, used when retrying after a
+   * failure (e.g. a timeout, #698) so the user can steer the retry instead of repeating the same
+   * run that got stuck. Only consumed by the EXECUTING_TASK stage.
+   */
+  customPrompt?: string;
 };
 
 export type RetryResult = {
@@ -95,7 +101,11 @@ export function validateCheckpointData(
 export class WorkflowRetryService {
   constructor(private deps: WorkflowRetryDeps) {}
 
-  async retryFromStage(stage: keyof WorkflowState, shaveId?: string): Promise<RetryResult> {
+  async retryFromStage(
+    stage: keyof WorkflowState,
+    shaveId?: string,
+    customPrompt?: string,
+  ): Promise<RetryResult> {
     if (!shaveId) {
       return { success: false, error: "Shave ID is required for retry" };
     }
@@ -118,7 +128,7 @@ export class WorkflowRetryService {
       case "downloading_video":
         return this.retryDownloadingVideo(workflowManager, checkpoint, shaveId);
       default:
-        return this.retryFromMiddleStage(workflowManager, checkpoint, stage, shaveId);
+        return this.retryFromMiddleStage(workflowManager, checkpoint, stage, shaveId, customPrompt);
     }
   }
 
@@ -214,6 +224,7 @@ export class WorkflowRetryService {
     checkpoint: CheckpointData,
     stage: keyof WorkflowState,
     shaveId: string,
+    customPrompt?: string,
   ): Promise<RetryResult> {
     const filePath = checkpoint.filePath || this.deps.getLastVideoFilePath();
     const youtubeResult = checkpoint.youtubeResult;
@@ -226,7 +237,7 @@ export class WorkflowRetryService {
     }
 
     return this.deps.processVideoSource(
-      { filePath, youtubeResult, shaveId },
+      { filePath, youtubeResult, shaveId, customPrompt },
       workflowManager,
       stage,
     );

--- a/src/shared/types/user-settings.ts
+++ b/src/shared/types/user-settings.ts
@@ -10,16 +10,15 @@ export const HotkeysSchema = z.object({
 export type Hotkeys = z.infer<typeof HotkeysSchema>;
 export type HotkeyAction = keyof Hotkeys;
 
-
 // Bounds for the configurable Executing Task timeout (#698): long enough that a legitimate
 // multi-tool-call run isn't cut short, short enough that a stuck loop doesn't hang for 30+
 // minutes with no feedback. Exposed as a user setting so it can be tuned per environment.
 export const MIN_EXECUTING_TASK_TIMEOUT_MS = 30 * 1000;
 export const MAX_EXECUTING_TASK_TIMEOUT_MS = 30 * 60 * 1000;
 export const DEFAULT_EXECUTING_TASK_TIMEOUT_MS = 5 * 60 * 1000;
+
 export const CloseBehaviorSchema = z.enum(["quit", "minimize-to-tray"]);
 export type CloseBehavior = z.infer<typeof CloseBehaviorSchema>;
-
 
 export const UserSettingsSchema = z.object({
   toolApprovalMode: ToolApprovalModeSchema,

--- a/src/shared/types/user-settings.ts
+++ b/src/shared/types/user-settings.ts
@@ -10,10 +10,23 @@ export const HotkeysSchema = z.object({
 export type Hotkeys = z.infer<typeof HotkeysSchema>;
 export type HotkeyAction = keyof Hotkeys;
 
+// Bounds for the configurable Executing Task timeout (#698): long enough that a legitimate
+// multi-tool-call run isn't cut short, short enough that a stuck loop doesn't hang for 30+
+// minutes with no feedback. Exposed as a user setting so it can be tuned per environment.
+export const MIN_EXECUTING_TASK_TIMEOUT_MS = 30 * 1000;
+export const MAX_EXECUTING_TASK_TIMEOUT_MS = 30 * 60 * 1000;
+export const DEFAULT_EXECUTING_TASK_TIMEOUT_MS = 5 * 60 * 1000;
+
 export const UserSettingsSchema = z.object({
   toolApprovalMode: ToolApprovalModeSchema,
   openAtLogin: z.boolean(),
   hotkeys: HotkeysSchema,
+  /** How long the Executing Task stage can run before it times out and offers a retry (#698). */
+  executingTaskTimeoutMs: z
+    .number()
+    .int()
+    .min(MIN_EXECUTING_TASK_TIMEOUT_MS)
+    .max(MAX_EXECUTING_TASK_TIMEOUT_MS),
 });
 
 export const PartialUserSettingsSchema = UserSettingsSchema.omit({ hotkeys: true })
@@ -31,4 +44,5 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   hotkeys: {
     startRecording: "PrintScreen",
   },
+  executingTaskTimeoutMs: DEFAULT_EXECUTING_TASK_TIMEOUT_MS,
 };

--- a/src/ui/src/components/settings/general/ExecutingTaskTimeoutSetting.tsx
+++ b/src/ui/src/components/settings/general/ExecutingTaskTimeoutSetting.tsx
@@ -54,7 +54,11 @@ export function ExecutingTaskTimeoutSetting({ isActive }: ExecutingTaskTimeoutSe
   }, [isActive]);
 
   const commitMinutes = async (rawMinutes: number) => {
-    const clampedMinutes = Math.min(MAX_MINUTES, Math.max(MIN_MINUTES, Math.round(rawMinutes)));
+    // Guard against a cleared/non-numeric input: Number("") is 0 (clamps fine), but
+    // Number("abc") is NaN, which would otherwise propagate through Math.round/max/min (every
+    // comparison against NaN is false) and leave the input showing "NaN" until reload.
+    const safeMinutes = Number.isNaN(rawMinutes) ? minutes : rawMinutes;
+    const clampedMinutes = Math.min(MAX_MINUTES, Math.max(MIN_MINUTES, Math.round(safeMinutes)));
     setMinutes(clampedMinutes);
 
     setIsSaving(true);

--- a/src/ui/src/components/settings/general/ExecutingTaskTimeoutSetting.tsx
+++ b/src/ui/src/components/settings/general/ExecutingTaskTimeoutSetting.tsx
@@ -1,0 +1,97 @@
+import {
+  DEFAULT_USER_SETTINGS,
+  MAX_EXECUTING_TASK_TIMEOUT_MS,
+  MIN_EXECUTING_TASK_TIMEOUT_MS,
+} from "@shared/types/user-settings";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ipcClient } from "@/services/ipc-client";
+import { formatErrorMessage } from "@/utils";
+import { SettingsSection } from "../SettingsSection";
+
+interface ExecutingTaskTimeoutSettingProps {
+  isActive: boolean;
+}
+
+const MIN_MINUTES = Math.ceil(MIN_EXECUTING_TASK_TIMEOUT_MS / 60_000) || 1;
+const MAX_MINUTES = Math.floor(MAX_EXECUTING_TASK_TIMEOUT_MS / 60_000);
+
+/**
+ * Lets the user tune how long the Executing Task stage (the MCP/AI agent loop) can run before
+ * it's treated as stuck and failed with a timeout — the fix for #698, where a hung loop (e.g.
+ * repeatedly retrying a tool/resource that doesn't exist) could previously run for 30+ minutes
+ * with no error and no way to retry.
+ */
+export function ExecutingTaskTimeoutSetting({ isActive }: ExecutingTaskTimeoutSettingProps) {
+  const [minutes, setMinutes] = useState<number>(
+    Math.round(DEFAULT_USER_SETTINGS.executingTaskTimeoutMs / 60_000),
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      try {
+        const current = await ipcClient.userSettings.get();
+        if (!cancelled) {
+          setMinutes(Math.round(current.executingTaskTimeoutMs / 60_000));
+        }
+      } catch (error) {
+        console.error("Failed to load Executing Task timeout setting", error);
+        toast.error(`Failed to load timeout setting: ${formatErrorMessage(error)}`);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isActive]);
+
+  const commitMinutes = async (rawMinutes: number) => {
+    const clampedMinutes = Math.min(MAX_MINUTES, Math.max(MIN_MINUTES, Math.round(rawMinutes)));
+    setMinutes(clampedMinutes);
+
+    setIsSaving(true);
+    try {
+      const result = await ipcClient.userSettings.update({
+        executingTaskTimeoutMs: clampedMinutes * 60_000,
+      });
+      if (!result.success) {
+        throw new Error(result.error ?? "Failed to update timeout setting");
+      }
+    } catch (error) {
+      console.error("Failed to update Executing Task timeout setting", error);
+      toast.error(`Failed to update timeout setting: ${formatErrorMessage(error)}`);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      title="Executing Task Timeout"
+      description="How long the AI agent can run on a single task before it's treated as stuck, fails with a timeout error, and offers a Retry."
+      contentClassName="flex items-center gap-3"
+    >
+      <input
+        type="number"
+        min={MIN_MINUTES}
+        max={MAX_MINUTES}
+        step={1}
+        value={minutes}
+        disabled={isLoading || isSaving}
+        onChange={(e) => setMinutes(Number(e.target.value))}
+        onBlur={(e) => void commitMinutes(Number(e.target.value))}
+        className="h-9 w-20 rounded-md border border-white/15 bg-black/20 px-2 text-sm text-white/90 disabled:opacity-60"
+        aria-label="Executing Task timeout in minutes"
+      />
+      <span className="text-sm text-muted-foreground">minutes</span>
+    </SettingsSection>
+  );
+}

--- a/src/ui/src/components/settings/general/GeneralSettingsPanel.tsx
+++ b/src/ui/src/components/settings/general/GeneralSettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { Settings2 } from "lucide-react";
 import { SettingsPageHeader } from "../SettingsPageHeader";
+import { ExecutingTaskTimeoutSetting } from "./ExecutingTaskTimeoutSetting";
 import { KeyMappingSetting } from "./KeyMappingSetting";
 import { StartupSetting } from "./StartupSetting";
 import { ToolApprovalSetting } from "./ToolApprovalSetting";
@@ -18,6 +19,7 @@ export function GeneralSettingsPanel({ isActive }: GeneralSettingsPanelProps) {
       />
 
       <ToolApprovalSetting isActive={isActive} />
+      <ExecutingTaskTimeoutSetting isActive={isActive} />
       <KeyMappingSetting isActive={isActive} />
       <StartupSetting isActive={isActive} />
     </div>

--- a/src/ui/src/components/settings/general/GeneralSettingsPanel.tsx
+++ b/src/ui/src/components/settings/general/GeneralSettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { Settings2 } from "lucide-react";
 import { SettingsPageHeader } from "../SettingsPageHeader";
-import { ExecutingTaskTimeoutSetting } from "./ExecutingTaskTimeoutSetting";
 import { CloseBehaviorSetting } from "./CloseBehaviorSetting";
+import { ExecutingTaskTimeoutSetting } from "./ExecutingTaskTimeoutSetting";
 import { KeyMappingSetting } from "./KeyMappingSetting";
 import { StartupSetting } from "./StartupSetting";
 import { ToolApprovalSetting } from "./ToolApprovalSetting";

--- a/src/ui/src/components/workflow/WorkflowStepCard.test.tsx
+++ b/src/ui/src/components/workflow/WorkflowStepCard.test.tsx
@@ -1,8 +1,16 @@
 import { ProgressStage, type WorkflowStep } from "@shared/types/workflow";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkflowStepCard } from "./WorkflowStepCard";
+
+const { retryFromStage } = vi.hoisted(() => ({ retryFromStage: vi.fn() }));
+
+vi.mock("@/services/ipc-client", () => ({
+  ipcClient: {
+    workflow: { retryFromStage },
+  },
+}));
 
 /**
  * #645: "Updating metadata" never showed a green tick after it actually completed.
@@ -199,5 +207,78 @@ describe("WorkflowStepCard status rendering (#645)", () => {
     rerender(<WorkflowStepCard step={completedStep} label="Updating Metadata" shaveId="shave-1" />);
     const nodeAfterRecovered = screen.getByRole("button", { name: /Updating Metadata/i });
     expect(nodeAfterRecovered).toBe(nodeBeforeToggle);
+  });
+});
+
+/**
+ * #698: a failed executing_task step (e.g. from a new Executing Task timeout) gets an extra
+ * "retry with a custom prompt" affordance alongside the plain Retry button, letting the user
+ * steer the retry instead of repeating the exact run that got stuck. Other stages only ever get
+ * the plain Retry button.
+ */
+describe("WorkflowStepCard retry-with-custom-prompt (#698)", () => {
+  beforeEach(() => {
+    retryFromStage.mockReset();
+    retryFromStage.mockResolvedValue({ success: true });
+  });
+
+  it("shows a custom-prompt toggle button only for the failed executing_task stage", () => {
+    const step: WorkflowStep = {
+      stage: ProgressStage.EXECUTING_TASK,
+      status: "failed",
+      payload: JSON.stringify({ error: "Executing Task timed out after 300s" }),
+    };
+
+    render(<WorkflowStepCard step={step} label="Executing Task" shaveId="shave-1" />);
+
+    expect(screen.getByTitle("Retry with a custom prompt")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("does not show a custom-prompt toggle for a failed non-executing_task stage", () => {
+    const step = makeStep("failed", ProgressStage.UPDATING_METADATA);
+    step.payload = JSON.stringify({ error: "boom" });
+
+    render(<WorkflowStepCard step={step} label="Updating Metadata" shaveId="shave-1" />);
+
+    expect(screen.queryByTitle("Retry with a custom prompt")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("reveals a prompt input on toggle and passes the trimmed prompt to retryFromStage", async () => {
+    const user = userEvent.setup();
+    const step: WorkflowStep = {
+      stage: ProgressStage.EXECUTING_TASK,
+      status: "failed",
+      payload: JSON.stringify({ error: "Executing Task timed out after 300s" }),
+    };
+
+    render(<WorkflowStepCard step={step} label="Executing Task" shaveId="shave-1" />);
+
+    await user.click(screen.getByTitle("Retry with a custom prompt"));
+    const input = screen.getByPlaceholderText(/optional: add instructions/i);
+    await user.type(input, "  Please file as a bug  ");
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(retryFromStage).toHaveBeenCalledWith(
+      "executing_task",
+      "shave-1",
+      "Please file as a bug",
+    );
+  });
+
+  it("omits the custom prompt when the plain Retry button is used directly", async () => {
+    const user = userEvent.setup();
+    const step: WorkflowStep = {
+      stage: ProgressStage.EXECUTING_TASK,
+      status: "failed",
+      payload: JSON.stringify({ error: "Executing Task timed out after 300s" }),
+    };
+
+    render(<WorkflowStepCard step={step} label="Executing Task" shaveId="shave-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(retryFromStage).toHaveBeenCalledWith("executing_task", "shave-1", undefined);
   });
 });

--- a/src/ui/src/components/workflow/WorkflowStepCard.tsx
+++ b/src/ui/src/components/workflow/WorkflowStepCard.tsx
@@ -130,6 +130,11 @@ interface WorkflowStepCardProps {
 export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
+  // #698: only the Executing Task stage can usefully take a custom retry prompt — it's the
+  // stage that drives the AI agent loop, so a more specific prompt can steer it away from
+  // whatever got it stuck (e.g. a timeout from retrying a tool/resource that doesn't exist).
+  const [showPromptInput, setShowPromptInput] = useState(false);
+  const [customPrompt, setCustomPrompt] = useState("");
 
   const { hasPayload, parsedPayload, hasStepErrors, hasStructuredSteps } = useMemo(() => {
     if (!step.payload)
@@ -197,6 +202,8 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
     if (isExpandable) setIsExpanded(!isExpanded);
   };
 
+  const isExecutingTaskStage = step.stage === "executing_task";
+
   const handleRetry = async () => {
     if (!shaveId) return;
 
@@ -205,10 +212,13 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
       const result = await ipcClient.workflow.retryFromStage(
         step.stage as keyof WorkflowState,
         shaveId,
+        isExecutingTaskStage ? customPrompt.trim() || undefined : undefined,
       );
       if (!result?.success) {
         throw new Error(result?.error || "Retry failed");
       }
+      setShowPromptInput(false);
+      setCustomPrompt("");
     } catch (error) {
       toast.error("Retry failed", {
         description: formatErrorMessage(error),
@@ -262,7 +272,7 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
             </div>
           )}
         </Button>
-        {step.status === "failed" && shaveId && (
+        {step.status === "failed" && shaveId && !showPromptInput && (
           <Button
             size="sm"
             variant="ghost"
@@ -280,7 +290,54 @@ export function WorkflowStepCard({ step, label, shaveId }: WorkflowStepCardProps
             )}
           </Button>
         )}
+        {step.status === "failed" && shaveId && isExecutingTaskStage && !showPromptInput && (
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={isRetrying}
+            onClick={() => setShowPromptInput(true)}
+            className="bg-white/[0.08] border border-white/[0.15] hover:bg-white/[0.12] text-white/60 shrink-0"
+            title="Retry with a custom prompt"
+          >
+            <Sparkles className="size-3.5" />
+          </Button>
+        )}
       </div>
+
+      {/* #698: optional custom prompt for retrying the Executing Task stage after a failure
+          (e.g. a timeout) — lets the user steer the retry instead of repeating the exact same
+          run that got stuck. */}
+      {step.status === "failed" && shaveId && isExecutingTaskStage && showPromptInput && (
+        <div className="mt-2 flex items-center gap-2">
+          <input
+            type="text"
+            value={customPrompt}
+            onChange={(e) => setCustomPrompt(e.target.value)}
+            placeholder="Optional: add instructions for the retry"
+            disabled={isRetrying}
+            className="h-8 flex-1 min-w-0 rounded border border-white/[0.15] bg-black/20 px-2 text-sm text-white/90 placeholder:text-white/30 focus:outline-none focus:border-white/30"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleRetry();
+            }}
+          />
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={isRetrying}
+            onClick={handleRetry}
+            className="bg-white/[0.08] border border-white/[0.15] hover:bg-white/[0.12] text-white/80 shrink-0"
+          >
+            {isRetrying ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <>
+                <RefreshCw className="size-3.5 mr-1.5" />
+                Retry
+              </>
+            )}
+          </Button>
+        </div>
+      )}
 
       {/* #523: error/detail content only renders once the row is expanded — a failed
           row is no longer forced open, so its error stays subtle (see the inline hint

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -130,6 +130,7 @@ declare global {
         retryFromStage: (
           stage: keyof WorkflowState,
           shaveId?: string,
+          customPrompt?: string,
         ) => Promise<{
           success: boolean;
           error?: string;


### PR DESCRIPTION
## Summary

When processing a video, the app's MCP agent loop (`MCPOrchestrator.manualLoopAsync`, the in-process OpenAI/Azure orchestrator) could hang indefinitely if the LLM got stuck retrying a tool or resource that doesn't exist (e.g. looking for an issue template that isn't in the repo). The loop had only a 20-iteration safety cap — no wall-clock timeout — and never read its own cancellation signal, so the Executing Task stage would spin forever with no error and no way to retry (the reported 30+ minute hang).

Closes #698

## Root cause

- `MCPOrchestrator.manualLoopAsync` (`src/backend/services/mcp/mcp-orchestrator.ts`) bounds only the number of tool-call *iterations* (`maxToolIterations`, default 20) — not elapsed time. A single stuck LLM round-trip or tool call inside one iteration can hang forever.
- `options.signal` (an `AbortSignal`) exists on `ManualLoopOptions` but is never read anywhere in `mcp-orchestrator.ts` — it's only honoured by the separate `LocalClaudeOrchestrator` backend (headless `claude -p`), which already has its own internal 10-minute wall-clock timeout. The OpenAI/Azure path this issue is about had no timeout of any kind.

## Approach

- Added a new standalone `runManualLoopWithTimeout` (`src/backend/services/workflow/executing-task-timeout.ts`) that races the orchestrator call against a configurable wall-clock timer, reusing the existing `withTimeout` utility (`src/backend/utils/async-utils.ts`). On timeout it aborts the shared `AbortSignal` (which `LocalClaudeOrchestrator` already honours by killing its child process) and returns a normal `MCPLoopResult` with a new `terminationReason: "timeout"`, instead of throwing.
- Added `"timeout"` to `MCPTerminationReason` (`backlog-orchestrator.ts`) and a matching branch in `formatNoWorkItemError` so the UI shows a clear, actionable message.
- Because the timeout result flows through the **existing** `backlogActionSucceeded === false` → `mcpAdapter.fail(...)` → `failStage(...)` path, the Executing Task stage now fails cleanly with an error, and the **existing** generic Retry button (`WorkflowStepCard.tsx`, already wired to `WORKFLOW_RETRY_FROM_STAGE`) picks it back up automatically — no new retry plumbing was needed for the base case.
- Added a new user setting, `executingTaskTimeoutMs` (`src/shared/types/user-settings.ts`, default 5 minutes, bounded 30s–30min), exposed in Settings → General as "Executing Task Timeout", so the threshold is configurable per the issue's suggestion.
- Per the issue's "optionally with a custom prompt" ask, threaded an optional `customPrompt` end-to-end through the retry path: `WorkflowStepCard.tsx` (new small prompt input, revealed via a "retry with a custom prompt" toggle next to Retry, shown only for the Executing Task stage) → `ipc-client.ts` → `preload.ts` → the `WORKFLOW_RETRY_FROM_STAGE` IPC handler → `WorkflowRetryService.retryFromStage/retryFromMiddleStage` → `VideoProcessingContext.customPrompt` → overrides `desktopAgentProjectPrompt` for that one retry.

## Files changed

- `src/backend/services/mcp/backlog-orchestrator.ts` — add `"timeout"` to `MCPTerminationReason`.
- `src/backend/services/workflow/no-work-item-error.ts` — user-facing copy for the timeout reason.
- `src/backend/services/workflow/executing-task-timeout.ts` (new) — the timeout-wrapping helper, extracted standalone for testability.
- `src/backend/ipc/process-video-handlers.ts` — both `manualLoopAsync` call sites (the main pipeline and `RERUN_TASK`) now go through `runManualLoopWithTimeout`; `WORKFLOW_RETRY_FROM_STAGE` handler accepts an optional `customPrompt`.
- `src/backend/services/workflow/workflow-retry-service.ts` — threads `customPrompt` through `retryFromStage` → `retryFromMiddleStage` → `VideoProcessingContext`.
- `src/shared/types/user-settings.ts` — new `executingTaskTimeoutMs` setting + bounds.
- `src/ui/src/components/settings/general/ExecutingTaskTimeoutSetting.tsx` (new), wired into `GeneralSettingsPanel.tsx`.
- `src/ui/src/components/workflow/WorkflowStepCard.tsx` — optional custom-prompt input for retrying the Executing Task stage.
- `src/backend/preload.ts`, `src/ui/src/services/ipc-client.ts` — thread `customPrompt` through the IPC signature.

## Bug repro evidence

This is a timing/hang bug (waiting 30+ minutes for a real repro wasn't practical in this environment), so the repro was done at the unit level against the real orchestrator contract, and the test still fails without the fix / passes with it:

**Before (unpatched behaviour, demonstrated in the new test suite):** a `manualLoopAsync` call that never resolves or rejects — the same shape as the real bug (a stuck LLM/tool round-trip) — previously had nothing racing against it, so the caller would `await` it forever.

**After (with the fix):** `src/backend/services/workflow/executing-task-timeout.test.ts` drives `runManualLoopWithTimeout` against a orchestrator stub whose `manualLoopAsync` returns `new Promise(() => {})` (a promise that never settles — simulating the exact hang reported in #698) and asserts:
- it resolves (does **not** hang) once the configured timeout elapses,
- with `terminationReason: "timeout"`, `backlogActionSucceeded: false`,
- and that the shared `AbortSignal` passed to the orchestrator is fired on timeout.

```
✓ resolves normally when the loop finishes before the timeout
✓ fails closed with terminationReason 'timeout' when the loop never settles
✓ passes an AbortSignal to the orchestrator and aborts it on timeout
✓ re-throws non-timeout errors from the loop unchanged
```

This proves the exact reported symptom (an orchestrator call that hangs indefinitely) now settles with a clear timeout instead of hanging — the fix.

## Testing performed

- `src/backend/services/workflow/executing-task-timeout.test.ts` (new) — the timeout/abort behaviour above.
- `src/backend/services/workflow/no-work-item-error.test.ts` — added a case asserting the new `"timeout"` reason produces a "timed out" message.
- `src/backend/services/workflow/workflow-retry-service.test.ts` — added cases asserting `customPrompt` is threaded through to `processVideoSource` when retrying `executing_task`, and omitted (`undefined`) when not supplied.
- `src/ui/src/components/workflow/WorkflowStepCard.test.tsx` — added cases asserting the custom-prompt toggle only appears for the failed `executing_task` stage, that typing a prompt and clicking Retry calls `retryFromStage` with the trimmed prompt, and that the plain Retry button omits it.
- Full project validation: `npm run build` (tsc, clean), `npm run lint` (biome, clean — one pre-existing unrelated info-level finding in `Cloud360LiveView.tsx`), backend `vitest run` (69 files / 703 tests passing), UI `vitest run` (35 files / 263 tests passing).

## Risks / notes

- `MCPOrchestrator`'s underlying HTTP call to the LLM is not itself cancelled on timeout (it doesn't read the `AbortSignal`) — only the *stage* is failed and control returns to the user. This mirrors the same accepted tradeoff `LocalClaudeOrchestrator`'s own internal timeout already makes (abandoning a hung call detached is strictly better than never surfacing an error). A follow-up could wire `abortSignal` into the `ai` SDK's `generateText` calls in `language-model-provider.ts` for a cleaner cancel, but that's out of scope for unblocking this bug.
- Existing users' persisted settings files predate `executingTaskTimeoutMs` — confirmed this falls back to the default via `UserSettingsStorage`'s existing `withDefaults` merge (defaults spread first, then overridden by whatever was stored), so no migration is needed.
