### PR TITLE
S✔ ◾ ✨ Pre-check credits before recording in YakShaver Anywhere

### DIFF
--- a/src/backend/ipc/channels.ts
+++ b/src/backend/ipc/channels.ts
@@ -134,4 +134,5 @@ export const IPC_CHANNELS = {
   // Cloud 360 orchestration
   CLOUD360_EVENT: "cloud-360:event",
   CLOUD360_LIST_PROJECTS: "cloud-360:list-projects",
+  CLOUD360_CHECK_CREDITS: "cloud-360:check-credits",
 } as const;

--- a/src/backend/ipc/cloud-360-handlers.ts
+++ b/src/backend/ipc/cloud-360-handlers.ts
@@ -1,6 +1,10 @@
 import { ipcMain } from "electron";
 import type { Cloud360Project } from "../../shared/types/cloud360";
 import { IdentityServerAuthService } from "../services/auth/identity-server-auth";
+import {
+  checkCloud360Credits,
+  type CreditPrecheckResult,
+} from "../services/yakshaver360/credit-precheck";
 import { fetchGitHubProjects } from "../services/yakshaver360/github-projects";
 import { IPC_CHANNELS } from "./channels";
 
@@ -15,5 +19,19 @@ export class Cloud360IPCHandlers {
       }
       return fetchGitHubProjects(token);
     });
+
+    // Asked by the project dialog before recording starts, so a user with no credits never reaches
+    // the source picker (issue #3899). Fails open — a signed-out user or unreachable backend must
+    // not block a shave here; the 360 process route still rejects with 402.
+    ipcMain.handle(
+      IPC_CHANNELS.CLOUD360_CHECK_CREDITS,
+      async (): Promise<CreditPrecheckResult> => {
+        const token = await this.auth.getAccessToken();
+        if (!token) {
+          return { canShave: true };
+        }
+        return checkCloud360Credits(token);
+      },
+    );
   }
 }

--- a/src/backend/ipc/cloud-360-handlers.ts
+++ b/src/backend/ipc/cloud-360-handlers.ts
@@ -2,8 +2,8 @@ import { ipcMain } from "electron";
 import type { Cloud360Project } from "../../shared/types/cloud360";
 import { IdentityServerAuthService } from "../services/auth/identity-server-auth";
 import {
-  checkCloud360Credits,
   type CreditPrecheckResult,
+  checkCloud360Credits,
 } from "../services/yakshaver360/credit-precheck";
 import { fetchGitHubProjects } from "../services/yakshaver360/github-projects";
 import { IPC_CHANNELS } from "./channels";
@@ -23,15 +23,12 @@ export class Cloud360IPCHandlers {
     // Asked by the project dialog before recording starts, so a user with no credits never reaches
     // the source picker (issue #3899). Fails open — a signed-out user or unreachable backend must
     // not block a shave here; the 360 process route still rejects with 402.
-    ipcMain.handle(
-      IPC_CHANNELS.CLOUD360_CHECK_CREDITS,
-      async (): Promise<CreditPrecheckResult> => {
-        const token = await this.auth.getAccessToken();
-        if (!token) {
-          return { canShave: true };
-        }
-        return checkCloud360Credits(token);
-      },
-    );
+    ipcMain.handle(IPC_CHANNELS.CLOUD360_CHECK_CREDITS, async (): Promise<CreditPrecheckResult> => {
+      const token = await this.auth.getAccessToken();
+      if (!token) {
+        return { canShave: true };
+      }
+      return checkCloud360Credits(token);
+    });
   }
 }

