### PR TITLE
XS✔ ◾ Fix #785: make the Settings nav scrollbar visible across OSes

### DIFF
--- a/src/ui/src/components/settings/SettingsDialog.tsx
+++ b/src/ui/src/components/settings/SettingsDialog.tsx
@@ -214,7 +214,7 @@ export function SettingsDialog() {
             className="flex-1 min-w-0 h-full overflow-hidden"
           >
             <ScrollArea className="h-full">
-              <div className="pb-4 pr-1">
+              <div className="pb-4 pr-3">
                 {activeTab?.id === "general" && (
                   <GeneralSettingsPanel isActive={open && activeTabId === "general"} />
                 )}

--- a/src/ui/src/components/settings/SettingsNav.test.tsx
+++ b/src/ui/src/components/settings/SettingsNav.test.tsx
@@ -118,3 +118,24 @@ describe("SettingsNav (#803) keyboard navigation", () => {
     expect(buttons[0]).toHaveAttribute("tabindex", "-1");
   });
 });
+
+describe("SettingsNav (#785) scrollable when window height is reduced", () => {
+  it("renders the tablist inside a scroll-area viewport, not a plain overflow div", () => {
+    // #785: the nav previously scrolled via a bare `overflow-y-auto` div, whose
+    // scrollbar is the OS/browser's native one — which can render with zero
+    // visible width (observed on Linux/GTK themes) or stay hidden until
+    // scrolled (macOS default), leaving no visible affordance that more tabs
+    // exist below the fold. The tablist must live inside the shared
+    // `ScrollArea` (the same styled-scrollbar component the settings panel
+    // uses) so it gets a visible, cross-OS-consistent scrollbar whenever its
+    // content overflows.
+    render(<SettingsNav tabs={tabs} activeTabId="general" onSelect={vi.fn()} />);
+
+    const tablist = screen.getByRole("tablist", { name: "Settings sections" });
+    const viewport = tablist.closest('[data-slot="scroll-area-viewport"]');
+    expect(viewport).not.toBeNull();
+
+    const scrollAreaRoot = viewport?.closest('[data-slot="scroll-area"]');
+    expect(scrollAreaRoot).not.toBeNull();
+  });
+});

--- a/src/ui/src/components/settings/SettingsNav.tsx
+++ b/src/ui/src/components/settings/SettingsNav.tsx
@@ -1,4 +1,5 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { ScrollArea } from "../ui/scroll-area";
 import { SettingsNavHealthIndicator } from "./SettingsNavHealthIndicator";
 import type { SettingsHealthMap } from "./settings-health";
 import { nextRovingIndex } from "./settings-nav-keys";
