### PR TITLE
M✔ ◾ ✨ MCP Tools dialog polish: window/popup titles, inline errors, and in-place Reauthorize

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -79,7 +79,7 @@ const getAppVersion = (): string => app.getVersion();
 
 const version = getAppVersion();
 const commitHash = config.commitHash();
-const appTitle = `YakShaver`;
+const appTitle = `YakShaver Desktop`;
 
 const createMenu = (): Menu => {
   const hashString = commitHash ? `${commitHash}` : "N/A";
@@ -178,7 +178,7 @@ const createWindow = (): BrowserWindow | null => {
 
   isCreatingMainWindow = true;
 
-  const title = `YakShaver`;
+  const title = appTitle;
 
   const window = createGuardedBrowserWindow({
     width: 1200,

--- a/src/backend/ipc/channels.ts
+++ b/src/backend/ipc/channels.ts
@@ -59,6 +59,7 @@ export const IPC_CHANNELS = {
   MCP_LIST_SERVER_TOOLS: "mcp:list-server-tools",
   MCP_ADD_TOOL_TO_WHITELIST: "mcp:add-tool-to-whitelist",
   MCP_CLEAR_TOKENS: "mcp:clear-tokens",
+  MCP_REAUTHORIZE: "mcp:reauthorize",
 
   // Automated workflow
   WORKFLOW_PROGRESS_NEO: "workflow:progress-neo",

--- a/src/backend/ipc/mcp-handlers.test.ts
+++ b/src/backend/ipc/mcp-handlers.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IPC_CHANNELS } from "./channels";
+
+// Capture the handlers registered via ipcMain.handle so we can invoke them directly.
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    },
+    on: vi.fn(),
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+import { McpIPCHandlers } from "./mcp-handlers";
+
+type ManagerMock = {
+  getMcpClientAsync: ReturnType<typeof vi.fn>;
+  checkServerHealthAsync: ReturnType<typeof vi.fn>;
+};
+
+function makeManager(overrides: Partial<ManagerMock> = {}): ManagerMock {
+  return {
+    getMcpClientAsync: vi.fn(),
+    checkServerHealthAsync: vi.fn(),
+    ...overrides,
+  };
+}
+
+function invoke(channel: string, ...args: unknown[]): unknown {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for ${channel}`);
+  return handler({} as unknown, ...args);
+}
+
+describe("MCP_LIST_SERVER_TOOLS handler (#982)", () => {
+  beforeEach(() => {
+    handlers.clear();
+  });
+
+  it("throws the classified health error when the client can't be built", async () => {
+    const manager = makeManager({
+      getMcpClientAsync: vi.fn().mockResolvedValue(null),
+      checkServerHealthAsync: vi.fn().mockResolvedValue({
+        isHealthy: false,
+        isChecking: false,
+        authFailed: true,
+        error: "HTTP 401: token expired or revoked",
+      }),
+    });
+    new McpIPCHandlers(manager as unknown as ConstructorParameters<typeof McpIPCHandlers>[0]);
+
+    await expect(invoke(IPC_CHANNELS.MCP_LIST_SERVER_TOOLS, "srv-1")).rejects.toThrow(
+      "HTTP 401: token expired or revoked",
+    );
+  });
+
+  it("falls back to a generic message when health has no error string", async () => {
+    const manager = makeManager({
+      getMcpClientAsync: vi.fn().mockResolvedValue(null),
+      checkServerHealthAsync: vi.fn().mockResolvedValue({ isHealthy: false, isChecking: false }),
+    });
+    new McpIPCHandlers(manager as unknown as ConstructorParameters<typeof McpIPCHandlers>[0]);
+
+    await expect(invoke(IPC_CHANNELS.MCP_LIST_SERVER_TOOLS, "srv-1")).rejects.toThrow(
+      /Unable to connect/i,
+    );
+  });
+});

--- a/src/backend/ipc/mcp-handlers.ts
+++ b/src/backend/ipc/mcp-handlers.ts
@@ -128,6 +128,14 @@ export class McpIPCHandlers {
       },
     );
 
+    ipcMain.handle(
+      IPC_CHANNELS.MCP_REAUTHORIZE,
+      async (_event: IpcMainInvokeEvent, serverId: string) => {
+        await this.mcpServerManager.reauthorizeServerAsync(serverId);
+        return { success: true };
+      },
+    );
+
     ipcMain.on(IPC_CHANNELS.MCP_PREFILL_PROMPT, (_event, text: string) => {
       BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) {

--- a/src/backend/ipc/mcp-handlers.ts
+++ b/src/backend/ipc/mcp-handlers.ts
@@ -57,8 +57,12 @@ export class McpIPCHandlers {
       async (_event: IpcMainInvokeEvent, serverId: string) => {
         const client = await this.mcpServerManager.getMcpClientAsync(serverId);
         if (!client) {
-          // Throw the real reason (via a health check) instead of returning [],
-          // which the popup would show as a misleading "No tools available" (#982).
+          // We're already in the failure path: getMcpClientAsync returned no client,
+          // so we WILL throw. The health check here is not a retry and its boolean
+          // result is intentionally ignored — it's run purely to recover a specific
+          // error message (e.g. the 401 text) so the popup shows the real reason
+          // instead of a misleading empty "No tool available" list. If it yields no
+          // message, we fall back to a generic connection error (#982).
           const health = await this.mcpServerManager.checkServerHealthAsync(serverId);
           throw new Error(
             health.error ??

--- a/src/backend/ipc/mcp-handlers.ts
+++ b/src/backend/ipc/mcp-handlers.ts
@@ -57,7 +57,13 @@ export class McpIPCHandlers {
       async (_event: IpcMainInvokeEvent, serverId: string) => {
         const client = await this.mcpServerManager.getMcpClientAsync(serverId);
         if (!client) {
-          return [] as MCPToolSummary[];
+          // Throw the real reason (via a health check) instead of returning [],
+          // which the popup would show as a misleading "No tools available" (#982).
+          const health = await this.mcpServerManager.checkServerHealthAsync(serverId);
+          throw new Error(
+            health.error ??
+              "Unable to connect to the MCP server. Check the connection and try again.",
+          );
         }
         const raw = await client.listToolsAsync();
         if (Array.isArray(raw)) {

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -75,6 +75,7 @@ const IPC_CHANNELS = {
   MCP_LIST_SERVER_TOOLS: "mcp:list-server-tools",
   MCP_ADD_TOOL_TO_WHITELIST: "mcp:add-tool-to-whitelist",
   MCP_CLEAR_TOKENS: "mcp:clear-tokens",
+  MCP_REAUTHORIZE: "mcp:reauthorize",
 
   // Automated workflow
   WORKFLOW_PROGRESS_NEO: "workflow:progress-neo",
@@ -319,6 +320,8 @@ const electronAPI = {
       ipcRenderer.invoke(IPC_CHANNELS.MCP_LIST_SERVER_TOOLS, serverId),
     clearTokensAsync: (serverId: string) =>
       ipcRenderer.invoke(IPC_CHANNELS.MCP_CLEAR_TOKENS, serverId),
+    reauthorizeAsync: (serverId: string) =>
+      ipcRenderer.invoke(IPC_CHANNELS.MCP_REAUTHORIZE, serverId),
   },
   settings: {
     getAllPrompts: () => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_GET_ALL_PROMPTS),

--- a/src/backend/services/mcp/mcp-oauth.test.ts
+++ b/src/backend/services/mcp/mcp-oauth.test.ts
@@ -1,3 +1,4 @@
+import { shell } from "electron";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({ shell: { openExternal: vi.fn() } }));
@@ -17,6 +18,7 @@ vi.mock("../storage/mcp-oauth-token-storage", () => ({
 }));
 
 import {
+  authorizeWithBackend,
   extractUpstreamOAuthErrorCode,
   isInvalidRefreshTokenError,
   McpTokenRefreshError,
@@ -269,5 +271,53 @@ describe("refreshTokenWithBackendWithRetry — bounded retry on transient failur
     expect(isInvalidRefreshTokenError(error)).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(sleep).not.toHaveBeenCalled();
+  });
+});
+
+describe("authorizeWithBackend — concurrent de-duplication (#982)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("opens only ONE browser tab when the same server is authorized concurrently", async () => {
+    const openExternal = vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+    openExternal.mockClear();
+    // getAuthUrlFromBackend does a fetch → return an auth URL.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse(200, { authorizationUrl: "https://auth.test/go" })),
+    );
+    // waitForTokens resolves immediately when the store already yields a token.
+    const tokenStorage = {
+      getTokensAsync: vi.fn().mockResolvedValue(TOKENS),
+    } as unknown as import("../storage/mcp-oauth-token-storage").McpOAuthTokenStorage;
+
+    // Fire two authorizations for the SAME serverId at once.
+    const [a, b] = await Promise.all([
+      authorizeWithBackend(tokenStorage, "https://srv", "srv-1"),
+      authorizeWithBackend(tokenStorage, "https://srv", "srv-1"),
+    ]);
+
+    expect(a).toEqual(TOKENS);
+    expect(b).toEqual(TOKENS);
+    // The dedup means only one browser tab / one backend auth-URL fetch happened.
+    expect(openExternal).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a fresh authorization after the previous one settles", async () => {
+    const openExternal = vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+    openExternal.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse(200, { authorizationUrl: "https://auth.test/go" })),
+    );
+    const tokenStorage = {
+      getTokensAsync: vi.fn().mockResolvedValue(TOKENS),
+    } as unknown as import("../storage/mcp-oauth-token-storage").McpOAuthTokenStorage;
+
+    await authorizeWithBackend(tokenStorage, "https://srv", "srv-1");
+    await authorizeWithBackend(tokenStorage, "https://srv", "srv-1");
+
+    // Sequential (not concurrent) calls each open their own tab — the entry is
+    // cleared once settled, so a later re-auth is not swallowed.
+    expect(openExternal).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/backend/services/mcp/mcp-oauth.ts
+++ b/src/backend/services/mcp/mcp-oauth.ts
@@ -177,15 +177,35 @@ export async function waitForTokens(
 /**
  * Initiates the OAuth flow using the .NET backend.
  */
+/**
+ * De-duplicates concurrent OAuth authorizations by serverId. Without this, a
+ * single Reauthorize (which clears the token) races the health-check and
+ * list-tools paths — each rediscovers "no token" and opens its own browser tab,
+ * so the user gets several authorization pages for one action (#982).
+ */
+const inFlightAuthorizations = new Map<string, Promise<OAuthTokens>>();
+
 export async function authorizeWithBackend(
   tokenStorage: McpOAuthTokenStorage,
   serverUrl: string,
   serverId: string,
   timeoutMs: number = 60000,
 ): Promise<OAuthTokens> {
-  const authUrl = await getAuthUrlFromBackend(serverUrl, serverId);
-  await shell.openExternal(authUrl);
-  return waitForTokens(tokenStorage, serverId, timeoutMs);
+  const existing = inFlightAuthorizations.get(serverId);
+  if (existing) return existing;
+
+  const authorization = (async () => {
+    const authUrl = await getAuthUrlFromBackend(serverUrl, serverId);
+    await shell.openExternal(authUrl);
+    return waitForTokens(tokenStorage, serverId, timeoutMs);
+  })();
+
+  inFlightAuthorizations.set(serverId, authorization);
+  try {
+    return await authorization;
+  } finally {
+    inFlightAuthorizations.delete(serverId);
+  }
 }
 
 /**

--- a/src/backend/services/mcp/mcp-server-client.test.ts
+++ b/src/backend/services/mcp/mcp-server-client.test.ts
@@ -133,4 +133,48 @@ describe("MCPServerClient.isAuthError", () => {
     expect(MCPServerClient.isAuthError({ status: 503 })).toBe(false);
     expect(MCPServerClient.isAuthError(undefined)).toBe(false);
   });
+  it("unwraps a wrapped error to find the original 401 status on cause", () => {
+    const wrapped = new Error("Failed to get tool count from MCP server: GitHub. Error: nope", {
+      cause: { status: 401 },
+    });
+    expect(MCPServerClient.isAuthError(wrapped)).toBe(true);
+  });
+  it("does not classify a wrapped non-401 cause as auth failure", () => {
+    const wrapped = new Error("Failed to get tool count", { cause: { status: 503 } });
+    expect(MCPServerClient.isAuthError(wrapped)).toBe(false);
+  });
+});
+
+// End-to-end proof for the screenshot scenario: a server that connected fine
+// (valid, non-expired token) but returns HTTP 401 on the actual MCP call must
+// be classified authFailed by the REAL chain — createClientAsync → probeHealthAsync
+// → toolCountAsync (cause-wrapping) → isAuthError. Nothing here is mocked to
+// short-circuit that classification; only the transport's tools() call is stubbed
+// to throw the exact MCPClientError string from the screenshot.
+describe("MCPServerClient.probeHealthAsync — POST-time 401 classification (#982)", () => {
+  const SCREENSHOT_401 =
+    "MCP HTTP Transport Error: POSTing to endpoint (HTTP 401): unauthorized: unauthorized: AuthenticateToken authentication failed";
+
+  it("classifies a real post-connect 401 from tools() as authFailed", async () => {
+    // Valid, non-expired token → createClientAsync builds the client and never
+    // hits the refresh/OAuth branches (mirrors GitHub after a successful connect).
+    const validTokens = {
+      access_token: "live-access",
+      refresh_token: "live-refresh",
+      expires_in: 3600,
+      storedAt: Date.now(),
+    };
+    mocks.mockStorage.getTokensAsync.mockResolvedValue(validTokens);
+    mocks.mockStorage.isTokenExpired.mockReturnValue(false);
+    // The transport builds fine, but the actual JSON-RPC call 401s.
+    mocks.createMcpClient.mockResolvedValue({
+      tools: vi.fn().mockRejectedValue(new Error(SCREENSHOT_401)),
+    });
+
+    const client = await MCPServerClient.createClientAsync(SERVER_CONFIG);
+    const probe = await client.probeHealthAsync();
+
+    expect(probe.healthy).toBe(false);
+    expect(probe.authFailed).toBe(true);
+  });
 });

--- a/src/backend/services/mcp/mcp-server-client.test.ts
+++ b/src/backend/services/mcp/mcp-server-client.test.ts
@@ -122,3 +122,15 @@ describe("MCPServerClient.createClientAsync — token refresh failure handling (
     expect(mocks.createMcpClient).toHaveBeenCalled();
   });
 });
+
+describe("MCPServerClient.isAuthError", () => {
+  it("classifies a 401 error as auth failure", () => {
+    expect(MCPServerClient.isAuthError(new Error("HTTP 401 Unauthorized"))).toBe(true);
+    expect(MCPServerClient.isAuthError({ status: 401 })).toBe(true);
+  });
+  it("does not classify network/5xx errors as auth failure", () => {
+    expect(MCPServerClient.isAuthError(new Error("fetch failed"))).toBe(false);
+    expect(MCPServerClient.isAuthError({ status: 503 })).toBe(false);
+    expect(MCPServerClient.isAuthError(undefined)).toBe(false);
+  });
+});

--- a/src/backend/services/mcp/mcp-server-client.ts
+++ b/src/backend/services/mcp/mcp-server-client.ts
@@ -255,8 +255,11 @@ export class MCPServerClient {
       }
     } catch (error) {
       const errorMsg = formatAndReportError(error, "mcp_tool_count");
+      // Preserve the original error as `cause` so callers (e.g. isAuthError) can
+      // still inspect its structured `status` (401), not just the wrapped text (#982).
       throw new Error(
         `Failed to get tool count from MCP server: ${this.mcpClientName}. Error: ${errorMsg}`,
+        { cause: error },
       );
     }
   }
@@ -284,7 +287,12 @@ export class MCPServerClient {
         : undefined;
     if (status === 401) return true;
     const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
-    return /\b401\b/.test(message) || /unauthorized/i.test(message);
+    if (/\b401\b/.test(message) || /unauthorized/i.test(message)) return true;
+    // Errors wrapped with `{ cause }` (e.g. toolCountAsync) keep the original
+    // 401's structured `status` on the cause — unwrap one level to find it (#982).
+    const cause =
+      err instanceof Error && err.cause !== undefined && err.cause !== err ? err.cause : undefined;
+    return cause !== undefined ? MCPServerClient.isAuthError(cause) : false;
   }
 
   /**

--- a/src/backend/services/mcp/mcp-server-client.ts
+++ b/src/backend/services/mcp/mcp-server-client.ts
@@ -270,6 +270,40 @@ export class MCPServerClient {
     }
   }
 
+  /**
+   * Positively identifies an OAuth/authorization failure (HTTP 401 / Unauthorized).
+   * Deliberately narrow: only a 401 counts. Network / SSL / 5xx / unknown shapes
+   * return false so the caller treats them as plain "unhealthy", not "auth-failed"
+   * (re-authorizing cannot fix those). Mirrors the conservative stance in #836.
+   */
+  public static isAuthError(err: unknown): boolean {
+    if (!err) return false;
+    const status =
+      typeof err === "object" && err !== null && "status" in err
+        ? (err as { status?: unknown }).status
+        : undefined;
+    if (status === 401) return true;
+    const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+    return /\b401\b/.test(message) || /unauthorized/i.test(message);
+  }
+
+  /**
+   * Like healthCheckAsync but classifies the failure. `authFailed` is true only
+   * when the underlying tool-list call failed with a positively-identified 401.
+   */
+  public async probeHealthAsync(): Promise<{
+    healthy: boolean;
+    toolCount: number;
+    authFailed: boolean;
+  }> {
+    try {
+      const toolCount = await this.toolCountAsync();
+      return { healthy: true, toolCount, authFailed: false };
+    } catch (err) {
+      return { healthy: false, toolCount: 0, authFailed: MCPServerClient.isAuthError(err) };
+    }
+  }
+
   public async disconnectAsync(): Promise<void> {
     await this.mcpClient.close();
   }

--- a/src/backend/services/mcp/mcp-server-client.ts
+++ b/src/backend/services/mcp/mcp-server-client.ts
@@ -295,12 +295,18 @@ export class MCPServerClient {
     healthy: boolean;
     toolCount: number;
     authFailed: boolean;
+    error?: string;
   }> {
     try {
       const toolCount = await this.toolCountAsync();
       return { healthy: true, toolCount, authFailed: false };
     } catch (err) {
-      return { healthy: false, toolCount: 0, authFailed: MCPServerClient.isAuthError(err) };
+      return {
+        healthy: false,
+        toolCount: 0,
+        authFailed: MCPServerClient.isAuthError(err),
+        error: err instanceof Error ? err.message : String(err),
+      };
     }
   }
 

--- a/src/backend/services/mcp/mcp-server-manager.test.ts
+++ b/src/backend/services/mcp/mcp-server-manager.test.ts
@@ -133,9 +133,12 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
     mocks.createClientAsync.mockReset();
     mocks.clearTokensAsync.mockReset();
     mocks.authorizeWithBackend.mockReset();
-    // Health checks now read/write the shared client cache; clear it so cases
-    // don't leak a cached client into one another (#982).
+    // Health checks now read/write the shared client cache + in-flight creation
+    // map; clear both so cases don't leak state into one another (#982).
     (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.clear();
+    (
+      MCPServerManager as unknown as { clientCreationPromises: Map<string, unknown> }
+    ).clientCreationPromises.clear();
   });
 
   it("reports authFailed when the tool probe returns 401", async () => {
@@ -298,6 +301,42 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
     expect(
       (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.get("srv-1"),
     ).toBe(cached);
+  });
+
+  it("deduplicates concurrent client creation — no leaked connection/process (#982)", async () => {
+    // Two overlapping health checks with an empty cache must share ONE client
+    // creation, not each build a client and race to overwrite the cache.
+    let resolveCreate: (client: unknown) => void = () => {};
+    const created = {
+      probeHealthAsync: vi
+        .fn()
+        .mockResolvedValue({ healthy: true, toolCount: 1, authFailed: false }),
+      disconnectAsync: vi.fn().mockResolvedValue(undefined),
+    };
+    mocks.createClientAsync.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const first = manager.checkServerHealthAsync("srv-1");
+    const second = manager.checkServerHealthAsync("srv-1");
+    // Let both calls drain their pre-creation awaits (config resolution, etc.)
+    // and reach the shared in-flight creation before it resolves.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    resolveCreate(created);
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a.isHealthy).toBe(true);
+    expect(b.isHealthy).toBe(true);
+    // The client was built exactly once and cached; nothing leaked.
+    expect(mocks.createClientAsync).toHaveBeenCalledTimes(1);
+    expect(created.disconnectAsync).not.toHaveBeenCalled();
+    expect(
+      (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.get("srv-1"),
+    ).toBe(created);
   });
 
   it("surfaces a non-empty error string when the probe fails with 401", async () => {

--- a/src/backend/services/mcp/mcp-server-manager.test.ts
+++ b/src/backend/services/mcp/mcp-server-manager.test.ts
@@ -3,6 +3,9 @@ import { GITHUB_PRESET_CONFIG, PRESET_SERVER_IDS } from "../../../shared/mcp/pre
 import type { MCPServerConfig } from "./types";
 
 const storageState = vi.hoisted(() => ({ configs: [] as MCPServerConfig[] }));
+const mocks = vi.hoisted(() => ({
+  createClientAsync: vi.fn(),
+}));
 
 vi.mock("../storage/mcp-storage", () => ({
   McpStorage: {
@@ -14,6 +17,17 @@ vi.mock("../storage/mcp-storage", () => ({
     }),
   },
 }));
+
+vi.mock("./mcp-server-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./mcp-server-client")>();
+  return {
+    ...actual,
+    MCPServerClient: {
+      ...actual.MCPServerClient,
+      createClientAsync: mocks.createClientAsync,
+    },
+  };
+});
 
 import { MCPServerManager } from "./mcp-server-manager";
 
@@ -84,5 +98,50 @@ describe("MCPServerManager server name uniqueness", () => {
       manager.updateServerAsync(server.id, { ...server, name: "GITHUB" }),
     ).rejects.toThrow("Server with name 'GITHUB' already exists");
     expect(storageState.configs.map((config) => config.name)).toEqual(["custom"]);
+  });
+});
+
+describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
+  beforeEach(() => {
+    storageState.configs = [
+      {
+        id: "srv-1",
+        name: "auth-test-server",
+        transport: "streamableHttp",
+        url: "https://mcp.example.com/",
+        enabled: true,
+      },
+    ];
+    mocks.createClientAsync.mockReset();
+  });
+
+  it("reports authFailed when the tool probe returns 401", async () => {
+    mocks.createClientAsync.mockResolvedValue({
+      probeHealthAsync: vi.fn().mockResolvedValue({
+        healthy: false,
+        toolCount: 0,
+        authFailed: true,
+      }),
+    });
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const result = await manager.checkServerHealthAsync("srv-1");
+    expect(result.isHealthy).toBe(false);
+    expect(result.authFailed).toBe(true);
+  });
+
+  it("does not set authFailed for a non-401 failure", async () => {
+    mocks.createClientAsync.mockResolvedValue({
+      probeHealthAsync: vi.fn().mockResolvedValue({
+        healthy: false,
+        toolCount: 0,
+        authFailed: false,
+      }),
+    });
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const result = await manager.checkServerHealthAsync("srv-1");
+    expect(result.isHealthy).toBe(false);
+    expect(result.authFailed).toBeFalsy();
   });
 });

--- a/src/backend/services/mcp/mcp-server-manager.test.ts
+++ b/src/backend/services/mcp/mcp-server-manager.test.ts
@@ -5,6 +5,8 @@ import type { MCPServerConfig } from "./types";
 const storageState = vi.hoisted(() => ({ configs: [] as MCPServerConfig[] }));
 const mocks = vi.hoisted(() => ({
   createClientAsync: vi.fn(),
+  clearTokensAsync: vi.fn(),
+  authorizeWithBackend: vi.fn(),
 }));
 
 vi.mock("../storage/mcp-storage", () => ({
@@ -17,6 +19,22 @@ vi.mock("../storage/mcp-storage", () => ({
     }),
   },
 }));
+
+vi.mock("../storage/mcp-oauth-token-storage", () => ({
+  McpOAuthTokenStorage: {
+    getInstance: () => ({
+      clearTokensAsync: mocks.clearTokensAsync,
+    }),
+  },
+}));
+
+vi.mock("./mcp-oauth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./mcp-oauth")>();
+  return {
+    ...actual,
+    authorizeWithBackend: mocks.authorizeWithBackend,
+  };
+});
 
 vi.mock("./mcp-server-client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./mcp-server-client")>();
@@ -113,6 +131,8 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
       },
     ];
     mocks.createClientAsync.mockReset();
+    mocks.clearTokensAsync.mockReset();
+    mocks.authorizeWithBackend.mockReset();
   });
 
   it("reports authFailed when the tool probe returns 401", async () => {
@@ -143,5 +163,18 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
     const result = await manager.checkServerHealthAsync("srv-1");
     expect(result.isHealthy).toBe(false);
     expect(result.authFailed).toBeFalsy();
+  });
+
+  it("reauthorize clears tokens and reruns OAuth without changing enabled", async () => {
+    mocks.authorizeWithBackend.mockResolvedValue({ access_token: "new-token" });
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    await manager.reauthorizeServerAsync("srv-1");
+
+    expect(mocks.clearTokensAsync).toHaveBeenCalledWith("srv-1");
+    expect(mocks.authorizeWithBackend).toHaveBeenCalled();
+
+    const cfg = (await manager.listAvailableServers()).find((s) => s.id === "srv-1");
+    expect(cfg?.enabled).not.toBe(false);
   });
 });

--- a/src/backend/services/mcp/mcp-server-manager.test.ts
+++ b/src/backend/services/mcp/mcp-server-manager.test.ts
@@ -133,6 +133,9 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
     mocks.createClientAsync.mockReset();
     mocks.clearTokensAsync.mockReset();
     mocks.authorizeWithBackend.mockReset();
+    // Health checks now read/write the shared client cache; clear it so cases
+    // don't leak a cached client into one another (#982).
+    (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.clear();
   });
 
   it("reports authFailed when the tool probe returns 401", async () => {
@@ -142,6 +145,7 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
         toolCount: 0,
         authFailed: true,
       }),
+      disconnectAsync: vi.fn().mockResolvedValue(undefined),
     });
 
     const manager = await MCPServerManager.getInstanceAsync();
@@ -157,6 +161,7 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
         toolCount: 0,
         authFailed: false,
       }),
+      disconnectAsync: vi.fn().mockResolvedValue(undefined),
     });
 
     const manager = await MCPServerManager.getInstanceAsync();
@@ -201,6 +206,100 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
     ).toBe(false);
   });
 
+  it("reuses the cached client for the probe instead of creating a new one (#982)", async () => {
+    const probeHealthAsync = vi
+      .fn()
+      .mockResolvedValue({ healthy: true, toolCount: 3, authFailed: false });
+    const cached = { probeHealthAsync, disconnectAsync: vi.fn() };
+    (
+      MCPServerManager as unknown as {
+        mcpClients: Map<string, unknown>;
+      }
+    ).mcpClients.set("srv-1", cached);
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const result = await manager.checkServerHealthAsync("srv-1");
+
+    expect(result.isHealthy).toBe(true);
+    // Probed the cached client; never spawned a fresh connection.
+    expect(probeHealthAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.createClientAsync).not.toHaveBeenCalled();
+    // The healthy cached client is left in place, untouched.
+    expect(cached.disconnectAsync).not.toHaveBeenCalled();
+    expect(
+      (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.get("srv-1"),
+    ).toBe(cached);
+  });
+
+  it("closes a freshly-created probe client when the probe fails (#982)", async () => {
+    const disconnectAsync = vi.fn().mockResolvedValue(undefined);
+    mocks.createClientAsync.mockResolvedValue({
+      probeHealthAsync: vi
+        .fn()
+        .mockResolvedValue({ healthy: false, toolCount: 0, authFailed: false }),
+      disconnectAsync,
+    });
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const result = await manager.checkServerHealthAsync("srv-1");
+
+    expect(result.isHealthy).toBe(false);
+    // The failed, never-cached probe client is closed, not leaked.
+    expect(disconnectAsync).toHaveBeenCalledTimes(1);
+    expect(
+      (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.has("srv-1"),
+    ).toBe(false);
+  });
+
+  it("evicts a cached client that fails a non-auth probe (#982)", async () => {
+    const disconnectAsync = vi.fn().mockResolvedValue(undefined);
+    const cached = {
+      probeHealthAsync: vi
+        .fn()
+        .mockResolvedValue({ healthy: false, toolCount: 0, authFailed: false }),
+      disconnectAsync,
+    };
+    (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.set(
+      "srv-1",
+      cached,
+    );
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const result = await manager.checkServerHealthAsync("srv-1");
+
+    expect(result.isHealthy).toBe(false);
+    // A dead cached client is evicted + closed so it isn't handed to the orchestrator.
+    expect(disconnectAsync).toHaveBeenCalledTimes(1);
+    expect(
+      (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.has("srv-1"),
+    ).toBe(false);
+  });
+
+  it("keeps a cached client on an auth (401) probe failure — reauth owns eviction (#982)", async () => {
+    const disconnectAsync = vi.fn().mockResolvedValue(undefined);
+    const cached = {
+      probeHealthAsync: vi
+        .fn()
+        .mockResolvedValue({ healthy: false, toolCount: 0, authFailed: true }),
+      disconnectAsync,
+    };
+    (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.set(
+      "srv-1",
+      cached,
+    );
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const result = await manager.checkServerHealthAsync("srv-1");
+
+    expect(result.isHealthy).toBe(false);
+    expect(result.authFailed).toBe(true);
+    // Left in place: the connection is still usable once re-credentialed.
+    expect(disconnectAsync).not.toHaveBeenCalled();
+    expect(
+      (MCPServerManager as unknown as { mcpClients: Map<string, unknown> }).mcpClients.get("srv-1"),
+    ).toBe(cached);
+  });
+
   it("surfaces a non-empty error string when the probe fails with 401", async () => {
     mocks.createClientAsync.mockResolvedValue({
       probeHealthAsync: vi.fn().mockResolvedValue({
@@ -209,6 +308,7 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
         authFailed: true,
         error: "HTTP 401 Unauthorized",
       }),
+      disconnectAsync: vi.fn().mockResolvedValue(undefined),
     });
 
     const manager = await MCPServerManager.getInstanceAsync();

--- a/src/backend/services/mcp/mcp-server-manager.test.ts
+++ b/src/backend/services/mcp/mcp-server-manager.test.ts
@@ -175,6 +175,47 @@ describe("MCPServerManager.checkServerHealthAsync auth classification", () => {
     expect(mocks.authorizeWithBackend).toHaveBeenCalled();
 
     const cfg = (await manager.listAvailableServers()).find((s) => s.id === "srv-1");
-    expect(cfg?.enabled).not.toBe(false);
+    expect(cfg?.enabled).toBe(true);
+  });
+
+  it("reauthorize disconnects and evicts a previously cached client", async () => {
+    mocks.authorizeWithBackend.mockResolvedValue({ access_token: "new-token" });
+    const disconnectAsync = vi.fn().mockResolvedValue(undefined);
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    (
+      MCPServerManager as unknown as {
+        mcpClients: Map<string, { disconnectAsync: () => Promise<void> }>;
+      }
+    ).mcpClients.set("srv-1", { disconnectAsync });
+
+    await manager.reauthorizeServerAsync("srv-1");
+
+    expect(disconnectAsync).toHaveBeenCalled();
+    expect(
+      (
+        MCPServerManager as unknown as {
+          mcpClients: Map<string, unknown>;
+        }
+      ).mcpClients.has("srv-1"),
+    ).toBe(false);
+  });
+
+  it("surfaces a non-empty error string when the probe fails with 401", async () => {
+    mocks.createClientAsync.mockResolvedValue({
+      probeHealthAsync: vi.fn().mockResolvedValue({
+        healthy: false,
+        toolCount: 0,
+        authFailed: true,
+        error: "HTTP 401 Unauthorized",
+      }),
+    });
+
+    const manager = await MCPServerManager.getInstanceAsync();
+    const result = await manager.checkServerHealthAsync("srv-1");
+    expect(result.isHealthy).toBe(false);
+    expect(result.authFailed).toBe(true);
+    expect(typeof result.error).toBe("string");
+    expect(result.error).not.toHaveLength(0);
   });
 });

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -32,6 +32,10 @@ export class MCPServerManager {
   private static internalClientTransports: Map<string, InMemoryTransport> = new Map();
   private static mcpClients: Map<string, MCPServerClient> = new Map();
   private static mcpClientPromises: Map<string, Promise<MCPServerClient | null>> = new Map();
+  // In-flight raw client creations, keyed by server id. Shared so concurrent
+  // callers (e.g. overlapping health checks) reuse ONE creation instead of each
+  // building a client and racing to overwrite the cache, leaking the loser (#982).
+  private static clientCreationPromises: Map<string, Promise<MCPServerClient>> = new Map();
   private constructor() {}
 
   public static async getInstanceAsync(): Promise<MCPServerManager> {
@@ -380,6 +384,42 @@ export class MCPServerManager {
     return await MCPServerManager.getAllServerConfigsAsync();
   }
 
+  /**
+   * Returns a cached client for the config, or creates one — deduplicating
+   * concurrent creations so overlapping callers share a single client and the
+   * cache is never overwritten by a racing build (which would leak the loser's
+   * connection / stdio process). The created client is cached before returning,
+   * so it is always cache-owned and never orphaned. Rejects if creation fails
+   * (callers classify the error); unlike getMcpClientAsync this does not run a
+   * health check or swallow the error (#982).
+   */
+  private static async getOrCreateClientAsync(config: MCPServerConfig): Promise<MCPServerClient> {
+    const cacheKey = config.id;
+
+    const cached = MCPServerManager.mcpClients.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const inFlight = MCPServerManager.clientCreationPromises.get(cacheKey);
+    if (inFlight) {
+      return await inFlight;
+    }
+
+    const creation = (async () => {
+      const client = await MCPServerClient.createClientAsync(config);
+      MCPServerManager.mcpClients.set(cacheKey, client);
+      return client;
+    })();
+
+    MCPServerManager.clientCreationPromises.set(cacheKey, creation);
+    try {
+      return await creation;
+    } finally {
+      MCPServerManager.clientCreationPromises.delete(cacheKey);
+    }
+  }
+
   public async checkServerHealthAsync(serverId: string): Promise<HealthStatusInfo> {
     const serverConfig = await MCPServerManager.resolveServerConfigAsync(serverId);
     if (!serverConfig) {
@@ -416,42 +456,38 @@ export class MCPServerManager {
     // spawning a fresh connection (a new stdio child process, in that transport's
     // case) on every recurring health check, and — critically — never disconnects
     // a client the orchestrator may currently be running tools through (#982).
-    const cachedClient = MCPServerManager.mcpClients.get(serverConfig.id);
     let client: MCPServerClient;
-    if (cachedClient) {
-      client = cachedClient;
-    } else {
-      try {
-        client = await MCPServerClient.createClientAsync(serverConfig);
-      } catch (err) {
-        return {
-          isHealthy: false,
-          error: String(err),
-          isChecking: false,
-          authFailed: MCPServerClient.isAuthError(err),
-        };
-      }
+    try {
+      // Deduplicate concurrent creation: two overlapping health checks must not
+      // both build a client and race to overwrite the cache, leaking the loser's
+      // connection / stdio process. getOrCreateClientAsync returns the cached
+      // client if present, else shares ONE in-flight creation via
+      // mcpClientPromises and caches the result before returning (#982).
+      client = await MCPServerManager.getOrCreateClientAsync(serverConfig);
+    } catch (err) {
+      return {
+        isHealthy: false,
+        error: String(err),
+        isChecking: false,
+        authFailed: MCPServerClient.isAuthError(err),
+      };
     }
 
+    // The client is now always cache-owned, so a probe failure just decides
+    // whether it should stay. Success: leave it. Non-auth failure: the
+    // connection / stdio process is likely dead — evict + close so the next
+    // getMcpClientAsync rebuilds a fresh one. Auth (401) failure: leave it in
+    // place; reauthorizeServerAsync owns that eviction and the connection object
+    // is still usable once re-credentialed (#982).
     const probe = await client.probeHealthAsync();
-    if (probe.healthy) {
-      // Only a freshly-created, healthy client needs caching; a reused cached
-      // client is already there and must be left untouched.
-      if (client !== cachedClient) {
-        MCPServerManager.mcpClients.set(serverConfig.id, client);
+    if (!probe.healthy && !probe.authFailed) {
+      // Only evict if the cache still holds THIS client — a concurrent reauth or
+      // health check may have already swapped it out, and we must not close the
+      // replacement or drop a newer entry.
+      if (MCPServerManager.mcpClients.get(serverConfig.id) === client) {
+        MCPServerManager.mcpClients.delete(serverConfig.id);
       }
-    } else if (client !== cachedClient) {
-      // A newly-created probe client that failed is never cached, so close it
-      // here instead of leaking its connection / stdio process (#982).
       await client.disconnectAsync().catch(() => undefined);
-    } else if (!probe.authFailed) {
-      // The *cached* client is unhealthy for a non-auth reason (its connection /
-      // stdio process is likely dead). Evict it so the next getMcpClientAsync
-      // rebuilds a fresh one instead of handing the orchestrator a dead client.
-      // Auth failures are left in place: reauthorizeServerAsync owns that eviction
-      // and the connection object itself is still usable once re-credentialed.
-      MCPServerManager.mcpClients.delete(serverConfig.id);
-      await cachedClient.disconnectAsync().catch(() => undefined);
     }
     return {
       isHealthy: probe.healthy,

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -451,13 +451,14 @@ export class MCPServerManager {
       throw new Error(`[MCPServerManager]: Reauthorize - MCP server '${serverId}' not found`);
     }
     if (config.transport !== "streamableHttp" || config.builtin || !config.url) {
-      throw new Error(
-        `[MCPServerManager]: Reauthorize - server '${serverId}' does not use OAuth`,
-      );
+      throw new Error(`[MCPServerManager]: Reauthorize - server '${serverId}' does not use OAuth`);
     }
     const tokenStorage = McpOAuthTokenStorage.getInstance();
     await tokenStorage.clearTokensAsync(serverId);
-    await MCPServerManager.mcpClients.get(config.id)?.disconnectAsync().catch(() => undefined);
+    await MCPServerManager.mcpClients
+      .get(config.id)
+      ?.disconnectAsync()
+      .catch(() => undefined);
     MCPServerManager.mcpClients.delete(config.id);
     await authorizeWithBackend(tokenStorage, expandHomePath(config.url), serverId);
   }

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -385,24 +385,55 @@ export class MCPServerManager {
       );
     }
 
-    const client = await this.getMcpClientAsync(serverId);
-    if (!client) {
+    // inMemory/builtin servers never hit the auth path; keep them on the
+    // existing null-returning cache path so they stay green.
+    if (serverConfig.transport === "inMemory") {
+      const client = await this.getMcpClientAsync(serverId);
+      if (!client) {
+        return {
+          isHealthy: false,
+          error: `MCP server client for '${serverId}' not found`,
+          isChecking: false,
+        };
+      }
+
+      const healthResult = await client.healthCheckAsync();
+
       return {
-        isHealthy: false,
-        error: `MCP server client for '${serverId}' not found`,
+        isHealthy: healthResult.healthy,
         isChecking: false,
+        successMessage:
+          healthResult.toolCount > 0
+            ? `Healthy - ${healthResult.toolCount} tools available`
+            : "Healthy",
       };
     }
 
-    const healthResult = await client.healthCheckAsync();
+    let client: MCPServerClient;
+    try {
+      client = await MCPServerClient.createClientAsync(serverConfig);
+    } catch (err) {
+      return {
+        isHealthy: false,
+        error: String(err),
+        isChecking: false,
+        authFailed: MCPServerClient.isAuthError(err),
+      };
+    }
 
+    const probe = await client.probeHealthAsync();
+    if (probe.healthy) {
+      MCPServerManager.mcpClients.set(serverConfig.id, client);
+    }
     return {
-      isHealthy: healthResult.healthy,
+      isHealthy: probe.healthy,
       isChecking: false,
-      successMessage:
-        healthResult.toolCount > 0
-          ? `Healthy - ${healthResult.toolCount} tools available`
-          : "Healthy",
+      authFailed: probe.authFailed,
+      successMessage: probe.healthy
+        ? probe.toolCount > 0
+          ? `Healthy - ${probe.toolCount} tools available`
+          : "Healthy"
+        : undefined,
     };
   }
 

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -3,8 +3,11 @@ import type { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { ToolSet } from "ai";
 import { PRESET_MCP_SERVERS } from "../../../shared/mcp/preset-servers";
 import type { HealthStatusInfo } from "../../types/index.js";
+import { McpOAuthTokenStorage } from "../storage/mcp-oauth-token-storage";
 import { McpStorage } from "../storage/mcp-storage";
+import { authorizeWithBackend } from "./mcp-oauth";
 import { type CreateClientOptions, MCPServerClient } from "./mcp-server-client";
+import { expandHomePath } from "./mcp-utils";
 import type { MCPServerConfig } from "./types";
 
 /** Fields valid ONLY on an HTTP (streamableHttp) server config. */
@@ -435,6 +438,28 @@ export class MCPServerManager {
           : "Healthy"
         : undefined,
     };
+  }
+
+  /**
+   * Re-authorizes an OAuth MCP server in place (#982): drop the dead credential,
+   * invalidate any cached client, and rerun the existing backend OAuth flow.
+   * Never mutates `enabled` — this is a credential refresh, not a disconnect.
+   */
+  public async reauthorizeServerAsync(serverId: string): Promise<void> {
+    const config = await MCPServerManager.resolveServerConfigAsync(serverId);
+    if (!config) {
+      throw new Error(`[MCPServerManager]: Reauthorize - MCP server '${serverId}' not found`);
+    }
+    if (config.transport !== "streamableHttp" || config.builtin || !config.url) {
+      throw new Error(
+        `[MCPServerManager]: Reauthorize - server '${serverId}' does not use OAuth`,
+      );
+    }
+    const tokenStorage = McpOAuthTokenStorage.getInstance();
+    await tokenStorage.clearTokensAsync(serverId);
+    await MCPServerManager.mcpClients.get(config.id)?.disconnectAsync().catch(() => undefined);
+    MCPServerManager.mcpClients.delete(config.id);
+    await authorizeWithBackend(tokenStorage, expandHomePath(config.url), serverId);
   }
 
   private static validateServerConfig(config: MCPServerConfig): void {

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -412,25 +412,46 @@ export class MCPServerManager {
       };
     }
 
+    // Reuse the cached client when one already exists: probing it avoids
+    // spawning a fresh connection (a new stdio child process, in that transport's
+    // case) on every recurring health check, and — critically — never disconnects
+    // a client the orchestrator may currently be running tools through (#982).
+    const cachedClient = MCPServerManager.mcpClients.get(serverConfig.id);
     let client: MCPServerClient;
-    try {
-      client = await MCPServerClient.createClientAsync(serverConfig);
-    } catch (err) {
-      return {
-        isHealthy: false,
-        error: String(err),
-        isChecking: false,
-        authFailed: MCPServerClient.isAuthError(err),
-      };
+    if (cachedClient) {
+      client = cachedClient;
+    } else {
+      try {
+        client = await MCPServerClient.createClientAsync(serverConfig);
+      } catch (err) {
+        return {
+          isHealthy: false,
+          error: String(err),
+          isChecking: false,
+          authFailed: MCPServerClient.isAuthError(err),
+        };
+      }
     }
 
     const probe = await client.probeHealthAsync();
     if (probe.healthy) {
-      await MCPServerManager.mcpClients
-        .get(serverConfig.id)
-        ?.disconnectAsync()
-        .catch(() => undefined);
-      MCPServerManager.mcpClients.set(serverConfig.id, client);
+      // Only a freshly-created, healthy client needs caching; a reused cached
+      // client is already there and must be left untouched.
+      if (client !== cachedClient) {
+        MCPServerManager.mcpClients.set(serverConfig.id, client);
+      }
+    } else if (client !== cachedClient) {
+      // A newly-created probe client that failed is never cached, so close it
+      // here instead of leaking its connection / stdio process (#982).
+      await client.disconnectAsync().catch(() => undefined);
+    } else if (!probe.authFailed) {
+      // The *cached* client is unhealthy for a non-auth reason (its connection /
+      // stdio process is likely dead). Evict it so the next getMcpClientAsync
+      // rebuilds a fresh one instead of handing the orchestrator a dead client.
+      // Auth failures are left in place: reauthorizeServerAsync owns that eviction
+      // and the connection object itself is still usable once re-credentialed.
+      MCPServerManager.mcpClients.delete(serverConfig.id);
+      await cachedClient.disconnectAsync().catch(() => undefined);
     }
     return {
       isHealthy: probe.healthy,

--- a/src/backend/services/mcp/mcp-server-manager.ts
+++ b/src/backend/services/mcp/mcp-server-manager.ts
@@ -426,12 +426,17 @@ export class MCPServerManager {
 
     const probe = await client.probeHealthAsync();
     if (probe.healthy) {
+      await MCPServerManager.mcpClients
+        .get(serverConfig.id)
+        ?.disconnectAsync()
+        .catch(() => undefined);
       MCPServerManager.mcpClients.set(serverConfig.id, client);
     }
     return {
       isHealthy: probe.healthy,
       isChecking: false,
       authFailed: probe.authFailed,
+      error: probe.healthy ? undefined : probe.error,
       successMessage: probe.healthy
         ? probe.toolCount > 0
           ? `Healthy - ${probe.toolCount} tools available`

--- a/src/backend/types/index.ts
+++ b/src/backend/types/index.ts
@@ -1,10 +1,5 @@
-export interface HealthStatusInfo {
-  isHealthy: boolean;
-  error?: string;
-  successMessage?: string;
-  isChecking: boolean;
-  authFailed?: boolean;
-}
+// Single shared contract — re-exported so existing `../types` imports keep working.
+export type { HealthStatusInfo } from "@shared/types/mcp";
 
 export enum ProgressStage {
   IDLE = "idle",

--- a/src/backend/types/index.ts
+++ b/src/backend/types/index.ts
@@ -3,6 +3,7 @@ export interface HealthStatusInfo {
   error?: string;
   successMessage?: string;
   isChecking: boolean;
+  authFailed?: boolean;
 }
 
 export enum ProgressStage {

--- a/src/shared/types/mcp.ts
+++ b/src/shared/types/mcp.ts
@@ -66,3 +66,16 @@ export interface MCPToolSummary {
   name: string;
   description?: string;
 }
+
+/**
+ * Result of an MCP server health check. Crosses the IPC boundary (backend
+ * produces it, UI consumes it), so it lives here as the single shared contract
+ * rather than being duplicated in backend and UI type modules (#982).
+ */
+export interface HealthStatusInfo {
+  isHealthy: boolean;
+  error?: string;
+  successMessage?: string;
+  isChecking: boolean;
+  authFailed?: boolean;
+}

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -19,7 +19,7 @@
       crossorigin
     />
 
-    <title>YakShaver</title>
+    <title>YakShaver Desktop</title>
   </head>
 
   <body>

--- a/src/ui/src/components/health-status/health-status.test.tsx
+++ b/src/ui/src/components/health-status/health-status.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { expect, it } from "vitest";
+import { HealthStatus } from "./health-status";
+
+it("shows an authentication-failed label distinct from generic unhealthy", () => {
+  render(
+    <HealthStatus isDisabled={false} isChecking={false} isHealthy={false} authFailed error="401" />,
+  );
+  expect(screen.getAllByText(/authentication failed/i).length).toBeGreaterThan(0);
+});

--- a/src/ui/src/components/health-status/health-status.tsx
+++ b/src/ui/src/components/health-status/health-status.tsx
@@ -116,7 +116,11 @@ export const HealthStatus = React.forwardRef<HTMLDivElement, HealthStatusProps>(
 
     if (authFailed) {
       return (
-        <div ref={ref} className={cn("group relative flex items-center gap-2", className)} {...props}>
+        <div
+          ref={ref}
+          className={cn("group relative flex items-center gap-2", className)}
+          {...props}
+        >
           <KeyRound className="h-5 w-5 text-ssw-red" aria-label="Authentication failed" />
           <div className="invisible group-hover:visible absolute left-0 top-6 z-10 w-max max-w-48 rounded bg-neutral-800 px-2 py-2 text-xs shadow-lg break-words whitespace-normal">
             <div className="font-semibold text-ssw-red">Authentication failed</div>

--- a/src/ui/src/components/health-status/health-status.tsx
+++ b/src/ui/src/components/health-status/health-status.tsx
@@ -1,4 +1,4 @@
-import { Ban, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { Ban, CheckCircle2, KeyRound, Loader2, XCircle } from "lucide-react";
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
@@ -15,6 +15,7 @@ interface HealthStatusProps extends React.HTMLAttributes<HTMLDivElement> {
   successMessage?: string;
   successDetails?: SuccessDetails;
   error?: string;
+  authFailed?: boolean;
 }
 
 export const HealthStatus = React.forwardRef<HTMLDivElement, HealthStatusProps>(
@@ -27,6 +28,7 @@ export const HealthStatus = React.forwardRef<HTMLDivElement, HealthStatusProps>(
       successMessage,
       successDetails,
       error,
+      authFailed,
       ...props
     },
     ref,
@@ -108,6 +110,19 @@ export const HealthStatus = React.forwardRef<HTMLDivElement, HealthStatusProps>(
               <span>{successMessage}</span>
             )}
           </div>
+        </div>
+      );
+    }
+
+    if (authFailed) {
+      return (
+        <div ref={ref} className={cn("group relative flex items-center gap-2", className)} {...props}>
+          <KeyRound className="h-5 w-5 text-ssw-red" aria-label="Authentication failed" />
+          <div className="invisible group-hover:visible absolute left-0 top-6 z-10 w-max max-w-48 rounded bg-neutral-800 px-2 py-2 text-xs shadow-lg break-words whitespace-normal">
+            <div className="font-semibold text-ssw-red">Authentication failed</div>
+            {error ? <div className="text-white/90">{error}</div> : null}
+          </div>
+          <span className="sr-only">Authentication failed</span>
         </div>
       );
     }

--- a/src/ui/src/components/health-status/health-status.tsx
+++ b/src/ui/src/components/health-status/health-status.tsx
@@ -1,4 +1,4 @@
-import { Ban, CheckCircle2, KeyRound, Loader2, XCircle } from "lucide-react";
+import { Ban, CheckCircle2, Loader2, TriangleAlert, X } from "lucide-react";
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
@@ -121,9 +121,9 @@ export const HealthStatus = React.forwardRef<HTMLDivElement, HealthStatusProps>(
           className={cn("group relative flex items-center gap-2", className)}
           {...props}
         >
-          <KeyRound className="h-5 w-5 text-ssw-red" aria-label="Authentication failed" />
+          <TriangleAlert className="h-5 w-5 text-warning" aria-label="Authentication failed" />
           <div className="invisible group-hover:visible absolute left-0 top-6 z-10 w-max max-w-48 rounded bg-neutral-800 px-2 py-2 text-xs shadow-lg break-words whitespace-normal">
-            <div className="font-semibold text-ssw-red">Authentication failed</div>
+            <div className="font-semibold text-warning">Authentication failed</div>
             {error ? <div className="text-white/90">{error}</div> : null}
           </div>
           <span className="sr-only">Authentication failed</span>
@@ -133,7 +133,7 @@ export const HealthStatus = React.forwardRef<HTMLDivElement, HealthStatusProps>(
 
     return (
       <div ref={ref} className={cn("group relative flex items-center gap-2", className)} {...props}>
-        <XCircle
+        <X
           className="h-5 w-5 text-ssw-red"
           aria-label={error ? `Unhealthy: ${error}` : "Unhealthy"}
         />

--- a/src/ui/src/components/settings/SettingsNavHealthIndicator.tsx
+++ b/src/ui/src/components/settings/SettingsNavHealthIndicator.tsx
@@ -28,10 +28,14 @@ export function SettingsNavHealthIndicator({ health }: SettingsNavHealthIndicato
         role="img"
         aria-label={`Configuration issue: ${health.message}`}
       />
-      {/* Flat, semi-transparent tooltip (no shadow) per design review (#878). */}
+      {/* Below the icon, right-aligned. Uses a SOLID background (not a translucent
+          warning tint) so it fully covers the next nav item's text instead of
+          letting it bleed through; z-50 + shadow keep it floating on top. Staying
+          inside the nav item avoids the w-48 overflow container clipping it and
+          spawning a horizontal scrollbar (which left-full did) (#982). */}
       <span
         role="tooltip"
-        className="pointer-events-none invisible absolute right-0 top-6 z-50 w-max max-w-[220px] whitespace-normal rounded-md border border-warning/40 bg-warning/15 px-2.5 py-1.5 text-left text-xs font-normal text-warning group-hover:visible group-focus-within:visible"
+        className="pointer-events-none invisible absolute right-0 top-6 z-50 w-max max-w-[220px] whitespace-normal rounded-md border border-warning/40 bg-neutral-800 px-2.5 py-1.5 text-left text-xs font-normal text-warning shadow-lg group-hover:visible group-focus-within:visible"
       >
         {health.message}
       </span>

--- a/src/ui/src/components/settings/SettingsNavHealthIndicator.tsx
+++ b/src/ui/src/components/settings/SettingsNavHealthIndicator.tsx
@@ -22,20 +22,23 @@ interface SettingsNavHealthIndicatorProps {
  */
 export function SettingsNavHealthIndicator({ health }: SettingsNavHealthIndicatorProps) {
   return (
-    <span className="relative inline-flex shrink-0 items-center">
+    // No `relative` here: the tooltip anchors to the nav button (the `group
+    // relative` ancestor) instead of this tiny icon span, so it can span the
+    // full nav-item width rather than overflowing the w-48 container from the
+    // icon's right edge (which clipped the text + spawned a scrollbar) (#982).
+    <span className="inline-flex shrink-0 items-center">
       <AlertTriangle
         className="h-4 w-4 text-warning"
         role="img"
         aria-label={`Configuration issue: ${health.message}`}
       />
-      {/* Below the icon, right-aligned. Uses a SOLID background (not a translucent
-          warning tint) so it fully covers the next nav item's text instead of
-          letting it bleed through; z-50 + shadow keep it floating on top. Staying
-          inside the nav item avoids the w-48 overflow container clipping it and
-          spawning a horizontal scrollbar (which left-full did) (#982). */}
+      {/* Anchored to the nav button: left-2/right-2 pins it inside the item's
+          horizontal padding and top-full drops it just below, so it always
+          stays within the nav column. Solid bg fully covers the item beneath;
+          z-50 + shadow keep it floating on top. */}
       <span
         role="tooltip"
-        className="pointer-events-none invisible absolute right-0 top-6 z-50 w-max max-w-[220px] whitespace-normal rounded-md border border-warning/40 bg-neutral-800 px-2.5 py-1.5 text-left text-xs font-normal text-warning shadow-lg group-hover:visible group-focus-within:visible"
+        className="pointer-events-none invisible absolute inset-x-2 top-full z-50 mt-1 whitespace-normal rounded-md border border-warning/40 bg-neutral-800 px-2.5 py-1.5 text-left text-xs font-normal text-warning shadow-lg group-hover:visible group-focus-within:visible"
       >
         {health.message}
       </span>

--- a/src/ui/src/components/settings/mcp/McpServerManager.tsx
+++ b/src/ui/src/components/settings/mcp/McpServerManager.tsx
@@ -2,7 +2,7 @@ import { Globe, Plug } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { HealthStatusInfo } from "@/types";
-import { formatErrorMessage } from "@/utils";
+import { formatErrorMessage, formatIpcErrorMessage } from "@/utils";
 import { ipcClient } from "../../../services/ipc-client";
 import {
   AlertDialog,
@@ -396,9 +396,11 @@ export function McpSettingsPanel({
               onReauthorize={async () => {
                 try {
                   await ipcClient.mcp.reauthorizeAsync(String(server.id));
-                  await loadServers({ serverIdToRefresh: String(server.id) });
                 } catch (e) {
-                  toast.error(`Failed to reauthorize: ${formatErrorMessage(e)}`);
+                  toast.error(`Failed to reauthorize: ${formatIpcErrorMessage(e)}`);
+                } finally {
+                  // Re-check health either way so a failed re-auth stays visible on the card (#982).
+                  await loadServers({ serverIdToRefresh: String(server.id) });
                 }
               }}
               onUpdate={async (newConfig) => {

--- a/src/ui/src/components/settings/mcp/McpServerManager.tsx
+++ b/src/ui/src/components/settings/mcp/McpServerManager.tsx
@@ -102,7 +102,7 @@ export function McpSettingsPanel({
             description: `Next to configure your Custom Prompt to include ${server.name} projects.`,
             duration: 8000,
           });
-        } else {
+        } else if (!result.authFailed) {
           toast.error(`Failed to connect ${server.name}`);
         }
       }
@@ -393,6 +393,14 @@ export function McpSettingsPanel({
               onTools={() => openWhitelistDialog(server)}
               onConnect={() => handleOnConnect(String(server.id), server)}
               onDisconnect={() => handleOnDisconnect(String(server.id), server)}
+              onReauthorize={async () => {
+                try {
+                  await ipcClient.mcp.reauthorizeAsync(String(server.id));
+                  await loadServers({ serverIdToRefresh: String(server.id) });
+                } catch (e) {
+                  toast.error(`Failed to reauthorize: ${formatErrorMessage(e)}`);
+                }
+              }}
               onUpdate={async (newConfig) => {
                 setEditingServer(server);
                 await handleSubmit(newConfig);

--- a/src/ui/src/components/settings/mcp/McpServerManager.tsx
+++ b/src/ui/src/components/settings/mcp/McpServerManager.tsx
@@ -1,8 +1,9 @@
 import { Globe, Plug } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { reauthorizeAndRefresh } from "@/hooks/useMcpCardActions";
 import type { HealthStatusInfo } from "@/types";
-import { formatErrorMessage, formatIpcErrorMessage } from "@/utils";
+import { formatErrorMessage } from "@/utils";
 import { ipcClient } from "../../../services/ipc-client";
 import {
   AlertDialog,
@@ -393,16 +394,11 @@ export function McpSettingsPanel({
               onTools={() => openWhitelistDialog(server)}
               onConnect={() => handleOnConnect(String(server.id), server)}
               onDisconnect={() => handleOnDisconnect(String(server.id), server)}
-              onReauthorize={async () => {
-                try {
-                  await ipcClient.mcp.reauthorizeAsync(String(server.id));
-                } catch (e) {
-                  toast.error(`Failed to reauthorize: ${formatIpcErrorMessage(e)}`);
-                } finally {
-                  // Re-check health either way so a failed re-auth stays visible on the card (#982).
-                  await loadServers({ serverIdToRefresh: String(server.id) });
-                }
-              }}
+              onReauthorize={() =>
+                reauthorizeAndRefresh(String(server.id), () =>
+                  loadServers({ serverIdToRefresh: String(server.id) }),
+                )
+              }
               onUpdate={async (newConfig) => {
                 setEditingServer(server);
                 await handleSubmit(newConfig);

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.test.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { McpWhitelistDialog } from "./McpWhitelistDialog";
+
+vi.mock("../../../services/ipc-client", () => ({
+  ipcClient: {
+    mcp: {
+      listServerTools: vi.fn().mockResolvedValue([]),
+      updateServerAsync: vi.fn().mockResolvedValue({ success: true }),
+    },
+  },
+}));
+
+const server = {
+  id: "srv-1",
+  name: "Acme",
+  transport: "streamableHttp" as const,
+  url: "https://example.com/mcp",
+  enabled: true,
+  toolWhitelist: [],
+};
+
+describe("McpWhitelistDialog", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("titles the popup 'MCP Tools'", async () => {
+    render(<McpWhitelistDialog server={server} onClose={() => {}} onSaved={() => {}} />);
+    expect(await screen.findByText("MCP Tools")).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.test.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.test.tsx
@@ -36,4 +36,29 @@ describe("McpWhitelistDialog", () => {
     render(<McpWhitelistDialog server={server} onClose={() => {}} onSaved={() => {}} />);
     expect(await screen.findByText(/Failed to load tools/i)).toBeInTheDocument();
   });
+
+  it("ignores a stale request that resolves after switching servers (#982)", async () => {
+    // First server's request never resolves until we release it, by which point
+    // the dialog has switched to the second server.
+    let releaseFirst: (tools: { name: string }[]) => void = () => {};
+    const first = new Promise<{ name: string }[]>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const listServerTools = ipcClient.mcp.listServerTools as ReturnType<typeof vi.fn>;
+    listServerTools.mockReturnValueOnce(first).mockResolvedValueOnce([{ name: "toolbeta" }]);
+
+    const serverB = { ...server, id: "srv-2", name: "Beta" };
+    const { rerender } = render(
+      <McpWhitelistDialog server={server} onClose={() => {}} onSaved={() => {}} />,
+    );
+    // Switch to server B before the first request resolves.
+    rerender(<McpWhitelistDialog server={serverB} onClose={() => {}} onSaved={() => {}} />);
+    expect(await screen.findByText(/toolbeta/i)).toBeInTheDocument();
+
+    // The stale first response arrives late — it must not overwrite server B's tools.
+    releaseFirst([{ name: "toolalpha" }]);
+    await Promise.resolve();
+    expect(screen.queryByText(/toolalpha/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/toolbeta/i)).toBeInTheDocument();
+  });
 });

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.test.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ipcClient } from "../../../services/ipc-client";
 import { McpWhitelistDialog } from "./McpWhitelistDialog";
 
 vi.mock("../../../services/ipc-client", () => ({
@@ -26,5 +27,13 @@ describe("McpWhitelistDialog", () => {
   it("titles the popup 'MCP Tools'", async () => {
     render(<McpWhitelistDialog server={server} onClose={() => {}} onSaved={() => {}} />);
     expect(await screen.findByText("MCP Tools")).toBeInTheDocument();
+  });
+
+  it("renders a load error inline instead of toasting", async () => {
+    (ipcClient.mcp.listServerTools as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("boom"),
+    );
+    render(<McpWhitelistDialog server={server} onClose={() => {}} onSaved={() => {}} />);
+    expect(await screen.findByText(/Failed to load tools/i)).toBeInTheDocument();
   });
 });

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -81,7 +81,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
     <Dialog open={open} onOpenChange={(value) => (!value ? onClose() : undefined)}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Configure Tool Whitelist</DialogTitle>
+          <DialogTitle>MCP Tools</DialogTitle>
           <DialogDescription>
             Add or remove tool from whitelist for server '{server?.name}'.
           </DialogDescription>

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -1,7 +1,8 @@
+import { AlertCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ipcClient } from "../../../services/ipc-client";
-import { formatToolName } from "../../../utils";
+import { formatIpcErrorMessage, formatToolName } from "../../../utils";
 import { Button } from "../../ui/button";
 import { Checkbox } from "../../ui/checkbox";
 import {
@@ -32,7 +33,13 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!server) return;
+    // On close, clear transient state so a re-open never shows a stale
+    // tool list or error (e.g. after reauthorizing from the card) (#982).
+    if (!server) {
+      setError(null);
+      setTools([]);
+      return;
+    }
     setIsLoading(true);
     setError(null);
     setTools([]);
@@ -45,7 +52,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
         setTools(sorted);
       })
       .catch((e) => {
-        setError(`Failed to load tools: ${String(e)}`);
+        setError(`Failed to load tools: ${formatIpcErrorMessage(e)}`);
       })
       .finally(() => setIsLoading(false));
   }, [server]);
@@ -74,7 +81,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
       toast.success(`Whitelist updated for '${server.name}'`);
       onSaved();
     } catch (e) {
-      setError(`Failed to save whitelist: ${String(e)}`);
+      setError(`Failed to save whitelist: ${formatIpcErrorMessage(e)}`);
     } finally {
       setIsSaving(false);
     }
@@ -130,9 +137,14 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
           </div>
         </ScrollArea>
         {error && (
-          <p role="alert" className="text-sm text-ssw-red break-words whitespace-normal">
-            {error}
-          </p>
+          // Persistent inline error (not a fleeting toast), styled like SettingsWarningBanner (#982).
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-ssw-red/40 bg-ssw-red/10 px-3 py-2 text-sm leading-relaxed text-ssw-red break-words whitespace-normal"
+          >
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{error}</span>
+          </div>
         )}
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={disabled}>

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -29,10 +29,12 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!server) return;
     setIsLoading(true);
+    setError(null);
     setTools([]);
     setSelected(new Set(server.toolWhitelist ?? []));
     ipcClient.mcp
@@ -43,7 +45,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
         setTools(sorted);
       })
       .catch((e) => {
-        toast.error(`Failed to load tools: ${String(e)}`);
+        setError(`Failed to load tools: ${String(e)}`);
       })
       .finally(() => setIsLoading(false));
   }, [server]);
@@ -62,6 +64,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
   const handleSave = useCallback(async () => {
     if (!server || !server.id) return;
     setIsSaving(true);
+    setError(null);
     try {
       const updated: MCPServerConfig = {
         ...server,
@@ -71,7 +74,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
       toast.success(`Whitelist updated for '${server.name}'`);
       onSaved();
     } catch (e) {
-      toast.error(`Failed to save whitelist: ${String(e)}`);
+      setError(`Failed to save whitelist: ${String(e)}`);
     } finally {
       setIsSaving(false);
     }
@@ -126,6 +129,11 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
             )}
           </div>
         </ScrollArea>
+        {error && (
+          <p role="alert" className="text-sm text-ssw-red break-words whitespace-normal">
+            {error}
+          </p>
+        )}
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={disabled}>
             Cancel

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ipcClient } from "../../../services/ipc-client";
 import { formatIpcErrorMessage, formatToolName } from "../../../utils";
+import { Alert, AlertDescription, AlertTitle } from "../../ui/alert";
 import { Button } from "../../ui/button";
 import { Checkbox } from "../../ui/checkbox";
 import {
@@ -111,7 +112,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
           <div className="flex flex-col gap-3">
             {isLoading && <p className="text-sm text-muted-foreground">Loading tools…</p>}
             {!isLoading && tools.length === 0 && !error && (
-              <p className="text-sm text-muted-foreground">No tools available.</p>
+              <p className="text-sm text-muted-foreground">No tool available</p>
             )}
             {!isLoading && tools.length > 0 && (
               <div className="flex flex-col gap-2">
@@ -148,30 +149,35 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
           </div>
         </ScrollArea>
         {error && (
-          // Persistent inline error (not a fleeting toast), styled like SettingsWarningBanner (#982).
-          <div
-            role="alert"
-            className="flex flex-col gap-1.5 rounded-md border border-ssw-red/40 bg-ssw-red/10 px-4 py-3"
-          >
-            {/* Header row: icon + "No tools available." reads as the error's title. */}
-            <div className="flex items-center gap-2 text-sm font-semibold text-ssw-red">
-              <AlertCircle className="h-4 w-4 shrink-0" />
-              <span>No tools available</span>
-            </div>
-            {/* Detail: kept verbatim, in a softer light tone + smaller size so the
-                long transport message stays legible against the dark tinted bg (#982). */}
-            <p className="pl-6 text-xs leading-relaxed text-foreground/80 wrap-break-word whitespace-normal">
+          // Persistent inline error (not a fleeting toast), built on the shared
+          // shadcn Alert primitive for consistency (#982). Red border + tint keep
+          // the "error" affordance; the detail stays verbatim in a softer light
+          // tone so the long transport message is legible on the dark tinted bg.
+          <Alert className="border-ssw-red/40 bg-ssw-red/10">
+            <AlertCircle className="text-ssw-red" />
+            <AlertTitle className="font-semibold text-ssw-red">No tool available</AlertTitle>
+            <AlertDescription className="wrap-break-word whitespace-normal text-foreground/80">
               {error}
-            </p>
-          </div>
+            </AlertDescription>
+          </Alert>
         )}
         <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={disabled}>
-            Cancel
-          </Button>
-          <Button onClick={handleSave} disabled={disabled}>
-            Save
-          </Button>
+          {error ? (
+            // On a load error there's nothing to select, so Cancel/Save are
+            // meaningless — offer a single neutral Close instead (#982).
+            <Button variant="outline" onClick={onClose}>
+              Close
+            </Button>
+          ) : (
+            <>
+              <Button variant="outline" onClick={onClose} disabled={disabled}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} disabled={disabled}>
+                Save
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -44,17 +44,28 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
     setError(null);
     setTools([]);
     setSelected(new Set(server.toolWhitelist ?? []));
+    // Guard against a late response landing after the dialog closed or the user
+    // switched servers — otherwise a stale request overwrites the current tools
+    // or error (#982).
+    let cancelled = false;
     ipcClient.mcp
       .listServerTools(server.id ?? server.name)
       .then((list) => {
+        if (cancelled) return;
         const valid = list.filter((t) => t && typeof t.name === "string");
         const sorted = [...valid].sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
         setTools(sorted);
       })
       .catch((e) => {
+        if (cancelled) return;
         setError(`Failed to load tools: ${formatIpcErrorMessage(e)}`);
       })
-      .finally(() => setIsLoading(false));
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [server]);
 
   const toggleTool = useCallback((toolName: string) => {
@@ -99,7 +110,7 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
         <ScrollArea className="max-h-[50vh] pr-2">
           <div className="flex flex-col gap-3">
             {isLoading && <p className="text-sm text-muted-foreground">Loading tools…</p>}
-            {!isLoading && tools.length === 0 && (
+            {!isLoading && tools.length === 0 && !error && (
               <p className="text-sm text-muted-foreground">No tools available.</p>
             )}
             {!isLoading && tools.length > 0 && (
@@ -140,10 +151,18 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
           // Persistent inline error (not a fleeting toast), styled like SettingsWarningBanner (#982).
           <div
             role="alert"
-            className="flex items-start gap-2 rounded-md border border-ssw-red/40 bg-ssw-red/10 px-3 py-2 text-sm leading-relaxed text-ssw-red break-words whitespace-normal"
+            className="flex flex-col gap-1.5 rounded-md border border-ssw-red/40 bg-ssw-red/10 px-4 py-3"
           >
-            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-            <span>{error}</span>
+            {/* Header row: icon + "No tools available." reads as the error's title. */}
+            <div className="flex items-center gap-2 text-sm font-semibold text-ssw-red">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span>No tools available</span>
+            </div>
+            {/* Detail: kept verbatim, in a softer light tone + smaller size so the
+                long transport message stays legible against the dark tinted bg (#982). */}
+            <p className="pl-6 text-xs leading-relaxed text-foreground/80 wrap-break-word whitespace-normal">
+              {error}
+            </p>
           </div>
         )}
         <DialogFooter>

--- a/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
+++ b/src/ui/src/components/settings/mcp/McpWhitelistDialog.tsx
@@ -154,7 +154,9 @@ export function McpWhitelistDialog({ server, onClose, onSaved }: McpWhitelistDia
           // the "error" affordance; the detail stays verbatim in a softer light
           // tone so the long transport message is legible on the dark tinted bg.
           <Alert className="border-ssw-red/40 bg-ssw-red/10">
-            <AlertCircle className="text-ssw-red" />
+            {/* text-ssw-red! overrides the Alert primitive's [&>svg]:text-current,
+                which would otherwise force the icon to the container's white. */}
+            <AlertCircle className="text-ssw-red!" />
             <AlertTitle className="font-semibold text-ssw-red">No tool available</AlertTitle>
             <AlertDescription className="wrap-break-word whitespace-normal text-foreground/80">
               {error}

--- a/src/ui/src/components/settings/mcp/devops/mcp-devops-card.tsx
+++ b/src/ui/src/components/settings/mcp/devops/mcp-devops-card.tsx
@@ -25,7 +25,7 @@ export function McpAzureDevOpsCard({
 }: McpDevOpsCardProps) {
   const configLocal = config ?? AZURE_DEVOPS_PRESET_CONFIG;
 
-  const { handleOnConnect, handleOnDisconnect } = useMcpCardActions(
+  const { handleOnConnect, handleOnDisconnect, handleOnReauthorize } = useMcpCardActions(
     McpAzureDevOpsCard.Id,
     configLocal,
     onChange,
@@ -38,6 +38,7 @@ export function McpAzureDevOpsCard({
       healthInfo={healthInfo}
       onConnect={handleOnConnect}
       onDisconnect={handleOnDisconnect}
+      onReauthorize={handleOnReauthorize}
       onTools={onTools}
       viewMode={viewMode}
       hideDelete={true}

--- a/src/ui/src/components/settings/mcp/github/mcp-github-card.tsx
+++ b/src/ui/src/components/settings/mcp/github/mcp-github-card.tsx
@@ -25,7 +25,7 @@ export function McpGitHubCard({
 }: McpGitHubCardProps) {
   const configLocal = config ?? GITHUB_PRESET_CONFIG;
 
-  const { handleOnConnect, handleOnDisconnect } = useMcpCardActions(
+  const { handleOnConnect, handleOnDisconnect, handleOnReauthorize } = useMcpCardActions(
     McpGitHubCard.Id,
     configLocal,
     onChange,
@@ -39,6 +39,7 @@ export function McpGitHubCard({
       healthInfo={healthInfo}
       onConnect={handleOnConnect}
       onDisconnect={handleOnDisconnect}
+      onReauthorize={handleOnReauthorize}
       onTools={onTools}
       viewMode={viewMode}
     />

--- a/src/ui/src/components/settings/mcp/jira/mcp-jira-card.tsx
+++ b/src/ui/src/components/settings/mcp/jira/mcp-jira-card.tsx
@@ -28,7 +28,7 @@ export function McpJiraCard({ config, onChange, healthInfo, onTools, viewMode }:
   const [setupExpanded, setSetupExpanded] = useState(false);
   const { copyToClipboard, copied } = useClipboard();
 
-  const { handleOnConnect, handleOnDisconnect } = useMcpCardActions(
+  const { handleOnConnect, handleOnDisconnect, handleOnReauthorize } = useMcpCardActions(
     McpJiraCard.Id,
     configLocal,
     onChange,
@@ -114,6 +114,7 @@ export function McpJiraCard({ config, onChange, healthInfo, onTools, viewMode }:
       config={configLocal}
       healthInfo={healthInfo}
       onDisconnect={handleDisconnect}
+      onReauthorize={handleOnReauthorize}
       onTools={onTools}
       viewMode={viewMode}
       extraContent={setupSection}

--- a/src/ui/src/components/settings/mcp/mcp-card.test.tsx
+++ b/src/ui/src/components/settings/mcp/mcp-card.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { McpCard } from "./mcp-card";
+
+const config = {
+  id: "srv-1",
+  name: "Acme",
+  transport: "streamableHttp" as const,
+  url: "https://example.com/mcp",
+  enabled: true,
+};
+
+it("shows Reauthorize (not Disconnect) when authFailed", () => {
+  const onReauthorize = vi.fn();
+  render(
+    <McpCard
+      icon={<span />}
+      config={config}
+      viewMode="detailed"
+      healthInfo={{ isHealthy: false, isChecking: false, authFailed: true }}
+      onDisconnect={vi.fn()}
+      onReauthorize={onReauthorize}
+    />,
+  );
+  expect(screen.queryByRole("button", { name: /disconnect/i })).toBeNull();
+  fireEvent.click(screen.getByRole("button", { name: /reauthorize/i }));
+  expect(onReauthorize).toHaveBeenCalled();
+});
+
+it("shows Disconnect (not Reauthorize) when unhealthy but not authFailed", () => {
+  render(
+    <McpCard
+      icon={<span />}
+      config={config}
+      viewMode="detailed"
+      healthInfo={{ isHealthy: false, isChecking: false, authFailed: false }}
+      onDisconnect={vi.fn()}
+      onReauthorize={vi.fn()}
+    />,
+  );
+  expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /reauthorize/i })).toBeNull();
+});

--- a/src/ui/src/components/settings/mcp/mcp-card.tsx
+++ b/src/ui/src/components/settings/mcp/mcp-card.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from "lucide-react";
 import { useRef, useState } from "react";
 import { HealthStatus } from "@/components/health-status/health-status";
 import { Button } from "@/components/ui/button";
@@ -12,7 +13,7 @@ interface McpCardProps {
   healthInfo?: HealthStatusInfo | null;
   onDisconnect?: () => void;
   onConnect?: () => void;
-  onReauthorize?: () => void;
+  onReauthorize?: () => void | Promise<void>;
   onDelete?: () => void;
   hideDelete?: boolean;
   onUpdate?: (data: MCPServerConfig) => Promise<void>;
@@ -40,7 +41,22 @@ export function McpCard({
   renderConnectButton,
 }: McpCardProps) {
   const [showSettings, setShowSettings] = useState(false);
+  const [isReauthorizing, setIsReauthorizing] = useState(false);
   const actionsRef = useRef<HTMLDivElement>(null);
+  // Auth-failed servers show Reauthorize in place of Disconnect (#982).
+  const showReauthorize = Boolean(healthInfo?.authFailed && onReauthorize);
+
+  // Latch a stable button for the whole re-auth round-trip so it doesn't
+  // flicker through other states while the parent re-checks health (#982).
+  const handleReauthorizeClick = async () => {
+    if (isReauthorizing) return;
+    setIsReauthorizing(true);
+    try {
+      await onReauthorize?.();
+    } finally {
+      setIsReauthorizing(false);
+    }
+  };
   return (
     <>
       {/* biome-ignore lint : lint message can be ignored for now as we don't support fully keyboard navigation and waiting for new designs */}
@@ -80,42 +96,51 @@ export function McpCard({
                   Tools
                 </Button>
               )}
-              {!config.enabled && renderConnectButton && renderConnectButton()}
-              {!config.enabled && !renderConnectButton && (
-                <Button
-                  variant="outline"
-                  className="w-28 cursor-pointer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onConnect?.();
-                  }}
-                >
-                  Connect
+              {isReauthorizing ? (
+                <Button variant="warningOutline" className="min-w-28" disabled>
+                  <Loader2 className="size-4 shrink-0 animate-spin" />
+                  Reauthorizing…
                 </Button>
-              )}
-              {config.enabled && healthInfo?.authFailed && onReauthorize && (
-                <Button
-                  variant="outline"
-                  className="w-28 cursor-pointer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onReauthorize();
-                  }}
-                >
-                  Reauthorize
-                </Button>
-              )}
-              {config.enabled && !(healthInfo?.authFailed && onReauthorize) && (
-                <Button
-                  variant="destructiveOutline"
-                  className="w-28 cursor-pointer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDisconnect?.();
-                  }}
-                >
-                  Disconnect
-                </Button>
+              ) : (
+                <>
+                  {!config.enabled && renderConnectButton && renderConnectButton()}
+                  {!config.enabled && !renderConnectButton && (
+                    <Button
+                      variant="outline"
+                      className="w-28 cursor-pointer"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onConnect?.();
+                      }}
+                    >
+                      Connect
+                    </Button>
+                  )}
+                  {config.enabled &&
+                    (showReauthorize ? (
+                      <Button
+                        variant="warningOutline"
+                        className="w-28 cursor-pointer"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleReauthorizeClick();
+                        }}
+                      >
+                        Reauthorize
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="destructiveOutline"
+                        className="w-28 cursor-pointer"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDisconnect?.();
+                        }}
+                      >
+                        Disconnect
+                      </Button>
+                    ))}
+                </>
               )}
             </div>
           </div>

--- a/src/ui/src/components/settings/mcp/mcp-card.tsx
+++ b/src/ui/src/components/settings/mcp/mcp-card.tsx
@@ -12,6 +12,7 @@ interface McpCardProps {
   healthInfo?: HealthStatusInfo | null;
   onDisconnect?: () => void;
   onConnect?: () => void;
+  onReauthorize?: () => void;
   onDelete?: () => void;
   hideDelete?: boolean;
   onUpdate?: (data: MCPServerConfig) => Promise<void>;
@@ -27,6 +28,7 @@ export function McpCard({
   config,
   onConnect,
   onDisconnect,
+  onReauthorize,
   onDelete,
   hideDelete,
   onUpdate,
@@ -58,6 +60,8 @@ export function McpCard({
                   isDisabled={!config.enabled}
                   isHealthy={healthInfo.isHealthy}
                   successMessage={healthInfo.successMessage}
+                  authFailed={healthInfo.authFailed}
+                  error={healthInfo.error}
                   className="mr-4"
                 />
               )}
@@ -89,7 +93,19 @@ export function McpCard({
                   Connect
                 </Button>
               )}
-              {config.enabled && (
+              {config.enabled && healthInfo?.authFailed && onReauthorize && (
+                <Button
+                  variant="outline"
+                  className="w-28 cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReauthorize();
+                  }}
+                >
+                  Reauthorize
+                </Button>
+              )}
+              {config.enabled && !(healthInfo?.authFailed && onReauthorize) && (
                 <Button
                   variant="destructiveOutline"
                   className="w-28 cursor-pointer"

--- a/src/ui/src/components/ui/alert.tsx
+++ b/src/ui/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/ui/src/components/ui/button.tsx
+++ b/src/ui/src/components/ui/button.tsx
@@ -36,6 +36,10 @@ const buttonVariants = cva(
         // never confirms — it only signals danger and triggers a confirm step.
         destructiveOutline:
           "min-h-11 border border-danger/60 text-white bg-danger/8 shadow-xs transition-colors duration-150 hover:bg-danger/15 focus-visible:ring-danger/40 focus-visible:border-danger",
+        // Outlined caution variant (shared --warning hue) for recover actions
+        // like Reauthorize — reads as caution, distinct from destructiveOutline.
+        warningOutline:
+          "min-h-11 border border-warning/60 text-warning bg-warning/8 shadow-xs transition-colors duration-150 hover:bg-warning/15 focus-visible:ring-warning/40 focus-visible:border-warning",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/src/ui/src/hooks/useMcpCardActions.ts
+++ b/src/ui/src/hooks/useMcpCardActions.ts
@@ -1,7 +1,7 @@
 import { toast } from "sonner";
 import type { MCPServerConfig } from "@/components/settings/mcp/McpServerForm";
 import { ipcClient } from "@/services/ipc-client";
-import { formatErrorMessage } from "@/utils";
+import { formatIpcErrorMessage } from "@/utils";
 
 export function useMcpCardActions(
   serverId: string,
@@ -20,7 +20,7 @@ export function useMcpCardActions(
     try {
       await toggleSettings(true);
     } catch (error) {
-      toast.error(`Failed to connect: ${formatErrorMessage(error)}`);
+      toast.error(`Failed to connect: ${formatIpcErrorMessage(error)}`);
     }
   }
 
@@ -32,9 +32,11 @@ export function useMcpCardActions(
   async function handleOnReauthorize(): Promise<void> {
     try {
       await ipcClient.mcp.reauthorizeAsync(serverId);
-      onChange?.({ ...configLocal });
     } catch (error) {
-      toast.error(`Failed to reauthorize: ${formatErrorMessage(error)}`);
+      toast.error(`Failed to reauthorize: ${formatIpcErrorMessage(error)}`);
+    } finally {
+      // Re-check health either way so a failed re-auth stays visible on the card (#982).
+      onChange?.({ ...configLocal });
     }
   }
 

--- a/src/ui/src/hooks/useMcpCardActions.ts
+++ b/src/ui/src/hooks/useMcpCardActions.ts
@@ -29,5 +29,14 @@ export function useMcpCardActions(
     await toggleSettings(false);
   }
 
-  return { toggleSettings, handleOnConnect, handleOnDisconnect };
+  async function handleOnReauthorize(): Promise<void> {
+    try {
+      await ipcClient.mcp.reauthorizeAsync(serverId);
+      onChange?.({ ...configLocal });
+    } catch (error) {
+      toast.error(`Failed to reauthorize: ${formatErrorMessage(error)}`);
+    }
+  }
+
+  return { toggleSettings, handleOnConnect, handleOnDisconnect, handleOnReauthorize };
 }

--- a/src/ui/src/hooks/useMcpCardActions.ts
+++ b/src/ui/src/hooks/useMcpCardActions.ts
@@ -3,6 +3,25 @@ import type { MCPServerConfig } from "@/components/settings/mcp/McpServerForm";
 import { ipcClient } from "@/services/ipc-client";
 import { formatIpcErrorMessage } from "@/utils";
 
+/**
+ * Reauthorize an MCP server, then refresh its health regardless of outcome so a
+ * failed re-auth stays visible on the card. Shared by the built-in cards (via
+ * this hook) and the generic user-server card, which only differ in how they
+ * refresh (`refresh`) (#982).
+ */
+export async function reauthorizeAndRefresh(
+  serverId: string,
+  refresh: () => void | Promise<void>,
+): Promise<void> {
+  try {
+    await ipcClient.mcp.reauthorizeAsync(serverId);
+  } catch (error) {
+    toast.error(`Failed to reauthorize: ${formatIpcErrorMessage(error)}`);
+  } finally {
+    await refresh();
+  }
+}
+
 export function useMcpCardActions(
   serverId: string,
   configLocal: MCPServerConfig,
@@ -30,14 +49,7 @@ export function useMcpCardActions(
   }
 
   async function handleOnReauthorize(): Promise<void> {
-    try {
-      await ipcClient.mcp.reauthorizeAsync(serverId);
-    } catch (error) {
-      toast.error(`Failed to reauthorize: ${formatIpcErrorMessage(error)}`);
-    } finally {
-      // Re-check health either way so a failed re-auth stays visible on the card (#982).
-      onChange?.({ ...configLocal });
-    }
+    await reauthorizeAndRefresh(serverId, () => onChange?.({ ...configLocal }));
   }
 
   return { toggleSettings, handleOnConnect, handleOnDisconnect, handleOnReauthorize };

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -178,6 +178,7 @@ declare global {
           serverId: string,
         ) => Promise<Array<{ name: string; description?: string }>>;
         clearTokensAsync: (serverId: string) => Promise<{ success: boolean }>;
+        reauthorizeAsync: (serverId: string) => Promise<{ success: boolean }>;
       };
       settings: {
         getAllPrompts: () => Promise<Array<CustomPrompt>>;

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -125,6 +125,7 @@ export interface HealthStatusInfo {
   error?: string;
   successMessage?: string;
   isChecking: boolean;
+  authFailed?: boolean;
 }
 
 export const UNDO_EVENT_CHANNEL = "yakshaver:undo-event";

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -120,13 +120,8 @@ export interface PromptFormData {
   selectedMcpServerIds?: string[];
 }
 
-export interface HealthStatusInfo {
-  isHealthy: boolean;
-  error?: string;
-  successMessage?: string;
-  isChecking: boolean;
-  authFailed?: boolean;
-}
+// Single shared contract — re-exported so existing `@/types` imports keep working.
+export type { HealthStatusInfo } from "@shared/types/mcp";
 
 export const UNDO_EVENT_CHANNEL = "yakshaver:undo-event";
 

--- a/src/ui/src/utils/index.test.ts
+++ b/src/ui/src/utils/index.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, expect, it } from "vitest";
 import { MCPStepType } from "@/types";
 import {
+  formatIpcErrorMessage,
   formatKeyAsTitle,
   getVersionBumpType,
   isWorkflowFailed,
@@ -51,6 +52,27 @@ function makeState(overrides: Partial<Record<keyof WorkflowState, WorkflowStatus
   }
   return base;
 }
+
+describe("formatIpcErrorMessage", () => {
+  it("strips the Electron IPC wrapper and leading Error: chain, keeping the real reason", () => {
+    const raw = new Error(
+      "Error invoking remote method 'mcp:list-server-tools': Error: MCPClientError: MCP HTTP Transport Error: POSTing to endpoint (HTTP 401): token expired or revoked",
+    );
+    expect(formatIpcErrorMessage(raw)).toBe(
+      "MCPClientError: MCP HTTP Transport Error: POSTing to endpoint (HTTP 401): token expired or revoked",
+    );
+  });
+
+  it("leaves an already-clean message untouched", () => {
+    expect(formatIpcErrorMessage(new Error("HTTP 401: token expired or revoked"))).toBe(
+      "HTTP 401: token expired or revoked",
+    );
+  });
+
+  it("handles non-Error values", () => {
+    expect(formatIpcErrorMessage("plain string reason")).toBe("plain string reason");
+  });
+});
 
 describe("formatKeyAsTitle", () => {
   it("converts camelCase to spaced title case", () => {

--- a/src/ui/src/utils/index.ts
+++ b/src/ui/src/utils/index.ts
@@ -190,6 +190,18 @@ export function formatErrorMessage(error: unknown): string {
 }
 
 /**
+ * Strips the Electron IPC wrapper (`Error invoking remote method '…':`) and
+ * leading `Error:` prefixes from an error, leaving the real reason for the
+ * user (e.g. `HTTP 401: token expired or revoked`) (#982).
+ */
+export function formatIpcErrorMessage(error: unknown): string {
+  return formatErrorMessage(error)
+    .replace(/^Error invoking remote method '[^']*':\s*/i, "")
+    .replace(/^(?:Error:\s*)+/i, "")
+    .trim();
+}
+
+/**
  * Converts a camelCase or PascalCase key into a human-readable title with spaces.
  * Acronyms (consecutive uppercase letters) are kept together.
  *


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Claude Opus 4.8

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ https://github.com/SSWConsulting/SSW.YakShaver.Desktop/issues/982

> 2. What was changed?

✏️ Renamed the app/window to "YakShaver Desktop" and the tool-whitelist popup to "MCP Tools", and moved MCP load/save failures from fleeting toasts to persistent, cleaned-up inline errors inside that popup. Added auth-failure (401) detection to the health check so an auth-failed server shows an amber Reauthorize button that re-auths in place (clears tokens + reruns OAuth) without disconnecting — with a stable loading state so the button no longer flickers.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ No
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
