### PR TITLE
XS✔ ◾ Replace stop emoji and remove dash in My Shaves empty state

### DIFF
--- a/src/ui/src/components/shaves/NoShaves.test.tsx
+++ b/src/ui/src/components/shaves/NoShaves.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NoShaves } from "./NoShaves";
+
+describe("NoShaves (#966)", () => {
+  it("uses a sad face emoji instead of the stop-sign emoji (AC1)", () => {
+    render(<NoShaves />);
+
+    const title = screen.getByText(/You don't have any YakShaves yet!/i);
+    expect(title.textContent).toContain("😢");
+    expect(title.textContent).not.toContain("⛔️");
+  });
+
+  it("has no dash between the emoji and the message text (AC2)", () => {
+    render(<NoShaves />);
+
+    const title = screen.getByText(/You don't have any YakShaves yet!/i);
+    expect(title.textContent).toBe("😢 You don't have any YakShaves yet!");
+    expect(title.textContent).not.toMatch(/-\s*You don't have any YakShaves yet!/);
+  });
+});

--- a/src/ui/src/components/shaves/NoShaves.tsx
+++ b/src/ui/src/components/shaves/NoShaves.tsx
@@ -10,7 +10,7 @@ export function NoShaves() {
   return (
     <Empty>
       <EmptyHeader className="gap-6 items-start!">
-        <EmptyTitle>⛔️ - You don't have any YakShaves yet!</EmptyTitle>
+        <EmptyTitle>😢 You don't have any YakShaves yet!</EmptyTitle>
         <EmptyDescription>Get started in 3 easy steps:</EmptyDescription>
       </EmptyHeader>
       <div className="flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- The "My shaves" empty state showed a stop-sign emoji (⛔️) followed by a dash before the message ("⛔️ - You don't have any YakShaves yet!"), which read as visually noisy and harsh for a first-run/empty state.
- Replaced the stop-sign emoji with a sad face emoji (😢) and removed the dash, so the empty state now reads "😢 You don't have any YakShaves yet!".

Closes #966

## Changes
- `src/ui/src/components/shaves/NoShaves.tsx` — swapped `⛔️ -` for `😢` (no dash) in the `EmptyTitle`.
- `src/ui/src/components/shaves/NoShaves.test.tsx` — new colocated test asserting the sad face emoji is present, the stop-sign emoji is gone, and there is no dash between the emoji and the message text.

## Acceptance criteria
- [x] Empty state uses a sad face emoji instead of the stop-sign emoji.
- [x] No dash between the emoji and the message text.

## Testing performed
- `cd src/ui && npx vitest run --reporter=verbose src/components/shaves/NoShaves.test.tsx` — 2/2 new tests pass.
- `cd src/ui && npm test` — full UI suite: 263/263 tests pass across 36 files.
- `npm run lint` — clean (biome check, exit 0).
- `npm run build` — clean (`tsc`, no errors).