### PR TITLE
XS⚠️ ◾ Simplify MCP tools permission prompt copy

### DIFF
--- a/src/ui/src/components/workflow/ApprovalDialog.tsx
+++ b/src/ui/src/components/workflow/ApprovalDialog.tsx
@@ -42,8 +42,9 @@ function getServiceIcon(serverName: string | null): ReactElement {
 
 /**
  * Plain-language explanations of why specific tools are needed, so non-technical
- * users can make an informed choice (issue #783 AC2). Returns null for tools
- * without a bespoke explanation, in which case the generic description is used.
+ * users can make an informed choice (issue #783 AC2, shortened further per #968).
+ * Returns null for tools without a bespoke explanation, in which case the generic
+ * description is used.
  *
  * Keyed on the raw, unformatted tool id (the segment after any server prefix) via
  * the shared {@link splitToolName} so it survives both MCP separators ("__" and ".").
@@ -51,7 +52,7 @@ function getServiceIcon(serverName: string | null): ReactElement {
 function getToolPurpose(rawToolName: string): string | null {
   switch (splitToolName(rawToolName).tool) {
     case "capture_video_frame":
-      return "YakShaver wants to capture a still frame from your screen recording so it can see what you're pointing at and keep working on your task accurately. It only runs when you say it's OK.";
+      return "YakShaver wants to grab a frame from your recording, so it can see what you're pointing at.";
     default:
       return null;
   }
@@ -154,20 +155,20 @@ export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDia
   const isOpen = true;
 
   const readableToolInfo = toolName ? parseToolName(toolName) : null;
-  const toolLabel = readableToolInfo?.tool ?? "an action";
   const dialogTitle = readableToolInfo
     ? `Can YakShaver use "${readableToolInfo.tool}"?`
     : "Can YakShaver perform this action?";
 
   // Some tools have a clear, user-facing purpose that non-technical users benefit
-  // from understanding (issue #783 AC2). Keyed on the raw, unformatted tool id so it
-  // survives both MCP separators ("__" and ".") and any display-label changes.
+  // from understanding (issue #783 AC2, shortened further per #968). Keyed on the raw,
+  // unformatted tool id so it survives both MCP separators ("__" and ".") and any
+  // display-label changes.
   const toolPurpose = toolName ? getToolPurpose(toolName) : null;
   const dialogDescription =
     toolPurpose ??
     (readableToolInfo?.server
-      ? `To keep working on your task, YakShaver needs to use the "${readableToolInfo.tool}" tool (from ${readableToolInfo.server}). It only runs when you say it's OK.`
-      : `To keep working on your task, YakShaver needs to perform an action. It only runs when you say it's OK.`);
+      ? `YakShaver needs to use "${readableToolInfo.tool}" (from ${readableToolInfo.server}) to keep going.`
+      : `YakShaver needs to perform an action to keep going.`);
 
   return (
     <AlertDialog open={isOpen}>
@@ -184,17 +185,15 @@ export function ApprovalDialog({ request, onSubmit, error: pError }: ApprovalDia
         {!showCorrectionForm && (
           <ul className="space-y-1.5 text-sm text-white/70">
             <li>
-              <span className="font-medium text-white/90">Allow</span> &mdash; let YakShaver use{" "}
-              {`"${toolLabel}"`} this one time.
+              <span className="font-medium text-white/90">Allow</span> &mdash; use it this once.
             </li>
             <li>
-              <span className="font-medium text-white/90">Allow Always</span> &mdash; let YakShaver
-              use {`"${toolLabel}"`} now and skip this prompt next time.
+              <span className="font-medium text-white/90">Allow Always</span> &mdash; use it now and
+              don't ask again.
             </li>
             <li>
               <span className="font-medium text-white/90">Review / Correct&hellip;</span> &mdash;
-              don't run {`"${toolLabel}"`} as-is. You can leave a note telling YakShaver what to
-              change and try again, or stop the step entirely.
+              don't run it yet. Tell YakShaver what to change, or stop this step.
             </li>
           </ul>
         )}


### PR DESCRIPTION
## Summary

The MCP tools permission dialog (`ApprovalDialog.tsx`) explained itself with a two-clause description plus a full sentence for each of the three response options, making it slower to scan than it needs to be. This trims the copy to short, plain language that states what YakShaver wants, why, and what happens if you don't allow it — matching the terser tone already used by the sibling screen-recording permission dialog.

Closes #968

## What changed

| File | Change |
|------|--------|
| `src/ui/src/components/workflow/ApprovalDialog.tsx` | Shortened the dialog description, the bespoke `capture_video_frame` purpose copy, and the three option bullets (Allow / Allow Always / Review-Correct); removed the now-unused `toolLabel` variable that only existed to repeat the tool name in each bullet. |

### Before / after

**Description (generic tool with a server):**
- Before: `To keep working on your task, YakShaver needs to use the "X" tool (from Y). It only runs when you say it's OK.`
- After: `YakShaver needs to use "X" (from Y) to keep going.`

**`capture_video_frame` purpose:**
- Before: `YakShaver wants to capture a still frame from your screen recording so it can see what you're pointing at and keep working on your task accurately. It only runs when you say it's OK.`
- After: `YakShaver wants to grab a frame from your recording, so it can see what you're pointing at.`

**Option bullets:**
- Before: `Allow — let YakShaver use "X" this one time.` / `Allow Always — let YakShaver use "X" now and skip this prompt next time.` / `Review / Correct… — don't run "X" as-is. You can leave a note telling YakShaver what to change and try again, or stop the step entirely.`
- After: `Allow — use it this once.` / `Allow Always — use it now and don't ask again.` / `Review / Correct… — don't run it yet. Tell YakShaver what to change, or stop this step.`

The tool name still appears once, prominently, in the dialog title (`Can YakShaver use "X"?`), so repeating it in every bullet was redundant rather than clarifying.

## Decisions

- **Decision:** Keep the three existing actions (Allow / Allow Always / Review-Correct) rather than restructuring the interaction model.
  - **Why:** The issue asks for simpler *wording*, not a different set of choices; the three actions are functionally necessary (one-time allow, whitelist, and a correction/deny path).
  - **Alternatives considered:** Collapsing "Review / Correct…" and "Don't Allow" into a single explicit "Deny" bullet — kept as-is since the existing flow (open a correction form with both "Don't Allow" and "Send correction") is unchanged and out of scope for a copy-only issue.
- **Decision:** Drop the recurring "It only runs when you say it's OK" reassurance from the description.
  - **Why:** It's redundant — the entire dialog's existence already communicates that nothing runs without a decision. Removing it shortens the description without losing information (AC1/AC3 — the per-option bullets already state what each button does).

## Acceptance criteria

- [x] Criterion 1 (shorter, easier to understand) — description and bullets condensed to short clauses/phrases instead of full sentences.
- [x] Criterion 2 (explains why permission is needed) — description keeps a plain "why" (e.g. "to keep going", "so it can see what you're pointing at").
- [x] Criterion 3 (impact of denying is clear) — the "Review / Correct…" bullet explicitly states the tool won't run yet and the step can be stopped.
- [x] Criterion 4 (consistent tone of voice) — matches the short, plain style already used by `MacScreenRecordingPermissionDialog` ("YakShaver needs permission to record your screen.").

## Testing

- [x] Unit tests added/updated — none needed; no test file exists for `ApprovalDialog.tsx` (pure copy change, no logic/behavior change) and no existing test asserts the old copy strings.
- [ ] Integration tests added/updated — n/a
- [x] Manual testing performed — read through the rendered JSX structure and Tailwind classes; the dialog container is `max-w-lg`, and the new copy is shorter than before, so there's no truncation/layout risk.
- [x] Build passes
- [x] Tests pass
- [x] Lint / format clean

Ran the full validation suite in the worktree:
- `npm run build` — clean (`tsc`, no errors).
- `npm rebuild better-sqlite3 --build-from-source && npx vitest run --reporter=verbose --exclude 'src/ui/**'` — 68 test files / 696 tests passed.
- `npm --prefix src/ui install && npm --prefix src/ui test` — 35 test files / 261 tests passed.
- `npm run lint` — clean (one pre-existing, unrelated `info`-level suggestion in `Cloud360LiveView.tsx`, not touched by this change).

## Screenshots

No screenshot captured (headless worktree without a display); the diff is copy-only within the existing dialog layout — see the before/after text above.

## Follow-up items

- No dedicated test coverage exists for `ApprovalDialog.tsx`'s copy/behavior; adding a lightweight render test (e.g. asserting the title/description render for a couple of tool-name shapes) would guard future copy regressions but is out of scope for this copy-only PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)