### PR TITLE
XS⚠️ ◾ Fix wizard heading icon and align "What we collect" icons in telemetry consent dialog

### DIFF
--- a/src/ui/src/components/settings/telemetry/TelemetryConsentDialog.tsx
+++ b/src/ui/src/components/settings/telemetry/TelemetryConsentDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import yakShaverLogo from "/logos/SQ-YakShaver-LogoIcon-Red.svg?url";
 
 interface TelemetryConsentDialogProps {
   open: boolean;
@@ -46,7 +47,7 @@ export function TelemetryConsentDialog({
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <BarChart3 className="h-5 w-5" />
+            <img src={yakShaverLogo} alt="" className="h-5 w-5" />
             Help Us Improve YakShaver
           </DialogTitle>
           <DialogDescription className="pt-2">
@@ -60,7 +61,9 @@ export function TelemetryConsentDialog({
             <h4 className="text-sm font-medium">What we collect:</h4>
 
             <div className="flex items-start space-x-3">
-              <Bug className="h-4 w-4 mt-0.5 text-muted-foreground" />
+              <div className="flex items-center min-h-11">
+                <Bug className="h-4 w-4 text-muted-foreground" />
+              </div>
               <div className="flex-1">
                 <div className="flex items-center space-x-2 min-h-11">
                   <Checkbox
@@ -82,7 +85,9 @@ export function TelemetryConsentDialog({
             </div>
 
             <div className="flex items-start space-x-3">
-              <Activity className="h-4 w-4 mt-0.5 text-muted-foreground" />
+              <div className="flex items-center min-h-11">
+                <Activity className="h-4 w-4 text-muted-foreground" />
+              </div>
               <div className="flex-1">
                 <div className="flex items-center space-x-2 min-h-11">
                   <Checkbox
@@ -104,7 +109,9 @@ export function TelemetryConsentDialog({
             </div>
 
             <div className="flex items-start space-x-3">
-              <BarChart3 className="h-4 w-4 mt-0.5 text-muted-foreground" />
+              <div className="flex items-center min-h-11">
+                <BarChart3 className="h-4 w-4 text-muted-foreground" />
+              </div>
               <div className="flex-1">
                 <div className="flex items-center space-x-2 min-h-11">
                   <Checkbox


### PR DESCRIPTION
## Summary

The "Help Us Improve YakShaver" telemetry consent dialog (shown early in the setup flow) had inconsistent iconography:

- The heading used a generic `BarChart3` "analyze" icon instead of the YakShaver brand icon.
- The three "What we collect" list icons (Error reports, Workflow performance, Usage metrics) used an ad-hoc `mt-0.5` top offset that didn't reliably line up with their checkbox/label row, since row heights differ (the row is `min-h-11`, the icon offset was a fixed guess).

## Changes

- `src/ui/src/components/settings/telemetry/TelemetryConsentDialog.tsx`
  - Replaced the `<BarChart3 className="h-5 w-5" />` heading icon with the YakShaver (small Red Bull) logo (`/logos/SQ-YakShaver-LogoIcon-Red.svg`), the same asset already used elsewhere in the app (e.g. the onboarding sidebar and recording control bar).
  - Wrapped each "What we collect" icon (`Bug`, `Activity`, `BarChart3`) in a `flex items-center min-h-11` container that matches the height of its corresponding checkbox/label row, replacing the fixed `mt-0.5` offset. This centers each icon against its row instead of guessing a top margin.

## Acceptance criteria mapping

- [x] The icon next to the "Help Us Improve YakShaver" heading uses the YakShaver (small Red Bull) icon → heading now renders `SQ-YakShaver-LogoIcon-Red.svg`.
- [x] The icons for the "What we collect" items are visually aligned with each other and with their corresponding text → each icon is now vertically centered against its checkbox/label row via a matching `min-h-11` container, so all three align consistently.

## Testing performed

- `npm run build` — passes (tsc clean).
- `npm run lint` — passes (0 errors; one pre-existing, unrelated info-level suggestion in `Cloud360LiveView.tsx` left untouched, out of scope).
- `npm run format` then `git diff --exit-code` — clean, no formatting drift.
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run --exclude 'src/ui/**'` — 696/696 backend tests pass.
- `npm --prefix src/ui test` — 261/261 UI tests pass.

This is a scoped, presentational-only change (icon swap + alignment wrapper) with no behavioural/state changes, so no new tests were added.

Closes #964
