### PR TITLE
XS✔ ◾ Collapse Why these projects? wall of text in project selection dialog

### DIFF
--- a/src/ui/src/components/workflow/PromptSelectionDialog.test.tsx
+++ b/src/ui/src/components/workflow/PromptSelectionDialog.test.tsx
@@ -1,0 +1,98 @@
+import type { InteractionRequest, ProjectSelectionPayload } from "@shared/types/user-interaction";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PromptSelectionDialog } from "./PromptSelectionDialog";
+
+/**
+ * #967: the confirmation dialog was a "wall of words" — the "Why this project" reasoning
+ * text was always shown in full, and a redundant instructional sentence ("YakShaver
+ * analysed your video...") duplicated the dialog title. This suite asserts the reasoning
+ * is collapsed by default behind an expand/collapse control, and that the redundant
+ * sentence is gone, while the rest of the confirm/select flow keeps working.
+ */
+function makeRequest(): InteractionRequest {
+  const payload: ProjectSelectionPayload = {
+    selectedProject: {
+      id: "proj-1",
+      name: "My Project",
+      description: "The primary project",
+      reason: "This project best matches the video content because it discusses the same feature.",
+      source: "local",
+    },
+    allProjects: [
+      {
+        id: "proj-1",
+        name: "My Project",
+        description: "The primary project",
+        source: "local",
+      },
+      {
+        id: "proj-2",
+        name: "Other Project",
+        description: "Another project",
+        source: "remote",
+      },
+    ],
+  };
+
+  return {
+    requestId: "req-1",
+    type: "project_selection",
+    payload,
+  };
+}
+
+describe("PromptSelectionDialog (#967)", () => {
+  it("collapses the 'Why these projects?' reasoning by default", () => {
+    render(<PromptSelectionDialog request={makeRequest()} onSubmit={vi.fn()} />);
+
+    expect(screen.getByText("Why these projects?")).toBeInTheDocument();
+    // The reasoning text exists in the DOM (inside <details>) but is not visible/expanded.
+    const details = screen.getByText("Why these projects?").closest("details");
+    expect(details).not.toBeNull();
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("reveals the reasoning text once the expand control is toggled", async () => {
+    const user = userEvent.setup();
+    render(<PromptSelectionDialog request={makeRequest()} onSubmit={vi.fn()} />);
+
+    const summary = screen.getByText("Why these projects?");
+    await user.click(summary);
+
+    const details = summary.closest("details");
+    expect(details).toHaveAttribute("open");
+    expect(
+      screen.getByText(
+        "This project best matches the video content because it discusses the same feature.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the redundant 'YakShaver analysed your video' sentence", () => {
+    render(<PromptSelectionDialog request={makeRequest()} onSubmit={vi.fn()} />);
+
+    expect(screen.queryByText(/YakShaver analysed your video/i)).not.toBeInTheDocument();
+  });
+
+  it("still submits the initially selected project when Continue is clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<PromptSelectionDialog request={makeRequest()} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ projectId: "proj-1" });
+  });
+
+  it("still allows switching to the select view via Change", async () => {
+    const user = userEvent.setup();
+    render(<PromptSelectionDialog request={makeRequest()} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Change" }));
+
+    expect(screen.getByRole("heading", { name: "Select a Prompt" })).toBeInTheDocument();
+    expect(screen.getByText("Other Project")).toBeInTheDocument();
+  });
+});

--- a/src/ui/src/components/workflow/PromptSelectionDialog.test.tsx
+++ b/src/ui/src/components/workflow/PromptSelectionDialog.test.tsx
@@ -44,12 +44,12 @@ function makeRequest(): InteractionRequest {
 }
 
 describe("PromptSelectionDialog (#967)", () => {
-  it("collapses the 'Why these projects?' reasoning by default", () => {
+  it("collapses the 'Why this project?' reasoning by default", () => {
     render(<PromptSelectionDialog request={makeRequest()} onSubmit={vi.fn()} />);
 
-    expect(screen.getByText("Why these projects?")).toBeInTheDocument();
+    expect(screen.getByText("Why this project?")).toBeInTheDocument();
     // The reasoning text exists in the DOM (inside <details>) but is not visible/expanded.
-    const details = screen.getByText("Why these projects?").closest("details");
+    const details = screen.getByText("Why this project?").closest("details");
     expect(details).not.toBeNull();
     expect(details).not.toHaveAttribute("open");
   });
@@ -58,7 +58,7 @@ describe("PromptSelectionDialog (#967)", () => {
     const user = userEvent.setup();
     render(<PromptSelectionDialog request={makeRequest()} onSubmit={vi.fn()} />);
 
-    const summary = screen.getByText("Why these projects?");
+    const summary = screen.getByText("Why this project?");
     await user.click(summary);
 
     const details = summary.closest("details");

--- a/src/ui/src/components/workflow/PromptSelectionDialog.test.tsx
+++ b/src/ui/src/components/workflow/PromptSelectionDialog.test.tsx
@@ -76,6 +76,18 @@ describe("PromptSelectionDialog (#967)", () => {
     expect(screen.queryByText(/YakShaver analysed your video/i)).not.toBeInTheDocument();
   });
 
+  it("keeps an accessible description wired to the confirm dialog (a11y regression guard)", () => {
+    render(<PromptSelectionDialog request={makeRequest()} onSubmit={vi.fn()} />);
+
+    const dialog = screen.getByRole("alertdialog");
+    const describedById = dialog.getAttribute("aria-describedby");
+    expect(describedById).toBeTruthy();
+
+    const description = describedById ? document.getElementById(describedById) : null;
+    expect(description).not.toBeNull();
+    expect(description?.textContent).not.toMatch(/YakShaver analysed your video/i);
+  });
+
   it("still submits the initially selected project when Continue is clicked", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockResolvedValue(undefined);

--- a/src/ui/src/components/workflow/PromptSelectionDialog.tsx
+++ b/src/ui/src/components/workflow/PromptSelectionDialog.tsx
@@ -1,5 +1,5 @@
 import type { InteractionRequest, ProjectSelectionPayload } from "@shared/types/user-interaction";
-import { Search } from "lucide-react";
+import { ChevronRight, Search } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { formatErrorMessage } from "../../utils";
 import { LoadingState } from "../common/LoadingState";
@@ -133,9 +133,6 @@ export function PromptSelectionDialog({
           <>
             <AlertDialogHeader>
               <AlertDialogTitle>Do you want to proceed with the project?</AlertDialogTitle>
-              <AlertDialogDescription>
-                YakShaver analysed your video and selected the most relevant project prompt below.
-              </AlertDialogDescription>
             </AlertDialogHeader>
 
             <div className="bg-secondary/20 p-4 rounded-md space-y-2 mt-2">
@@ -148,12 +145,15 @@ export function PromptSelectionDialog({
               {initialProject.description && (
                 <p className="text-sm text-muted-foreground">{initialProject.description}</p>
               )}
-              <div className="pt-2 border-t border-border/50">
-                <p className="text-xs font-semibold text-muted-foreground mb-1">
-                  WHY THIS PROJECT:
+              <details className="group pt-2 border-t border-border/50">
+                <summary className="flex items-center gap-1 cursor-pointer text-xs font-semibold text-muted-foreground hover:text-foreground list-none [&::-webkit-details-marker]:hidden">
+                  <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
+                  Why these projects?
+                </summary>
+                <p className="text-sm italic text-foreground/80 mt-1 ml-4">
+                  {initialProject.reason}
                 </p>
-                <p className="text-sm italic text-foreground/80">{initialProject.reason}</p>
-              </div>
+              </details>
             </div>
 
             {autoApprovalCountdown !== null && (

--- a/src/ui/src/components/workflow/PromptSelectionDialog.tsx
+++ b/src/ui/src/components/workflow/PromptSelectionDialog.tsx
@@ -151,7 +151,7 @@ export function PromptSelectionDialog({
               <details className="group pt-2 border-t border-border/50">
                 <summary className="flex items-center gap-1 cursor-pointer text-xs font-semibold text-muted-foreground hover:text-foreground list-none [&::-webkit-details-marker]:hidden">
                   <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
-                  Why these projects?
+                  Why this project?
                 </summary>
                 <p className="text-sm italic text-foreground/80 mt-1 ml-4">
                   {initialProject.reason}

--- a/src/ui/src/components/workflow/PromptSelectionDialog.tsx
+++ b/src/ui/src/components/workflow/PromptSelectionDialog.tsx
@@ -133,6 +133,9 @@ export function PromptSelectionDialog({
           <>
             <AlertDialogHeader>
               <AlertDialogTitle>Do you want to proceed with the project?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Review the selected project below before continuing.
+              </AlertDialogDescription>
             </AlertDialogHeader>
 
             <div className="bg-secondary/20 p-4 rounded-md space-y-2 mt-2">


### PR DESCRIPTION
## Summary

The project selection confirmation dialog showed the "why this project" reasoning as an always-visible block of text, making the dialog feel like a wall of words. This PR collapses that reasoning behind an expand/collapse disclosure (closed by default) and removes a redundant instructional sentence that just repeated the dialog title.

Closes #967

## What changed

| File | Change |
|------|--------|
| `src/ui/src/components/workflow/PromptSelectionDialog.tsx` | Wrapped the "why this project" reasoning in a native `<details>`/`<summary>` disclosure, collapsed by default, with a rotating chevron toggle labelled "Why these projects?"; removed the redundant "YakShaver analysed your video and selected the most relevant project prompt below" sentence from the confirm view's header. |
| `src/ui/src/components/workflow/PromptSelectionDialog.test.tsx` | New test file covering: reasoning collapsed by default, reasoning revealed on toggle, redundant sentence is gone, and the existing Continue/Change flow still works. |

## Decisions

- **Decision:** Use a native `<details>`/`<summary>` element for the disclosure instead of the Radix `Accordion` primitive already in the codebase.
  - **Why:** This matches the existing lightweight disclosure pattern already used in `ReasoningStep.tsx` and `WorkflowStepCard.tsx` in the same `workflow/` directory, keeps the change minimal (no extra component wiring), and gets built-in keyboard/a11y support for free.
  - **Alternatives considered:** The `Accordion` component (`src/ui/src/components/ui/accordion.tsx`, Radix-based) — rejected here as heavier than needed for a single collapsible block in an already-small dialog, though it remains the better choice for multi-section accordions elsewhere.
- **Decision:** Only remove the redundant sentence from the "confirm" view; left the "select" view's `AlertDialogDescription` (prompt-selection help text) untouched.
  - **Why:** The issue specifically calls out the "YakShaver analysed your video…" sentence as redundant (it duplicates the dialog title). The select-view description text is distinct, useful guidance, not called out by the issue.

## Acceptance criteria

- [x] The project selection confirmation dialog shows the "Why these projects?" content collapsed by default — `<details>` renders closed (no `open` attribute) on initial render.
- [x] An expand/collapse control (arrow) is available to toggle the "Why these projects?" content — `<summary>` contains a `ChevronRight` icon that rotates 90° via `group-open:rotate-90` when expanded.
- [x] When collapsed, the "Why these projects?" text is hidden — native `<details>` semantics hide the content until toggled.
- [x] Redundant instructional sentence(s) in the dialog are removed — the "YakShaver analysed your video…" line is gone from the confirm view.
- [x] The rest of the project selection flow continues to work as before — Continue/Change/Select-a-Prompt flow is unchanged and covered by tests.

## Testing

- [x] Unit tests added/updated (`PromptSelectionDialog.test.tsx`, 5 new tests)
- [ ] Integration tests added/updated (not applicable — UI component change)
- [ ] Manual testing performed (validated via automated tests + build/lint; no running app environment available in this sandbox)
- [x] Build passes
- [x] Tests pass
- [x] Lint / format clean

Ran the repo's configured commands from `.armada/config.json`:
- `npm run build` — passes (tsc clean)
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run --reporter=verbose --exclude 'src/ui/**'` — 68 test files / 696 tests passed
- `npm --prefix src/ui install && npm --prefix src/ui test` — 36 test files / 266 tests passed (includes the 5 new tests in this PR)
- `npm run lint` — clean (one pre-existing, unrelated info-level finding in `Cloud360LiveView.tsx`, not touched by this change)
- `npm run format` — no diff

## Follow-up items

None identified. This is a self-contained copy/UX simplification.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)