@@ -23,7 +24,7 @@ interface SettingsNavProps {
  * Keyboard-accessible Settings options list.
  *
  * Fixes #803:
- *  - `min-h-0` lets the nav shrink inside its flex row so `overflow-y-auto`
+ *  - `min-h-0` lets the nav shrink inside its flex row so the scroll container
  *    actually engages and every tab (e.g. "Account") stays reachable instead of
  *    overflowing and being clipped.
  *  - Roving-tabindex + Up/Down/Home/End arrow navigation (the list previously
@@ -35,6 +36,16 @@ interface SettingsNavProps {
  *    was vetoed by the unsaved-changes guard (where `activeIndex` doesn't change
  *    and the resync effect below wouldn't fire). A later Arrow press then steps
  *    from where the user visibly is, not a stale keyboard position.
+ *
+ * Fixes #785:
+ *  - The list previously scrolled via plain `overflow-y-auto`, which relies on
+ *    the OS/browser's native scrollbar. That scrollbar can render with zero
+ *    visible width (seen on Linux/GTK themes, and macOS's default
+ *    hidden-until-scroll setting), leaving no visual affordance that the list
+ *    has more content below the fold even though wheel/trackpad scrolling
+ *    mechanically works. Wrapping the tablist in the same `ScrollArea` used by
+ *    the settings panel gives it the app's styled, always-visible scrollbar
+ *    thumb consistently across OSes, matching AC3/AC4/AC5.
  */
 export function SettingsNav({ tabs, activeTabId, panelId, onSelect, tabHealth }: SettingsNavProps) {
   const activeIndex = Math.max(
@@ -61,40 +72,42 @@ export function SettingsNav({ tabs, activeTabId, panelId, onSelect, tabHealth }:
   };
 
   return (
-    <div
-      aria-label="Settings sections"
-      role="tablist"
-      aria-orientation="vertical"
-      onKeyDown={handleKeyDown}
-      className="w-48 flex flex-col gap-1 flex-shrink-0 overflow-y-auto pr-1 min-h-0"
-    >
-      {tabs.map((tab, index) => {
-        const isActive = tab.id === activeTabId;
-        const health = tabHealth?.[tab.id];
-        return (
-          <button
-            key={tab.id}
-            ref={(el: HTMLButtonElement | null) => {
-              buttonsRef.current[index] = el;
-            }}
-            type="button"
-            role="tab"
-            aria-selected={isActive}
-            aria-controls={panelId}
-            tabIndex={index === focusIndex ? 0 : -1}
-            onFocus={() => setFocusIndex(index)}
-            onClick={() => onSelect(tab.id)}
-            className={`group relative flex items-center justify-between gap-2 text-left px-3 py-2.5 rounded-md transition-colors border border-transparent ${
-              isActive
-                ? "bg-white/10 border-white/20 text-white"
-                : "text-white/80 hover:bg-white/5 hover:text-white"
-            }`}
-          >
-            <div className="text-sm font-medium">{tab.label}</div>
-            {health ? <SettingsNavHealthIndicator health={health} /> : null}
-          </button>
-        );
-      })}
-    </div>
+    <ScrollArea type="auto" className="w-48 h-full flex-shrink-0 min-h-0">
+      <div
+        aria-label="Settings sections"
+        role="tablist"
+        aria-orientation="vertical"
+        onKeyDown={handleKeyDown}
+        className="flex flex-col gap-1 pr-3"
+      >
+        {tabs.map((tab, index) => {
+          const isActive = tab.id === activeTabId;
+          const health = tabHealth?.[tab.id];
+          return (
+            <button
+              key={tab.id}
+              ref={(el: HTMLButtonElement | null) => {
+                buttonsRef.current[index] = el;
+              }}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={panelId}
+              tabIndex={index === focusIndex ? 0 : -1}
+              onFocus={() => setFocusIndex(index)}
+              onClick={() => onSelect(tab.id)}
+              className={`group relative flex items-center justify-between gap-2 text-left px-3 py-2.5 rounded-md transition-colors border border-transparent ${
+                isActive
+                  ? "bg-white/10 border-white/20 text-white"
+                  : "text-white/80 hover:bg-white/5 hover:text-white"
+              }`}
+            >
+              <div className="text-sm font-medium">{tab.label}</div>
+              {health ? <SettingsNavHealthIndicator health={health} /> : null}
+            </button>
+          );
+        })}
+      </div>
+    </ScrollArea>
   );
 }


### PR DESCRIPTION
## Summary

The Settings side-nav list already scrolled *mechanically* (fixed in #803 via `overflow-y-auto` + `min-h-0`), but relied on the OS/browser's native scrollbar to signal that. That scrollbar can render with effectively zero visible width or stay hidden until actively scrolled, so at a reduced window height the list looked clipped with no indication more tabs existed below the fold — matching the symptom in this issue's video/screenshot. This PR wraps the nav in the same styled `ScrollArea` component the settings content panel already uses, with `type="auto"`, so a visible scrollbar thumb renders immediately whenever the list overflows, consistently across OSes.

Closes #785

Requested by: @griffenedge

## What changed

| File | Change |
|------|--------|
| `src/ui/src/components/settings/SettingsNav.tsx` | Wrap the `role="tablist"` nav in the shared `ScrollArea`/`ScrollBar` (Radix) component, `type="auto"`, instead of a bare `overflow-y-auto` div. Preserves the existing `min-h-0` flex-shrink behavior, roving-tabindex keyboard nav, and focus-follow logic from #803 unchanged. |
| `src/ui/src/components/settings/SettingsNav.test.tsx` | Adds a regression test asserting the tablist renders inside a `scroll-area-viewport`/`scroll-area` (guards against a future refactor silently dropping the wrapper). |

## Decisions

- **Decision:** Reuse the existing `ScrollArea` UI component (already used by the settings content panel) rather than styling the native scrollbar with custom CSS (e.g. `::-webkit-scrollbar`).
  - **Why:** Keeps scrollbar treatment consistent with the rest of Settings, avoids maintaining separate cross-browser scrollbar CSS, and Radix's `ScrollArea` already ships in the project's dependencies.
  - **Alternatives considered:** Custom `::-webkit-scrollbar` styling — rejected because it's WebKit/Blink-only and wouldn't guarantee visibility in the packaged Electron/Chromium runtime the same way as an explicitly-rendered scrollbar element, and would duplicate styling already defined for the panel's `ScrollArea`.
- **Decision:** Use `type="auto"` (renders only while content actually overflows) rather than `type="always"` (always rendered, even with nothing to scroll).
  - **Why:** Matches AC4's "visible scrollbar **where applicable**" — showing a scrollbar track when there's nothing to scroll would be visual noise on tall windows where all tabs already fit.
  - **Alternatives considered:** Default `type="hover"` — rejected; it only mounts the scrollbar on pointer hover/scroll and auto-hides again, which is the same discoverability gap this issue reports (no persistent visual affordance that the list is scrollable).

## Acceptance criteria

- [x] AC1 — Settings menu list is scrollable when content exceeds visible vertical space → unchanged from #803 (`overflow`/`min-h-0` behavior preserved), reverified via Playwright at 220/250/300px window heights.
- [x] AC2 — All Settings menu items accessible at any supported window height → verified the last tab ("Releases") becomes fully visible and clickable after scrolling at all tested reduced heights.
- [x] AC3 — Scrolling works via mouse wheel/trackpad → verified with a real mouse-wheel event (Playwright `mouse.wheel`); `scrollTop` advances and the target tab becomes reachable.
- [x] AC4 — Visible scrollbar where applicable → this is the core fix. Confirmed a `ScrollArea` scrollbar thumb renders immediately (no hover needed) whenever the list overflows, and is absent when content fits (no unnecessary UI).
- [x] AC5 — Consistent across supported OSes → the fix replaces the OS-native scrollbar (whose visibility/style varies per OS/theme) with the app's own rendered scrollbar component, removing that OS dependency entirely.

## Testing

- [x] Unit tests added/updated (`SettingsNav.test.tsx` — new `#785` describe block; all 8 tests in the file pass)
- [ ] Integration tests added/updated (jsdom doesn't perform real layout, so the overflow/visibility behavior itself was verified with a real headless-browser rendering — see repro evidence below — rather than in vitest)
- [x] Manual testing performed (headless Chromium via Playwright against a rendering of the real component tree/CSS, see below)
- [x] Build passes (`npm run build` at root, and `npm run build` in `src/ui`)
- [x] Tests pass (`npx vitest run --exclude 'src/ui/**'` — 696/696 backend tests; `src/ui` vitest — 262/262 UI tests)
- [x] Lint / format clean (`npm run lint`, `npm run format` — no diffs, no errors)

No pre-existing failures were encountered on the base branch during validation.

## Bug repro evidence

- **Symptom (pinned):** At a reduced window height, the Settings nav list clips tabs below the visible area with **no scrollbar rendered at all** — no visual affordance that scrolling is possible, even though (post-#803) wheel-scrolling the list mechanically works.
- **Repro method:** Mounted the real `SettingsDialog`/`SettingsNav` component tree (with the project's actual Tailwind build) in the Vite dev server and drove it with headless Chromium (Playwright) at reduced viewport heights (300px/250px/220px), inspecting the rendered DOM for `[data-slot="scroll-area-scrollbar"]` and measuring `scrollHeight`/`clientHeight`/`scrollTop` before and after a synthesized mouse-wheel event.
- **Before (unpatched):** At 250px height, 8 tabs overflow the nav (`scrollHeight: 364` vs `clientHeight: 163`, `canScroll: true`), and `scrollTop` does move to `201` after a wheel event — but **zero** scrollbar-related elements exist in the DOM (native `overflow-y-auto` renders whatever the OS/browser default scrollbar is — in this Linux/Chromium environment, effectively invisible: `offsetWidth - clientWidth === 0`). Screenshots taken before/after the wheel scroll show no scrollbar track/thumb anywhere in the nav column.
- **After (patched):** Same setup, same 250px height: a `[data-slot="scroll-area-scrollbar"]` element is present in the DOM, `isVisible(): true`, with a real bounding box (`{width: 10, height: 162.5}`) rendered immediately (no hover/scroll interaction required to appear) whenever the list overflows — and disappears when the window is tall enough that all 8 tabs already fit (500px height → 0 scrollbar elements, correctly). Wheel-scroll and keyboard (Home/End/Arrow, from the #803 roving-tabindex) navigation both still correctly move `scrollTop` and bring the target tab fully into view.

## Screenshots

Captured locally during automated verification (headless Chromium, 250px viewport height) — not attached to this PR body, but the DOM/behavioral evidence above was captured from the same runs.

## Follow-up items

- None. The scroll mechanics themselves (#803) were already correct; this PR closes the remaining visibility/discoverability gap.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