--- a/src/backend/preload.ts
+++ b/src/backend/preload.ts
@@ -150,6 +150,7 @@ const IPC_CHANNELS = {
   // Cloud 360 orchestration
   CLOUD360_EVENT: "cloud-360:event",
   CLOUD360_LIST_PROJECTS: "cloud-360:list-projects",
+  CLOUD360_CHECK_CREDITS: "cloud-360:check-credits",
 } as const;
 
 const onIpcEvent = <T>(channel: string, callback: (payload: T) => void) => {
@@ -265,6 +266,7 @@ const electronAPI = {
   },
   cloud360: {
     listProjects: () => ipcRenderer.invoke(IPC_CHANNELS.CLOUD360_LIST_PROJECTS),
+    checkCredits: () => ipcRenderer.invoke(IPC_CHANNELS.CLOUD360_CHECK_CREDITS),
   },
   llm: {
     setConfig: (config: unknown) => ipcRenderer.invoke(IPC_CHANNELS.LLM_SET_CONFIG, config),

--- a/src/backend/services/yakshaver360/cloud-360-orchestrator.test.ts
+++ b/src/backend/services/yakshaver360/cloud-360-orchestrator.test.ts
@@ -1,13 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SandboxEvent } from "./types";
 
-const { broadcast, uploadRecordingFromFile, processRecording } = vi.hoisted(() => ({
-  broadcast: vi.fn(),
-  uploadRecordingFromFile: vi.fn(),
-  processRecording: vi.fn(),
-}));
+const { broadcast, uploadRecordingFromFile, processRecording, checkCloud360Credits, getAccessToken } =
+  vi.hoisted(() => ({
+    broadcast: vi.fn(),
+    uploadRecordingFromFile: vi.fn(),
+    processRecording: vi.fn(),
+    checkCloud360Credits: vi.fn(),
+    getAccessToken: vi.fn(),
+  }));
 
 vi.mock("./cloud-360-broadcast", () => ({ broadcastCloud360Event: broadcast }));
+
+vi.mock("./credit-precheck", () => ({ checkCloud360Credits }));
+
+vi.mock("../auth/identity-server-auth", () => ({
+  IdentityServerAuthService: { getInstance: () => ({ getAccessToken }) },
+}));
 
 vi.mock("./yakshaver360-client", () => ({
   YakShaver360Client: {
@@ -25,6 +34,9 @@ beforeEach(() => {
   broadcast.mockReset();
   uploadRecordingFromFile.mockReset();
   processRecording.mockReset();
+  // Default: signed in with credits available, so existing cases exercise the happy path.
+  checkCloud360Credits.mockReset().mockResolvedValue({ canShave: true });
+  getAccessToken.mockReset().mockResolvedValue("token-1");
 });
 
 describe("Cloud360Orchestrator", () => {
@@ -115,5 +127,45 @@ describe("Cloud360Orchestrator", () => {
       shaveId: undefined,
       event: { type: "error", message: "Not signed in" },
     });
+  });
+
+  // Issue #3899: the credit gate must stop the run before the upload, not after it.
+  it("blocks before uploading when the credit pre-check fails", async () => {
+    checkCloud360Credits.mockResolvedValue({
+      canShave: false,
+      message: "Out of YakShaver credits, so this recording can't be processed.",
+    });
+
+    await expect(
+      new Cloud360Orchestrator().run({
+        filePath: "/tmp/v.mp4",
+        projectId: "p1",
+        shaveId: "s1",
+        durationSeconds: 1,
+      }),
+    ).resolves.toBe(false);
+
+    expect(uploadRecordingFromFile).not.toHaveBeenCalled();
+    expect(processRecording).not.toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith({
+      shaveId: "s1",
+      event: {
+        type: "error",
+        message: "Out of YakShaver credits, so this recording can't be processed.",
+      },
+      runStart: true,
+    });
+  });
+
+  it("still uploads when the user is not signed in, leaving the failure to the upload call", async () => {
+    getAccessToken.mockResolvedValue(null);
+    uploadRecordingFromFile.mockRejectedValue(new Error("Not signed in"));
+
+    await expect(
+      new Cloud360Orchestrator().run({ filePath: "/tmp/v.mp4", projectId: "p1", durationSeconds: 1 }),
+    ).resolves.toBe(false);
+
+    expect(checkCloud360Credits).not.toHaveBeenCalled();
+    expect(uploadRecordingFromFile).toHaveBeenCalled();
   });
 });

--- a/src/backend/services/yakshaver360/cloud-360-orchestrator.test.ts
+++ b/src/backend/services/yakshaver360/cloud-360-orchestrator.test.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SandboxEvent } from "./types";
 
-const { broadcast, uploadRecordingFromFile, processRecording, checkCloud360Credits, getAccessToken } =
-  vi.hoisted(() => ({
-    broadcast: vi.fn(),
-    uploadRecordingFromFile: vi.fn(),
-    processRecording: vi.fn(),
-    checkCloud360Credits: vi.fn(),
-    getAccessToken: vi.fn(),
-  }));
+const {
+  broadcast,
+  uploadRecordingFromFile,
+  processRecording,
+  checkCloud360Credits,
+  getAccessToken,
+} = vi.hoisted(() => ({
+  broadcast: vi.fn(),
+  uploadRecordingFromFile: vi.fn(),
+  processRecording: vi.fn(),
+  checkCloud360Credits: vi.fn(),
+  getAccessToken: vi.fn(),
+}));
 
 vi.mock("./cloud-360-broadcast", () => ({ broadcastCloud360Event: broadcast }));
 
@@ -162,7 +167,11 @@ describe("Cloud360Orchestrator", () => {
     uploadRecordingFromFile.mockRejectedValue(new Error("Not signed in"));
 
     await expect(
-      new Cloud360Orchestrator().run({ filePath: "/tmp/v.mp4", projectId: "p1", durationSeconds: 1 }),
+      new Cloud360Orchestrator().run({
+        filePath: "/tmp/v.mp4",
+        projectId: "p1",
+        durationSeconds: 1,
+      }),
     ).resolves.toBe(false);
 
     expect(checkCloud360Credits).not.toHaveBeenCalled();

--- a/src/backend/services/yakshaver360/cloud-360-orchestrator.ts
+++ b/src/backend/services/yakshaver360/cloud-360-orchestrator.ts
@@ -29,7 +29,10 @@ export class Cloud360Orchestrator {
         if (!precheck.canShave) {
           broadcastCloud360Event({
             shaveId,
-            event: { type: "error", message: precheck.message ?? "This recording can't be processed." },
+            event: {
+              type: "error",
+              message: precheck.message ?? "This recording can't be processed.",
+            },
             runStart: true,
           });
           return false;

--- a/src/backend/services/yakshaver360/cloud-360-orchestrator.ts
+++ b/src/backend/services/yakshaver360/cloud-360-orchestrator.ts
@@ -1,4 +1,6 @@
+import { IdentityServerAuthService } from "../auth/identity-server-auth";
 import { broadcastCloud360Event } from "./cloud-360-broadcast";
+import { checkCloud360Credits } from "./credit-precheck";
 import { YakShaver360Client } from "./yakshaver360-client";
 
 export interface Cloud360RunParams {
@@ -18,6 +20,22 @@ export class Cloud360Orchestrator {
     const { shaveId } = params;
     let succeeded = false;
     try {
+      // Last-resort gate (issue #3899): Cloud360ProjectDialog already blocks before recording, so
+      // reaching here means the balance ran out since. Spares a pointless multi-megabyte upload
+      // and replaces the process route's opaque "Failed to start stream (402)". Fails open.
+      const token = await IdentityServerAuthService.getInstance().getAccessToken();
+      if (token) {
+        const precheck = await checkCloud360Credits(token);
+        if (!precheck.canShave) {
+          broadcastCloud360Event({
+            shaveId,
+            event: { type: "error", message: precheck.message ?? "This recording can't be processed." },
+            runStart: true,
+          });
+          return false;
+        }
+      }
+
       // Upload + sandbox spin-up emit no server events; synthesize status rows so the live
       // view shows progress instead of a blank feed during those silent stretches.
       broadcastCloud360Event({

--- a/src/backend/services/yakshaver360/credit-precheck.test.ts
+++ b/src/backend/services/yakshaver360/credit-precheck.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/env", () => ({
+  config: { portalApiUrl: () => "https://api.test/api" },
+}));
+
+import { checkCloud360Credits } from "./credit-precheck";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("checkCloud360Credits", () => {
+  it("allows a shave when credits remain", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ remaining: 3 }));
+    await expect(checkCloud360Credits("t")).resolves.toEqual({ canShave: true });
+  });
+
+  it("blocks and names the reason when the plan is spent", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ remaining: 0, error: "InsufficientCredits" }),
+    );
+    const result = await checkCloud360Credits("t");
+    expect(result.canShave).toBe(false);
+    expect(result.reason).toBe("out-of-credits");
+  });
+
+  it.each([
+    "NoStripeCustomer",
+    "NoActiveSubscription",
+  ])("reports %s as having no plan rather than a spent one", async (error) => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ remaining: 0, error }));
+    const result = await checkCloud360Credits("t");
+    expect(result.reason).toBe("no-subscription");
+  });
+
+  // Fail-open contract: this check is a courtesy, so anything it cannot confidently read must let
+  // the shave through and leave the verdict to the authoritative gate on the process route.
+  describe("fails open", () => {
+    it("when the request throws (offline, DNS, timeout)", async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error("network down"));
+      await expect(checkCloud360Credits("t")).resolves.toEqual({ canShave: true });
+    });
+
+    it("when the endpoint returns a non-ok status", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse({}, false));
+      await expect(checkCloud360Credits("t")).resolves.toEqual({ canShave: true });
+    });
+
+    it("when the body is not JSON", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error("not json");
+        },
+      } as unknown as Response);
+      await expect(checkCloud360Credits("t")).resolves.toEqual({ canShave: true });
+    });
+
+    // A malformed 200 must not read as "no credits" — `?? 0` alone would have blocked a paying user.
+    it.each([
+      [null],
+      [undefined],
+      ["5"],
+      [Number.NaN],
+    ])("when remaining is %p rather than a number", async (remaining) => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse({ remaining }));
+      await expect(checkCloud360Credits("t")).resolves.toEqual({ canShave: true });
+    });
+  });
+
+  it("gives the request a timeout so a hung backend cannot stall the dialog", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ remaining: 1 }));
+    await checkCloud360Credits("t");
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/src/backend/services/yakshaver360/credit-precheck.ts
+++ b/src/backend/services/yakshaver360/credit-precheck.ts
@@ -30,20 +30,31 @@ export interface CreditPrecheckResult {
 
 const BILLING_HINT = "Visit https://portal.yakshaver.ai/plan to update your subscription.";
 
+// The dialog holds its project list until this resolves, so a hung request would be indistinguishable
+// from a permanent spinner. Short enough that a slow backend costs a moment, not the whole flow.
+const TIMEOUT_MS = 5000;
+
 export async function checkCloud360Credits(token: string): Promise<CreditPrecheckResult> {
   let balance: CreditBalanceDto;
   try {
     const response = await fetch(`${config.portalApiUrl()}/credits/balance`, {
       headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
     });
     if (!response.ok) return { canShave: true };
     balance = (await response.json()) as CreditBalanceDto;
   } catch {
-    // Unreachable, non-ok or unparseable — fail open and let the process route report the truth.
+    // Unreachable, timed out, non-ok or unparseable — fail open and let the process route report
+    // the truth.
     return { canShave: true };
   }
 
-  if ((balance?.remaining ?? 0) >= 1) return { canShave: true };
+  // Only a number we can actually compare should ever block. `?? 0` alone would treat a null or a
+  // stringified count as "no credits" and stop a paying user over a malformed response.
+  if (typeof balance?.remaining !== "number" || Number.isNaN(balance.remaining)) {
+    return { canShave: true };
+  }
+  if (balance.remaining >= 1) return { canShave: true };
 
   const hasNoPlan =
     balance?.error === "NoStripeCustomer" || balance?.error === "NoActiveSubscription";

--- a/src/backend/services/yakshaver360/credit-precheck.ts
+++ b/src/backend/services/yakshaver360/credit-precheck.ts
@@ -1,0 +1,60 @@
+import { config } from "../../config/env";
+
+/**
+ * Pre-flight credit check for the YakShaver Anywhere (cloud 360) path, reading the same
+ * GET /api/credits/balance as assertCanShave in SSW.YakShaver.
+ *
+ * Fail-OPEN, unlike the server gate: this is a courtesy with no security role, and blocking a
+ * paying user because the balance endpoint was unreachable is worse than letting
+ * /api/360/recordings/[id]/process reject them a moment later.
+ */
+
+interface CreditBalanceDto {
+  remaining: number;
+  error?: string;
+}
+
+/**
+ * Mirrors ShaveBlockReason in SSW.YakShaver, minus "unavailable" — this check fails open, so an
+ * unreachable backend never blocks.
+ */
+export type ShaveBlockReason = "out-of-credits" | "no-subscription";
+
+export interface CreditPrecheckResult {
+  canShave: boolean;
+  /** Set only when canShave is false. */
+  reason?: ShaveBlockReason;
+  /** User-facing message, set only when canShave is false. */
+  message?: string;
+}
+
+const BILLING_HINT = "Visit https://portal.yakshaver.ai/plan to update your subscription.";
+
+export async function checkCloud360Credits(token: string): Promise<CreditPrecheckResult> {
+  let balance: CreditBalanceDto;
+  try {
+    const response = await fetch(`${config.portalApiUrl()}/credits/balance`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) return { canShave: true };
+    balance = (await response.json()) as CreditBalanceDto;
+  } catch {
+    // Unreachable, non-ok or unparseable — fail open and let the process route report the truth.
+    return { canShave: true };
+  }
+
+  if ((balance?.remaining ?? 0) >= 1) return { canShave: true };
+
+  const hasNoPlan = balance?.error === "NoStripeCustomer" || balance?.error === "NoActiveSubscription";
+  return hasNoPlan
+    ? {
+        canShave: false,
+        reason: "no-subscription",
+        message: `No active YakShaver subscription, so this recording can't be processed. ${BILLING_HINT}`,
+      }
+    : {
+        canShave: false,
+        reason: "out-of-credits",
+        message: `Out of YakShaver credits, so this recording can't be processed. ${BILLING_HINT}`,
+      };
+}

--- a/src/backend/services/yakshaver360/credit-precheck.ts
+++ b/src/backend/services/yakshaver360/credit-precheck.ts
@@ -45,7 +45,8 @@ export async function checkCloud360Credits(token: string): Promise<CreditPrechec
 
   if ((balance?.remaining ?? 0) >= 1) return { canShave: true };
 
-  const hasNoPlan = balance?.error === "NoStripeCustomer" || balance?.error === "NoActiveSubscription";
+  const hasNoPlan =
+    balance?.error === "NoStripeCustomer" || balance?.error === "NoActiveSubscription";
   return hasNoPlan
     ? {
         canShave: false,

--- a/src/shared/types/cloud360.ts
+++ b/src/shared/types/cloud360.ts
@@ -1,4 +1,10 @@
+import type {
+  CreditPrecheckResult,
+  ShaveBlockReason,
+} from "../../backend/services/yakshaver360/credit-precheck";
 import type { SandboxEvent } from "../../backend/services/yakshaver360/types";
+
+export type { CreditPrecheckResult, ShaveBlockReason };
 
 /** A GitHub-backed 360 project the user can file into. */
 export interface Cloud360Project {

--- a/src/ui/src/components/cloud360/Cloud360ProjectDialog.test.tsx
+++ b/src/ui/src/components/cloud360/Cloud360ProjectDialog.test.tsx
@@ -7,7 +7,7 @@ const { listProjects, checkCredits, openExternal } = vi.hoisted(() => ({
   openExternal: vi.fn(),
 }));
 vi.mock("@/services/ipc-client", () => ({
-  ipcClient: { cloud360: { listProjects, checkCredits } },
+  ipcClient: { cloud360: { listProjects, checkCredits }, app: { openExternal } },
 }));
 
 import { Cloud360ProjectDialog } from "./Cloud360ProjectDialog";
@@ -17,11 +17,6 @@ beforeEach(() => {
   // Default to a tenant that can shave, so the pre-existing cases below still exercise the list.
   checkCredits.mockReset().mockResolvedValue({ canShave: true });
   openExternal.mockReset();
-  Object.defineProperty(window, "electronAPI", {
-    value: { app: { openExternal } },
-    writable: true,
-    configurable: true,
-  });
 });
 
 describe("Cloud360ProjectDialog", () => {

--- a/src/ui/src/components/cloud360/Cloud360ProjectDialog.test.tsx
+++ b/src/ui/src/components/cloud360/Cloud360ProjectDialog.test.tsx
@@ -1,12 +1,28 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listProjects } = vi.hoisted(() => ({ listProjects: vi.fn() }));
-vi.mock("@/services/ipc-client", () => ({ ipcClient: { cloud360: { listProjects } } }));
+const { listProjects, checkCredits, openExternal } = vi.hoisted(() => ({
+  listProjects: vi.fn(),
+  checkCredits: vi.fn(),
+  openExternal: vi.fn(),
+}));
+vi.mock("@/services/ipc-client", () => ({
+  ipcClient: { cloud360: { listProjects, checkCredits } },
+}));
 
 import { Cloud360ProjectDialog } from "./Cloud360ProjectDialog";
 
-beforeEach(() => listProjects.mockClear());
+beforeEach(() => {
+  listProjects.mockClear();
+  // Default to a tenant that can shave, so the pre-existing cases below still exercise the list.
+  checkCredits.mockReset().mockResolvedValue({ canShave: true });
+  openExternal.mockReset();
+  Object.defineProperty(window, "electronAPI", {
+    value: { app: { openExternal } },
+    writable: true,
+    configurable: true,
+  });
+});
 
 describe("Cloud360ProjectDialog", () => {
   it("lists projects (name + repo) and confirms on selecting one", async () => {
@@ -34,5 +50,48 @@ describe("Cloud360ProjectDialog", () => {
     listProjects.mockRejectedValueOnce(new Error("Not signed in"));
     render(<Cloud360ProjectDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
     await waitFor(() => expect(screen.getByText(/not signed in/i)).toBeInTheDocument());
+  });
+
+  // Issue #3899: this dialog is the last point before the source picker opens, so blocking here is
+  // what actually spares the user recording a video that can never be processed.
+  describe("credit pre-check", () => {
+    it("withholds the project list and explains why when credits are spent", async () => {
+      listProjects.mockResolvedValueOnce([{ id: "1", name: "Widgets", githubRepo: "acme/widgets" }]);
+      checkCredits.mockResolvedValue({ canShave: false, reason: "out-of-credits" });
+      render(<Cloud360ProjectDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
+
+      await waitFor(() => expect(screen.getByText("Out of credits")).toBeInTheDocument());
+      expect(screen.queryByText("Widgets")).not.toBeInTheDocument();
+      // Nothing to filter, so the search box goes too.
+      expect(screen.queryByPlaceholderText("Search projects...")).not.toBeInTheDocument();
+    });
+
+    it("distinguishes having no plan from having spent one", async () => {
+      listProjects.mockResolvedValueOnce([]);
+      checkCredits.mockResolvedValue({ canShave: false, reason: "no-subscription" });
+      render(<Cloud360ProjectDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
+
+      await waitFor(() => expect(screen.getByText("No active subscription")).toBeInTheDocument());
+      expect(screen.getByRole("button", { name: "View plans" })).toBeInTheDocument();
+    });
+
+    it("opens billing in the system browser", async () => {
+      listProjects.mockResolvedValueOnce([]);
+      checkCredits.mockResolvedValue({ canShave: false, reason: "out-of-credits" });
+      render(<Cloud360ProjectDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
+
+      const button = await screen.findByRole("button", { name: "Manage plan" });
+      fireEvent.click(button);
+      expect(openExternal).toHaveBeenCalledWith("https://portal.yakshaver.ai/plan");
+    });
+
+    // Fails open: a broken pre-check must never be the thing that stops a paying user.
+    it("still lists projects when the credit check itself throws", async () => {
+      listProjects.mockResolvedValueOnce([{ id: "1", name: "Widgets", githubRepo: "acme/widgets" }]);
+      checkCredits.mockRejectedValue(new Error("ipc exploded"));
+      render(<Cloud360ProjectDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
+
+      await waitFor(() => expect(screen.getByText("Widgets")).toBeInTheDocument());
+    });
   });
 });

--- a/src/ui/src/components/cloud360/Cloud360ProjectDialog.test.tsx
+++ b/src/ui/src/components/cloud360/Cloud360ProjectDialog.test.tsx
@@ -56,7 +56,9 @@ describe("Cloud360ProjectDialog", () => {
   // what actually spares the user recording a video that can never be processed.
   describe("credit pre-check", () => {
     it("withholds the project list and explains why when credits are spent", async () => {
-      listProjects.mockResolvedValueOnce([{ id: "1", name: "Widgets", githubRepo: "acme/widgets" }]);
+      listProjects.mockResolvedValueOnce([
+        { id: "1", name: "Widgets", githubRepo: "acme/widgets" },
+      ]);
       checkCredits.mockResolvedValue({ canShave: false, reason: "out-of-credits" });
       render(<Cloud360ProjectDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
 
@@ -87,7 +89,9 @@ describe("Cloud360ProjectDialog", () => {
 
     // Fails open: a broken pre-check must never be the thing that stops a paying user.
     it("still lists projects when the credit check itself throws", async () => {
-      listProjects.mockResolvedValueOnce([{ id: "1", name: "Widgets", githubRepo: "acme/widgets" }]);
+      listProjects.mockResolvedValueOnce([
+        { id: "1", name: "Widgets", githubRepo: "acme/widgets" },
+      ]);
       checkCredits.mockRejectedValue(new Error("ipc exploded"));
       render(<Cloud360ProjectDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
 

--- a/src/ui/src/components/cloud360/Cloud360ProjectDialog.tsx
+++ b/src/ui/src/components/cloud360/Cloud360ProjectDialog.tsx
@@ -1,9 +1,29 @@
-import type { Cloud360Project } from "@shared/types/cloud360";
-import { Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import type { Cloud360Project, ShaveBlockReason } from "@shared/types/cloud360";
+import { CircleAlert, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ipcClient } from "@/services/ipc-client";
 import { formatErrorMessage } from "@/utils";
+import { Button } from "../ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
+
+const BILLING_URL = "https://portal.yakshaver.ai/plan";
+
+// Duplicated from shave-block-notice.ts in SSW.YakShaver — the repos ship separately, so keep the
+// wording in step when either changes.
+function getBlockCopy(reason: ShaveBlockReason) {
+  if (reason === "no-subscription") {
+    return {
+      title: "No active subscription",
+      body: "Your tenant doesn't have an active YakShaver plan, so recordings can't be processed. Choose a plan to start shaving.",
+      actionLabel: "View plans",
+    };
+  }
+  return {
+    title: "Out of credits",
+    body: "Your tenant has used all its YakShaver credits, so recordings can't be processed. Add credits or upgrade your plan to continue.",
+    actionLabel: "Manage plan",
+  };
+}
 
 interface Props {
   open: boolean;
@@ -11,11 +31,41 @@ interface Props {
   onConfirm: (projectId: string) => void;
 }
 
+/** Centred empty state shown instead of the project list when the tenant cannot shave. */
+function BlockedState({
+  reason,
+  onAction,
+}: {
+  reason: ShaveBlockReason;
+  onAction: () => void;
+}) {
+  const copy = getBlockCopy(reason);
+  return (
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center"
+    >
+      <div className="flex size-11 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+        <CircleAlert className="size-5" aria-hidden="true" />
+      </div>
+      <div className="space-y-1.5">
+        <p className="font-semibold text-base">{copy.title}</p>
+        <p className="mx-auto max-w-sm text-muted-foreground text-sm leading-relaxed">{copy.body}</p>
+      </div>
+      <Button size="sm" onClick={onAction}>
+        {copy.actionLabel}
+      </Button>
+    </div>
+  );
+}
+
 /** Searchable 360 project picker (mirrors the web ShaveProjectPickerDialog); selecting one proceeds immediately. */
 export function Cloud360ProjectDialog({ open, onOpenChange, onConfirm }: Props) {
   const [projects, setProjects] = useState<Cloud360Project[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [blockReason, setBlockReason] = useState<ShaveBlockReason | null>(null);
+  const [creditsChecked, setCreditsChecked] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -23,6 +73,23 @@ export function Cloud360ProjectDialog({ open, onOpenChange, onConfirm }: Props) 
     setProjects(null);
     setError(null);
     setQuery("");
+    setBlockReason(null);
+    setCreditsChecked(false);
+
+    // Fetched alongside the projects so a user with credits waits on no extra round-trip
+    // (issue #3899). The list still waits on creditsChecked below — projects rendered first, then
+    // swapped out, would let a fast click slip through the gate.
+    ipcClient.cloud360
+      .checkCredits()
+      .then((result) => {
+        if (!cancelled && !result.canShave) setBlockReason(result.reason ?? "out-of-credits");
+      })
+      // Fails open like checkCredits itself: a broken pre-check must never stop someone recording.
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setCreditsChecked(true);
+      });
+
     ipcClient.cloud360
       .listProjects()
       .then((list) => {
@@ -35,6 +102,10 @@ export function Cloud360ProjectDialog({ open, onOpenChange, onConfirm }: Props) 
       cancelled = true;
     };
   }, [open]);
+
+  const handleOpenBilling = useCallback(() => {
+    void window.electronAPI.app.openExternal(BILLING_URL);
+  }, []);
 
   const filtered = useMemo(() => {
     if (!projects) return [];
@@ -54,20 +125,27 @@ export function Cloud360ProjectDialog({ open, onOpenChange, onConfirm }: Props) 
         <DialogHeader className="sr-only">
           <DialogTitle>Select a project</DialogTitle>
         </DialogHeader>
-        <div className="flex items-center gap-2 border-white/10 border-b px-3">
-          <Search className="h-4 w-4 shrink-0 opacity-50" />
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search projects..."
-            autoFocus
-            className="h-12 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-          />
-        </div>
+        {/* Search is pointless while blocked, and premature until the gate has answered. */}
+        {blockReason === null && creditsChecked && (
+          <div className="flex items-center gap-2 border-white/10 border-b px-3">
+            <Search className="h-4 w-4 shrink-0 opacity-50" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search projects..."
+              autoFocus
+              className="h-12 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+        )}
         <div className="cloud360-project-scroll max-h-[60vh] min-h-105 overflow-y-auto p-1">
-          {error ? (
+          {blockReason !== null ? (
+            // The list is withheld, not disabled: picking a project would only lead to a recording
+            // we already know cannot be processed.
+            <BlockedState reason={blockReason} onAction={handleOpenBilling} />
+          ) : error ? (
             <div className="text-destructive py-6 text-center text-sm">{error}</div>
-          ) : projects === null ? (
+          ) : projects === null || !creditsChecked ? (
             <div className="text-muted-foreground py-6 text-center text-sm">
               Loading projects...
             </div>

--- a/src/ui/src/components/cloud360/Cloud360ProjectDialog.tsx
+++ b/src/ui/src/components/cloud360/Cloud360ProjectDialog.tsx
@@ -99,7 +99,7 @@ export function Cloud360ProjectDialog({ open, onOpenChange, onConfirm }: Props) 
   }, [open]);
 
   const handleOpenBilling = useCallback(() => {
-    void window.electronAPI.app.openExternal(BILLING_URL);
+    void ipcClient.app.openExternal(BILLING_URL);
   }, []);
 
   const filtered = useMemo(() => {

--- a/src/ui/src/components/cloud360/Cloud360ProjectDialog.tsx
+++ b/src/ui/src/components/cloud360/Cloud360ProjectDialog.tsx
@@ -32,30 +32,25 @@ interface Props {
 }
 
 /** Centred empty state shown instead of the project list when the tenant cannot shave. */
-function BlockedState({
-  reason,
-  onAction,
-}: {
-  reason: ShaveBlockReason;
-  onAction: () => void;
-}) {
+function BlockedState({ reason, onAction }: { reason: ShaveBlockReason; onAction: () => void }) {
   const copy = getBlockCopy(reason);
   return (
-    <div
-      role="status"
-      className="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center"
-    >
+    // <output> is the semantic element for role="status" — announced politely by screen readers
+    // when the gate replaces the project list.
+    <output className="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center">
       <div className="flex size-11 items-center justify-center rounded-full bg-destructive/10 text-destructive">
         <CircleAlert className="size-5" aria-hidden="true" />
       </div>
       <div className="space-y-1.5">
         <p className="font-semibold text-base">{copy.title}</p>
-        <p className="mx-auto max-w-sm text-muted-foreground text-sm leading-relaxed">{copy.body}</p>
+        <p className="mx-auto max-w-sm text-muted-foreground text-sm leading-relaxed">
+          {copy.body}
+        </p>
       </div>
       <Button size="sm" onClick={onAction}>
         {copy.actionLabel}
       </Button>
-    </div>
+    </output>
   );
 }
 

--- a/src/ui/src/services/ipc-client.ts
+++ b/src/ui/src/services/ipc-client.ts
@@ -1,4 +1,8 @@
-import type { Cloud360EventPayload, Cloud360Project } from "@shared/types/cloud360";
+import type {
+  Cloud360EventPayload,
+  Cloud360Project,
+  CreditPrecheckResult,
+} from "@shared/types/cloud360";
 import type { LLMConfigV2, OrchestratorReadiness } from "@shared/types/llm";
 import type { ReleaseListResult, ReleaseUpdateCheckResult } from "@shared/types/release-channel";
 import type { TelemetrySettings } from "@shared/types/telemetry";
@@ -59,6 +63,7 @@ declare global {
       };
       cloud360: {
         listProjects: () => Promise<Cloud360Project[]>;
+        checkCredits: () => Promise<CreditPrecheckResult>;
       };
       youtube: {
         startAuth: () => Promise<AuthResult>;


### PR DESCRIPTION
The cloud-360 path only learned a tenant was out of credits once the process route rejected it, by which point the user had recorded a video and waited out a multi-megabyte upload — and all they saw was "Failed to start stream (402)".

Check in the project dialog instead, before the source picker opens, so the recording never happens. The orchestrator keeps a second check before the upload: the balance can run out between picking a project and submitting, and that one now reports a message that names the actual problem.

Both checks fail open. This is a courtesy to save the user's time, not a security boundary — the 360 process route remains authoritative, and a broken pre-check must never be what stops a paying user recording.

Only affects Anywhere: the dialog opens solely in 360 mode.

> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Claude Opus 5

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ https://github.com/SSWConsulting/SSW.YakShaver/issues/3899

> 2. What was changed?

✏️ Moved the credit check into the project dialog so the source picker never opens for a tenant that can't pay, replacing a flow where the user recorded a video, waited out the upload, and got "Failed to start stream (402)". A second fail-open check before the upload covers a balance that runs out mid-flow

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ No
<!-- E.g.  I paired or mob programmed with: @gordonbeeming and @sethdailyssw -->

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
