### PR TITLE
XS✔ ◾ ♻️ Auth result pages - Extract the duplicated inline CSS into one shared stylesheet

### DIFF
--- a/src/backend/assets/auth/auth-pages.css
+++ b/src/backend/assets/auth/auth-pages.css
@@ -1,0 +1,124 @@
+/* Shared look for the auth result pages (success / failure / error). The success page's button
+   styles stay in that page: it is the only one with a button.
+
+   Dark-only: the app hardcodes `class="dark"`, so a light page here would be the product's only
+   light surface. Colours are the app's `.dark` tokens (src/ui/src/App.css) resolved to hex, since
+   these pages run outside Tailwind. Keep in sync with that block and with SSW.YakShaver:
+   backend/src/SSW.YakShaver/Features/Mcp/WebApi/AuthResultPages/auth-pages.css. */
+
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+  font-family:
+    Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, Avenir, Helvetica, Arial,
+    sans-serif;
+  /* --background */
+  background: #1a1414;
+  /* --foreground */
+  color: #faf9f8;
+}
+
+.card {
+  width: 100%;
+  max-width: 420px;
+  /* --card */
+  background: #2b2523;
+  /* --border */
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 40px 32px 32px;
+  text-align: center;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+.logo {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.logo svg {
+  width: 44px;
+  height: auto;
+}
+
+.status-badge {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 16px;
+}
+
+.status-badge svg {
+  width: 15px;
+  height: 15px;
+}
+
+.status-badge--success {
+  background: #2e9e5b;
+}
+
+/* --warning: the shared "needs attention" token, so these pages stop hand-mixing amber. */
+.status-badge--warning {
+  background: #f2b134;
+  /* --warning-foreground */
+  color: #1a1414;
+}
+
+/* --danger: reserved for genuine faults. */
+.status-badge--error {
+  background: #ff453a;
+}
+
+h1 {
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: 600;
+  margin: 0 0 8px;
+  color: #faf9f8;
+}
+
+p {
+  font-size: 14px;
+  line-height: 21px;
+  /* --muted-foreground */
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0 0 24px;
+}
+
+.brand {
+  font-weight: 600;
+  /* --ssw-red */
+  color: #cc4141;
+}
+
+.hint {
+  margin-top: 18px;
+  margin-bottom: 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+}

--- a/src/backend/assets/auth/errorTemplate.html
+++ b/src/backend/assets/auth/errorTemplate.html
@@ -5,110 +5,7 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>YakShaver | Authorization Error</title>
-    <style>
-      :root {
-        color-scheme: dark;
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      html,
-      body {
-        height: 100%;
-      }
-
-      body {
-        margin: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        padding: 24px;
-        font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          system-ui,
-          Avenir,
-          Helvetica,
-          Arial,
-          sans-serif;
-        background: #1a1414;
-        color: #faf9f8;
-      }
-
-      .card {
-        width: 100%;
-        max-width: 420px;
-        background: #2b2523;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-radius: 16px;
-        padding: 40px 32px 32px;
-        text-align: center;
-        box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
-      }
-
-      .logo {
-        width: 56px;
-        height: 56px;
-        margin: 0 auto 20px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .logo svg {
-        width: 44px;
-        height: auto;
-      }
-
-      .status-badge {
-        width: 28px;
-        height: 28px;
-        border-radius: 999px;
-        background: #ff453a;
-        color: #ffffff;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin: 0 auto 16px;
-      }
-
-      .status-badge svg {
-        width: 14px;
-        height: 14px;
-      }
-
-      h1 {
-        font-size: 20px;
-        line-height: 28px;
-        font-weight: 600;
-        margin: 0 0 8px;
-        color: #faf9f8;
-      }
-
-      p {
-        font-size: 14px;
-        line-height: 21px;
-        color: rgba(255, 255, 255, 0.75);
-        margin: 0 0 24px;
-      }
-
-      .brand {
-        font-weight: 600;
-        color: #cc4141;
-      }
-
-      .hint {
-        margin-top: 18px;
-        margin-bottom: 0;
-        font-size: 12px;
-        color: rgba(255, 255, 255, 0.5);
-      }
-    </style>
+    <link rel="stylesheet" href="auth-pages.css" />
   </head>
   <body>
     <main class="card">
@@ -117,7 +14,7 @@
           <path fill-rule="evenodd" clip-rule="evenodd" d="M45.1437 25.5946C44.4965 25.6897 43.8485 25.7802 43.2013 25.8708L42.6766 25.9442C41.2732 26.1448 39.8668 26.3382 38.4532 26.3977C37.0488 26.4638 35.6408 26.4517 34.233 26.4393C33.7997 26.4356 33.3658 26.432 32.9328 26.4304C29.5826 26.4127 26.291 25.9097 23.0772 24.7915C20.2516 23.8102 17.6709 22.352 15.2805 20.3841C13.2082 18.675 11.5067 16.6221 10.0832 14.3844C7.62966 10.5158 5.97601 6.23915 5.13532 1.65092C5.06515 1.28509 4.93633 0.929975 4.80752 0.573805C4.74311 0.396654 4.67897 0.219214 4.62163 0.0400897C4.5512 0.0245594 4.47397 0.0122926 4.39699 0C4.27917 0.2473 4.15874 0.493047 4.03804 0.73861C3.74925 1.3271 3.46073 1.91462 3.21227 2.52022C0.753797 8.4737 0.0149451 14.7698 0.800137 21.2764C1.02792 23.2256 1.62356 25.1524 2.21212 27.0566C2.29433 27.3227 2.37655 27.5886 2.45745 27.8536C3.07612 29.9076 4.19565 31.683 5.32854 33.4798L5.50317 33.7567C7.41104 36.7783 9.7496 39.3139 12.3785 41.5208C14.34 43.162 16.4922 44.5529 18.6312 45.9354C18.8703 46.0901 19.1114 46.246 19.3502 46.4008C22.16 48.2317 25.1827 49.585 28.2434 50.8329C28.662 51.0038 29.0814 51.1714 29.5017 51.3354L29.5318 70.2155L40.0566 62.0256L50.2512 95.5239C50.5251 96.4233 51.2556 97.1077 52.1672 97.3188L68.0653 101L83.9514 97.3188C84.863 97.1077 85.5933 96.4233 85.8671 95.5241L96.0217 62.1572L106.37 70.2155L106.402 50.1475C108.897 49.083 111.345 47.9027 113.65 46.4008C113.889 46.2457 114.128 46.0909 114.368 45.9362C116.507 44.5537 118.66 43.162 120.622 41.5208C123.25 39.3139 125.589 36.7783 127.497 33.7567L127.671 33.4798C128.804 31.683 129.924 29.9076 130.543 27.8536C130.623 27.5901 130.704 27.3261 130.786 27.0619L130.788 27.0566C131.376 25.1524 131.972 23.2256 132.2 21.2764C132.985 14.7698 132.246 8.4737 129.788 2.52022C129.539 1.91462 129.251 1.32713 128.962 0.738663C128.841 0.493074 128.721 0.247327 128.603 0C128.526 0.0122926 128.449 0.0245594 128.378 0.0400897C128.321 0.219083 128.257 0.39639 128.193 0.573436C128.064 0.929579 127.935 1.28512 127.865 1.65092C127.024 6.23915 125.37 10.5158 122.917 14.3844C121.493 16.6221 119.792 18.675 117.72 20.3841C115.329 22.352 112.748 23.8102 109.923 24.7915C106.709 25.9097 103.417 26.4127 100.067 26.4304C99.6343 26.432 99.201 26.4356 98.7677 26.4393C97.3599 26.4517 95.951 26.4638 94.5469 26.3977C94.2958 26.3872 94.0447 26.3722 93.7942 26.354L68.0653 19.4128L45.1437 25.5946Z" fill="#CC4141"/>
         </svg>
       </div>
-      <div class="status-badge" aria-hidden="true">
+      <div class="status-badge status-badge--error" aria-hidden="true">
         <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>

--- a/src/backend/assets/auth/failureTemplate.html
+++ b/src/backend/assets/auth/failureTemplate.html
@@ -5,110 +5,7 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>YakShaver | Authorization Declined</title>
-    <style>
-      :root {
-        color-scheme: dark;
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      html,
-      body {
-        height: 100%;
-      }
-
-      body {
-        margin: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        padding: 24px;
-        font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          system-ui,
-          Avenir,
-          Helvetica,
-          Arial,
-          sans-serif;
-        background: #1a1414;
-        color: #faf9f8;
-      }
-
-      .card {
-        width: 100%;
-        max-width: 420px;
-        background: #2b2523;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-radius: 16px;
-        padding: 40px 32px 32px;
-        text-align: center;
-        box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
-      }
-
-      .logo {
-        width: 56px;
-        height: 56px;
-        margin: 0 auto 20px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .logo svg {
-        width: 44px;
-        height: auto;
-      }
-
-      .status-badge {
-        width: 28px;
-        height: 28px;
-        border-radius: 999px;
-        background: #f2b134;
-        color: #1a1414;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin: 0 auto 16px;
-      }
-
-      .status-badge svg {
-        width: 14px;
-        height: 14px;
-      }
-
-      h1 {
-        font-size: 20px;
-        line-height: 28px;
-        font-weight: 600;
-        margin: 0 0 8px;
-        color: #faf9f8;
-      }
-
-      p {
-        font-size: 14px;
-        line-height: 21px;
-        color: rgba(255, 255, 255, 0.75);
-        margin: 0 0 24px;
-      }
-
-      .brand {
-        font-weight: 600;
-        color: #cc4141;
-      }
-
-      .hint {
-        margin-top: 18px;
-        margin-bottom: 0;
-        font-size: 12px;
-        color: rgba(255, 255, 255, 0.5);
-      }
-    </style>
+    <link rel="stylesheet" href="auth-pages.css" />
   </head>
   <body>
     <main class="card">
@@ -117,7 +14,7 @@
           <path fill-rule="evenodd" clip-rule="evenodd" d="M45.1437 25.5946C44.4965 25.6897 43.8485 25.7802 43.2013 25.8708L42.6766 25.9442C41.2732 26.1448 39.8668 26.3382 38.4532 26.3977C37.0488 26.4638 35.6408 26.4517 34.233 26.4393C33.7997 26.4356 33.3658 26.432 32.9328 26.4304C29.5826 26.4127 26.291 25.9097 23.0772 24.7915C20.2516 23.8102 17.6709 22.352 15.2805 20.3841C13.2082 18.675 11.5067 16.6221 10.0832 14.3844C7.62966 10.5158 5.97601 6.23915 5.13532 1.65092C5.06515 1.28509 4.93633 0.929975 4.80752 0.573805C4.74311 0.396654 4.67897 0.219214 4.62163 0.0400897C4.5512 0.0245594 4.47397 0.0122926 4.39699 0C4.27917 0.2473 4.15874 0.493047 4.03804 0.73861C3.74925 1.3271 3.46073 1.91462 3.21227 2.52022C0.753797 8.4737 0.0149451 14.7698 0.800137 21.2764C1.02792 23.2256 1.62356 25.1524 2.21212 27.0566C2.29433 27.3227 2.37655 27.5886 2.45745 27.8536C3.07612 29.9076 4.19565 31.683 5.32854 33.4798L5.50317 33.7567C7.41104 36.7783 9.7496 39.3139 12.3785 41.5208C14.34 43.162 16.4922 44.5529 18.6312 45.9354C18.8703 46.0901 19.1114 46.246 19.3502 46.4008C22.16 48.2317 25.1827 49.585 28.2434 50.8329C28.662 51.0038 29.0814 51.1714 29.5017 51.3354L29.5318 70.2155L40.0566 62.0256L50.2512 95.5239C50.5251 96.4233 51.2556 97.1077 52.1672 97.3188L68.0653 101L83.9514 97.3188C84.863 97.1077 85.5933 96.4233 85.8671 95.5241L96.0217 62.1572L106.37 70.2155L106.402 50.1475C108.897 49.083 111.345 47.9027 113.65 46.4008C113.889 46.2457 114.128 46.0909 114.368 45.9362C116.507 44.5537 118.66 43.162 120.622 41.5208C123.25 39.3139 125.589 36.7783 127.497 33.7567L127.671 33.4798C128.804 31.683 129.924 29.9076 130.543 27.8536C130.623 27.5901 130.704 27.3261 130.786 27.0619L130.788 27.0566C131.376 25.1524 131.972 23.2256 132.2 21.2764C132.985 14.7698 132.246 8.4737 129.788 2.52022C129.539 1.91462 129.251 1.32713 128.962 0.738663C128.841 0.493074 128.721 0.247327 128.603 0C128.526 0.0122926 128.449 0.0245594 128.378 0.0400897C128.321 0.219083 128.257 0.39639 128.193 0.573436C128.064 0.929579 127.935 1.28512 127.865 1.65092C127.024 6.23915 125.37 10.5158 122.917 14.3844C121.493 16.6221 119.792 18.675 117.72 20.3841C115.329 22.352 112.748 23.8102 109.923 24.7915C106.709 25.9097 103.417 26.4127 100.067 26.4304C99.6343 26.432 99.201 26.4356 98.7677 26.4393C97.3599 26.4517 95.951 26.4638 94.5469 26.3977C94.2958 26.3872 94.0447 26.3722 93.7942 26.354L68.0653 19.4128L45.1437 25.5946Z" fill="#CC4141"/>
         </svg>
       </div>
-      <div class="status-badge" aria-hidden="true">
+      <div class="status-badge status-badge--warning" aria-hidden="true">
         <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M8 5V9" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
           <path d="M8 11.25V11.26" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>

--- a/src/backend/assets/auth/successTemplate.html
+++ b/src/backend/assets/auth/successTemplate.html
@@ -54,9 +54,10 @@
         let triggered = false;
         const link = document.getElementById('deeplink');
         // Stays put when opened directly in a browser, where the placeholder is unsubstituted and
-        // would otherwise be followed as a relative URL. Matched on the scheme, not on the
-        // placeholder, which the renderer would itself substitute here.
-        const isDeeplink = () => link.getAttribute('href').indexOf('yakshaver-desktop') === 0;
+        // would otherwise be followed as a relative URL. Tests for a scheme rather than a known
+        // one, since the protocol is configurable, and not for the placeholder itself, which the
+        // renderer would substitute here too.
+        const isDeeplink = () => link.getAttribute('href').includes('://');
         const triggerDeeplink = () => {
           if (triggered || !isDeeplink()) {
             return; // Prevent multiple triggers

--- a/src/backend/assets/auth/successTemplate.html
+++ b/src/backend/assets/auth/successTemplate.html
@@ -5,103 +5,10 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>YakShaver | Signed In</title>
+    <link rel="stylesheet" href="auth-pages.css" />
     <style>
-      :root {
-        color-scheme: dark;
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      html,
-      body {
-        height: 100%;
-      }
-
-      body {
-        margin: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 100vh;
-        padding: 24px;
-        font-family:
-          Inter,
-          -apple-system,
-          BlinkMacSystemFont,
-          "Segoe UI",
-          system-ui,
-          Avenir,
-          Helvetica,
-          Arial,
-          sans-serif;
-        background: #1a1414;
-        color: #faf9f8;
-      }
-
-      .card {
-        width: 100%;
-        max-width: 420px;
-        background: #2b2523;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-radius: 16px;
-        padding: 40px 32px 32px;
-        text-align: center;
-        box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
-      }
-
-      .logo {
-        width: 56px;
-        height: 56px;
-        margin: 0 auto 20px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .logo svg {
-        width: 44px;
-        height: auto;
-      }
-
-      .status-badge {
-        width: 28px;
-        height: 28px;
-        border-radius: 999px;
-        background: #2e9e5b;
-        color: #ffffff;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin: 0 auto 16px;
-      }
-
-      .status-badge svg {
-        width: 15px;
-        height: 15px;
-      }
-
-      h1 {
-        font-size: 20px;
-        line-height: 28px;
-        font-weight: 600;
-        margin: 0 0 8px;
-        color: #faf9f8;
-      }
-
-      p {
-        font-size: 14px;
-        line-height: 21px;
-        color: rgba(255, 255, 255, 0.75);
-        margin: 0 0 24px;
-      }
-
-      .brand {
-        font-weight: 600;
-        color: #cc4141;
-      }
-
+      /* This is the only result page with a button, so its styles stay here rather than in the
+         shared stylesheet. */
       .cta {
         display: inline-flex;
         align-items: center;
@@ -123,13 +30,6 @@
       .cta:hover {
         background: #b23636;
       }
-
-      .hint {
-        margin-top: 18px;
-        margin-bottom: 0;
-        font-size: 12px;
-        color: rgba(255, 255, 255, 0.5);
-      }
     </style>
   </head>
   <body>
@@ -139,7 +39,7 @@
           <path fill-rule="evenodd" clip-rule="evenodd" d="M45.1437 25.5946C44.4965 25.6897 43.8485 25.7802 43.2013 25.8708L42.6766 25.9442C41.2732 26.1448 39.8668 26.3382 38.4532 26.3977C37.0488 26.4638 35.6408 26.4517 34.233 26.4393C33.7997 26.4356 33.3658 26.432 32.9328 26.4304C29.5826 26.4127 26.291 25.9097 23.0772 24.7915C20.2516 23.8102 17.6709 22.352 15.2805 20.3841C13.2082 18.675 11.5067 16.6221 10.0832 14.3844C7.62966 10.5158 5.97601 6.23915 5.13532 1.65092C5.06515 1.28509 4.93633 0.929975 4.80752 0.573805C4.74311 0.396654 4.67897 0.219214 4.62163 0.0400897C4.5512 0.0245594 4.47397 0.0122926 4.39699 0C4.27917 0.2473 4.15874 0.493047 4.03804 0.73861C3.74925 1.3271 3.46073 1.91462 3.21227 2.52022C0.753797 8.4737 0.0149451 14.7698 0.800137 21.2764C1.02792 23.2256 1.62356 25.1524 2.21212 27.0566C2.29433 27.3227 2.37655 27.5886 2.45745 27.8536C3.07612 29.9076 4.19565 31.683 5.32854 33.4798L5.50317 33.7567C7.41104 36.7783 9.7496 39.3139 12.3785 41.5208C14.34 43.162 16.4922 44.5529 18.6312 45.9354C18.8703 46.0901 19.1114 46.246 19.3502 46.4008C22.16 48.2317 25.1827 49.585 28.2434 50.8329C28.662 51.0038 29.0814 51.1714 29.5017 51.3354L29.5318 70.2155L40.0566 62.0256L50.2512 95.5239C50.5251 96.4233 51.2556 97.1077 52.1672 97.3188L68.0653 101L83.9514 97.3188C84.863 97.1077 85.5933 96.4233 85.8671 95.5241L96.0217 62.1572L106.37 70.2155L106.402 50.1475C108.897 49.083 111.345 47.9027 113.65 46.4008C113.889 46.2457 114.128 46.0909 114.368 45.9362C116.507 44.5537 118.66 43.162 120.622 41.5208C123.25 39.3139 125.589 36.7783 127.497 33.7567L127.671 33.4798C128.804 31.683 129.924 29.9076 130.543 27.8536C130.623 27.5901 130.704 27.3261 130.786 27.0619L130.788 27.0566C131.376 25.1524 131.972 23.2256 132.2 21.2764C132.985 14.7698 132.246 8.4737 129.788 2.52022C129.539 1.91462 129.251 1.32713 128.962 0.738663C128.841 0.493074 128.721 0.247327 128.603 0C128.526 0.0122926 128.449 0.0245594 128.378 0.0400897C128.321 0.219083 128.257 0.39639 128.193 0.573436C128.064 0.929579 127.935 1.28512 127.865 1.65092C127.024 6.23915 125.37 10.5158 122.917 14.3844C121.493 16.6221 119.792 18.675 117.72 20.3841C115.329 22.352 112.748 23.8102 109.923 24.7915C106.709 25.9097 103.417 26.4127 100.067 26.4304C99.6343 26.432 99.201 26.4356 98.7677 26.4393C97.3599 26.4517 95.951 26.4638 94.5469 26.3977C94.2958 26.3872 94.0447 26.3722 93.7942 26.354L68.0653 19.4128L45.1437 25.5946Z" fill="#CC4141"/>
         </svg>
       </div>
-      <div class="status-badge" aria-hidden="true">
+      <div class="status-badge status-badge--success" aria-hidden="true">
         <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M3 8.5L6.2 11.5L13 4.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>

--- a/src/backend/assets/auth/successTemplate.html
+++ b/src/backend/assets/auth/successTemplate.html
@@ -53,8 +53,12 @@
       (() => {
         let triggered = false;
         const link = document.getElementById('deeplink');
+        // Stays put when opened directly in a browser, where the placeholder is unsubstituted and
+        // would otherwise be followed as a relative URL. Matched on the scheme, not on the
+        // placeholder, which the renderer would itself substitute here.
+        const isDeeplink = () => link.getAttribute('href').indexOf('yakshaver-desktop') === 0;
         const triggerDeeplink = () => {
-          if (triggered) {
+          if (triggered || !isDeeplink()) {
             return; // Prevent multiple triggers
           }
           triggered = true;
@@ -79,6 +83,10 @@
 
         // Handle manual clicks as fallback (only if auto-trigger failed)
         link.addEventListener('click', (e) => {
+          if (!isDeeplink()) {
+            e.preventDefault(); // Opened directly in a browser; there is nowhere to go.
+            return;
+          }
           if (!triggered) {
             e.preventDefault();
             triggerDeeplink();

--- a/src/backend/services/auth/auth-templates.test.ts
+++ b/src/backend/services/auth/auth-templates.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { type AuthTemplateName, loadAuthTemplate, loadSuccessAuthTemplate } from "./auth-templates";
 
@@ -58,5 +60,15 @@ describe("auth template shared styles", () => {
   // a stylesheet sitting in front of the href would swallow it.
   it("substitutes the deep link into the href, not somewhere in the styles", () => {
     expect(loadSuccessAuthTemplate()).toContain('href="yakshaver-desktop-dev://auth"');
+  });
+
+  // The success page follows its own deep link on load. Opened from disk the href is still the
+  // bare placeholder, which the browser would chase as a relative URL — so the page navigates
+  // away before anyone can look at it. The scheme guard is what keeps it reviewable.
+  it("guards the redirect on the scheme, so an unsubstituted page stays put", () => {
+    const raw = readFileSync(join(__dirname, "../../assets/auth/successTemplate.html"), "utf8");
+
+    expect(raw).toContain("indexOf('yakshaver-desktop') === 0");
+    expect(raw).toMatch(/href="redirectUrl"/);
   });
 });

--- a/src/backend/services/auth/auth-templates.test.ts
+++ b/src/backend/services/auth/auth-templates.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { type AuthTemplateName, loadAuthTemplate, loadSuccessAuthTemplate } from "./auth-templates";
+
+// Templates are read relative to __dirname, so these run against the real files that ship.
+vi.mock("electron", () => ({
+  app: { isPackaged: false },
+}));
+
+vi.mock("../../config/env", () => ({
+  config: {
+    isDev: () => true,
+    azure: () => ({}),
+  },
+}));
+
+const templateNames: AuthTemplateName[] = [
+  "successTemplate.html",
+  "failureTemplate.html",
+  "errorTemplate.html",
+];
+
+/**
+ * A link that survived being handed to MSAL would leave the user on an unstyled page, and nothing
+ * at runtime would report it: auth still succeeds and the text still reads correctly.
+ */
+describe("auth template shared styles", () => {
+  it.each(templateNames)("%s carries the styles rather than a link to them", (templateName) => {
+    const html = loadAuthTemplate(templateName);
+
+    expect(html).not.toContain("<link");
+    expect(html).toContain("<style>");
+  });
+
+  // The swap could "succeed" with no content and every other assertion here would still pass.
+  it.each(templateNames)("%s includes the shared rules", (templateName) => {
+    const html = loadAuthTemplate(templateName);
+
+    expect(html).toContain(".card {");
+    expect(html).toContain("background: #1a1414;");
+  });
+
+  // The badge is the one thing that differs between the pages.
+  it.each([
+    ["successTemplate.html", "status-badge--success"] as const,
+    ["failureTemplate.html", "status-badge--warning"] as const,
+    ["errorTemplate.html", "status-badge--error"] as const,
+  ])("%s keeps its own status badge", (templateName, modifier) => {
+    expect(loadAuthTemplate(templateName)).toContain(modifier);
+  });
+
+  it("keeps the success page's button styles after the shared styles", () => {
+    const html = loadAuthTemplate("successTemplate.html");
+
+    expect(html.indexOf(".card {")).toBeLessThan(html.indexOf(".cta {"));
+  });
+
+  // Substitution runs before inlining: `replace` takes the first match in the whole document, so
+  // a stylesheet sitting in front of the href would swallow it.
+  it("substitutes the deep link into the href, not somewhere in the styles", () => {
+    expect(loadSuccessAuthTemplate()).toContain('href="yakshaver-desktop-dev://auth"');
+  });
+});

--- a/src/backend/services/auth/auth-templates.test.ts
+++ b/src/backend/services/auth/auth-templates.test.ts
@@ -68,7 +68,15 @@ describe("auth template shared styles", () => {
   it("guards the redirect on the scheme, so an unsubstituted page stays put", () => {
     const raw = readFileSync(join(__dirname, "../../assets/auth/successTemplate.html"), "utf8");
 
-    expect(raw).toContain("indexOf('yakshaver-desktop') === 0");
+    expect(raw).toContain("includes('://')");
     expect(raw).toMatch(/href="redirectUrl"/);
+  });
+
+  // The protocol is configurable, so the guard must not assume the default scheme — a custom one
+  // that failed it would strand the user on this page after a successful sign-in.
+  it("still redirects when a custom protocol is configured", () => {
+    const html = loadSuccessAuthTemplate("acme-yakshaver");
+
+    expect(html).toContain('href="acme-yakshaver://auth"');
   });
 });

--- a/src/backend/services/auth/auth-templates.ts
+++ b/src/backend/services/auth/auth-templates.ts
@@ -8,10 +8,43 @@ export type AuthTemplateName =
   | "errorTemplate.html"
   | "failureTemplate.html";
 
+/** Matched literally, so keep these in step with the markup. */
+const SHARED_STYLESHEET_FILE_NAME = "auth-pages.css";
+const SHARED_STYLESHEET_LINK = '<link rel="stylesheet" href="auth-pages.css" />';
+
 function getAuthTemplateDirectory(): string {
   return app.isPackaged
     ? join(process.resourcesPath, "src/backend/assets/auth")
     : join(__dirname, "../../../../src/backend/assets/auth");
+}
+
+/**
+ * Replaces a page's stylesheet link with the stylesheet itself, inlined.
+ *
+ * The link is what lets the file render when opened straight from disk. It cannot survive being
+ * handed to MSAL, which takes an HTML string with no base URL for a relative href to resolve
+ * against, so the page would arrive unstyled.
+ *
+ * Throws when the link is missing: an unstyled page is far harder to notice than a failed load.
+ */
+function inlineSharedStyles(html: string, templateName: AuthTemplateName): string {
+  if (!html.includes(SHARED_STYLESHEET_LINK)) {
+    throw new Error(
+      `${templateName} does not link ${SHARED_STYLESHEET_FILE_NAME} as expected ` +
+        `(${SHARED_STYLESHEET_LINK}), so the shared styles cannot be inlined.`,
+    );
+  }
+
+  const cssPath = join(getAuthTemplateDirectory(), SHARED_STYLESHEET_FILE_NAME);
+
+  if (!fs.existsSync(cssPath)) {
+    throw new Error(`Auth stylesheet not found: ${cssPath}`);
+  }
+
+  const css = fs.readFileSync(cssPath, "utf8");
+
+  // A function replacer, so `$&` and friends in the CSS stay literal text.
+  return html.replace(SHARED_STYLESHEET_LINK, () => `<style>\n${css}</style>`);
 }
 
 export function getMainAppAuthUri(customProtocol?: string | null): string {
@@ -21,7 +54,7 @@ export function getMainAppAuthUri(customProtocol?: string | null): string {
   return `${protocol}://auth`;
 }
 
-export function loadAuthTemplate(templateName: AuthTemplateName): string {
+function readAuthTemplate(templateName: AuthTemplateName): string {
   const templatePath = join(getAuthTemplateDirectory(), templateName);
 
   if (!fs.existsSync(templatePath)) {
@@ -31,11 +64,19 @@ export function loadAuthTemplate(templateName: AuthTemplateName): string {
   return fs.readFileSync(templatePath, "utf8");
 }
 
+export function loadAuthTemplate(templateName: AuthTemplateName): string {
+  return inlineSharedStyles(readAuthTemplate(templateName), templateName);
+}
+
 export function loadSuccessAuthTemplate(customProtocol?: string | null): string {
-  return loadAuthTemplate("successTemplate.html").replace(
+  // Substitutes before inlining: `replace` takes the first match in the whole document, and the
+  // stylesheet would otherwise sit in front of the href.
+  const html = readAuthTemplate("successTemplate.html").replace(
     "redirectUrl",
     getMainAppAuthUri(customProtocol),
   );
+
+  return inlineSharedStyles(html, "successTemplate.html");
 }
 
 /**

--- a/src/backend/services/auth/microsoft-auth.test.ts
+++ b/src/backend/services/auth/microsoft-auth.test.ts
@@ -69,7 +69,13 @@ vi.mock("../../config/env", () => ({
 vi.mock("node:fs", () => {
   return {
     existsSync: vi.fn().mockReturnValue(true),
-    readFileSync: vi.fn().mockReturnValue("<html>YOUR_APP_PROTOCOL</html>"),
+    // Stands in for both an auth template and the stylesheet it links: loadAuthTemplate swaps
+    // that link for the stylesheet's contents, so markup without it is rejected as malformed.
+    readFileSync: vi
+      .fn()
+      .mockReturnValue(
+        '<html><link rel="stylesheet" href="auth-pages.css" />YOUR_APP_PROTOCOL</html>',
+      ),
     promises: {
       access: vi.fn().mockResolvedValue(undefined),
       mkdir: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
> 0. AI Development - Prompt & Model (include prompts/models used or `N/A`)

✏️ Claude Opus 5 via Claude Code. Prompt: complete SSWConsulting/SSW.YakShaver#3914 across both repos, then review for bugs, simplify, and trim comments before committing.

> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

✏️ Fixes SSWConsulting/SSW.YakShaver#3914, raised by @tomek-i in review of #1000. Backend side: SSWConsulting/SSW.YakShaver#3955.

> 2. What was changed?

✏️ The three auth result pages shared ~75% of their inline `<style>` blocks. The CSS now lives once, in `src/backend/assets/auth/auth-pages.css`.

A plain `<link>` can't work alone — MSAL gets the markup as a string with no base URL. So the pages keep the link (that's what makes them render when opened straight from disk) and `loadAuthTemplate` swaps it for an inline `<style>` first. The success page's button styles stay page-local.

Three things to look at:

- **One intentional visual change** — badge colours move to `--success`/`--warning`/`--error` modifiers, matching the API's copy. That takes the failure and error glyphs from 14px to 15px. Everything else is byte-identical.
- **The deep-link substitution now runs before the swap** — `replace` takes the first match in the document, and the stylesheet would otherwise sit in front of the href.
- **Second commit fixes a pre-existing bug** that blocked reviewing this page: the success page follows its own deep link on load, and opened from disk the browser chased the bare `redirectUrl` placeholder as a relative URL. Now guarded on the scheme, matching the API's copy. Production unaffected — happy to split it out.

**To review the look:** open any `*Template.html` directly in a browser, keeping the `.css` alongside it.

> 3. I paired or mob programmed with: <!-- list names or remove if not relevant -->

✏️ N/A